### PR TITLE
update tester utils

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.x
+          go-version: 1.20.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.x
+          go-version: 1.20.x
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: "3.x" # Version range or exact version of a Python version to use, using SemVer's version range syntax
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -19,23 +19,13 @@ test_starter_with_redis: build
 
 test_with_redis: build
 	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
-	CODECRAFTERS_CURRENT_STAGE_SLUG="expiry" \
-	dist/main.out
-
-test_stage_1_failure: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/scenarios/bind/failure \
-	CODECRAFTERS_CURRENT_STAGE_SLUG="init" \
-	dist/main.out
-
-test_ping_pong_eof: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/scenarios/ping-pong/eof \
-	CODECRAFTERS_CURRENT_STAGE_SLUG="ping-pong" \
+	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"init\",\"tester_log_prefix\":\"stage-1\",\"title\":\"Stage #1: Bind to a port\"},{\"slug\":\"ping-pong\",\"tester_log_prefix\":\"stage-2\",\"title\":\"Stage #2: Respond to PING\"},{\"slug\":\"ping-pong-multiple\",\"tester_log_prefix\":\"stage-3\",\"title\":\"Stage #3: Respond to multiple PINGs\"},{\"slug\":\"concurrent-clients\",\"tester_log_prefix\":\"stage-4\",\"title\":\"Stage #4: Handle concurrent clients\"},{\"slug\":\"echo\",\"tester_log_prefix\":\"stage-5\",\"title\":\"Stage #5: Implement the ECHO command\"},{\"slug\":\"set_get\",\"tester_log_prefix\":\"stage-6\",\"title\":\"Stage #6: Implement the SET \u0026 GET commands\"},{\"slug\":\"expiry\",\"tester_log_prefix\":\"stage-7\",\"title\":\"Stage #7: Expiry\"}]" \
 	dist/main.out
 
 test_tmp: build
 	cd /tmp/0d8e4ba11c57085f && \
 	CODECRAFTERS_SUBMISSION_DIR=/tmp/0d8e4ba11c57085f  \
-	CODECRAFTERS_CURRENT_STAGE_SLUG="ping-pong" \
+	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"init\",\"tester_log_prefix\":\"stage-1\",\"title\":\"Stage #1: Bind to a port\"},{\"slug\":\"ping-pong\",\"tester_log_prefix\":\"stage-2\",\"title\":\"Stage #2: Respond to PING\"},{\"slug\":\"ping-pong-multiple\",\"tester_log_prefix\":\"stage-3\",\"title\":\"Stage #3: Respond to multiple PINGs\"},{\"slug\":\"concurrent-clients\",\"tester_log_prefix\":\"stage-4\",\"title\":\"Stage #4: Handle concurrent clients\"},{\"slug\":\"echo\",\"tester_log_prefix\":\"stage-5\",\"title\":\"Stage #5: Implement the ECHO command\"},{\"slug\":\"set_get\",\"tester_log_prefix\":\"stage-6\",\"title\":\"Stage #6: Implement the SET \u0026 GET commands\"},{\"slug\":\"expiry\",\"tester_log_prefix\":\"stage-7\",\"title\":\"Stage #7: Expiry\"}]" \
 	$(shell pwd)/dist/main.out
 
 copy_course_file:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This is a program that validates your progress on the Redis challenge.
 
 - Following environment variables:
   - `CODECRAFTERS_SUBMISSION_DIR` - root of the user's code submission
-  - `CODECRAFTERS_CURRENT_STAGE_SLUG` - current stage the user is on
+  - `CODECRAFTERS_TEST_CASES_JSON` - test cases in JSON format
 
 # User code requirements
 
 - A binary named `spawn_redis_server.sh` that spins up the Redis server.
-- A file named `codecrafters.yml`, with the following values: 
+- A file named `codecrafters.yml`, with the following values:
   - `debug`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codecrafters-io/redis-tester
 go 1.14
 
 require (
-	github.com/codecrafters-io/tester-utils v0.1.52
+	github.com/codecrafters-io/tester-utils v0.2.0
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -11,5 +11,5 @@ require (
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/codecrafters-io/tester-utils v0.1.50 h1:ZKushCP0ICeVkK7rX/eYBFEVpMpHn
 github.com/codecrafters-io/tester-utils v0.1.50/go.mod h1:VifsWEvXrRB18l2+rkE7gwuzWRhGX4AffJ01VTgMYfw=
 github.com/codecrafters-io/tester-utils v0.1.52 h1:BI67UikgRom7+DMNpra/DL2FcZewtyOUwjvAq1gHir8=
 github.com/codecrafters-io/tester-utils v0.1.52/go.mod h1:VifsWEvXrRB18l2+rkE7gwuzWRhGX4AffJ01VTgMYfw=
+github.com/codecrafters-io/tester-utils v0.2.0 h1:LHGrqE5wVaOoJ7aSa5vS93W3ToR7/tnHt3ATIt9z8gE=
+github.com/codecrafters-io/tester-utils v0.2.0/go.mod h1:BeSLyqBpFxUwIm41QlnuRG7ZsabBXWE2Ga3LMFUXAPM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -64,6 +66,8 @@ golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/internal/log_friendly_error.go
+++ b/internal/log_friendly_error.go
@@ -1,11 +1,11 @@
 package internal
 
 import (
-	testerutils "github.com/codecrafters-io/tester-utils"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"strings"
 )
 
-func logFriendlyError(logger *testerutils.Logger, err error) {
+func logFriendlyError(logger *logger.Logger, err error) {
 	if err.Error() == "EOF" {
 		logger.Infof("Hint: EOF is short for 'end of file'. This usually means that your program either:")
 		logger.Infof(" (a) didn't send a complete response, or")

--- a/internal/redis_binary_helper.go
+++ b/internal/redis_binary_helper.go
@@ -5,12 +5,14 @@ import (
 	"net"
 	"time"
 
+	executable "github.com/codecrafters-io/tester-utils/executable"
+	logger "github.com/codecrafters-io/tester-utils/logger"
 	testerutils "github.com/codecrafters-io/tester-utils"
 )
 
 type RedisBinary struct {
-	executable *testerutils.Executable
-	logger     *testerutils.Logger
+	executable *executable.Executable
+	logger     *logger.Logger
 }
 
 func NewRedisBinary(stageHarness *testerutils.StageHarness) *RedisBinary {

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -4,48 +4,48 @@ import (
 	"regexp"
 	"testing"
 
-	tester_utils "github.com/codecrafters-io/tester-utils"
+	tester_utils_testing "github.com/codecrafters-io/tester-utils/testing"
 )
 
 func TestStages(t *testing.T) {
-	testCases := map[string]tester_utils.TesterOutputTestCase{
+	testCases := map[string]tester_utils_testing.TesterOutputTestCase{
 		"bind_failure": {
-			StageName:           "init",
+			UntilStageSlug:      "init",
 			CodePath:            "./test_helpers/scenarios/bind/failure",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/bind/failure",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"bind_timeout": {
-			StageName:           "init",
+			UntilStageSlug:      "init",
 			CodePath:            "./test_helpers/scenarios/bind/timeout",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/bind/timeout",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"bind_success": {
-			StageName:           "init",
+			UntilStageSlug:      "init",
 			CodePath:            "./test_helpers/scenarios/bind/success",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/bind/success",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"ping_pong_eof": {
-			StageName:           "ping-pong",
+			UntilStageSlug:      "ping-pong",
 			CodePath:            "./test_helpers/scenarios/ping-pong/eof",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/ping-pong/eof",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"ping_pong_without_crlf": {
-			StageName:           "ping-pong",
+			UntilStageSlug:      "ping-pong",
 			CodePath:            "./test_helpers/scenarios/ping-pong/without_crlf",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/ping-pong/without_crlf",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"ping_pong_without_read_multiple_pongs": {
-			StageName:           "ping-pong",
+			UntilStageSlug:      "ping-pong",
 			CodePath:            "./test_helpers/scenarios/ping-pong/without_read_multiple_pongs",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/ping-pong/without_read_multiple_pongs",
@@ -53,7 +53,7 @@ func TestStages(t *testing.T) {
 		},
 	}
 
-	tester_utils.TestTesterOutput(t, testerDefinition, testCases)
+	tester_utils_testing.TestTesterOutput(t, testerDefinition, testCases)
 }
 
 func normalizeTesterOutput(testerOutput []byte) []byte {

--- a/internal/test_helpers/fixtures/bind/failure
+++ b/internal/test_helpers/fixtures/bind/failure
@@ -1,4 +1,4 @@
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[your_program] [0mhey, not going to bind!
 [33m[stage-1] [0m[91m[91mLooks like your program has terminated. A redis server is expected to be a long-running process.[0m[0m
-[33m[stage-1] [0m[91m[91mTest failed (see README.md for instructions on how to pass this stage)[0m[0m
+[33m[stage-1] [0m[91m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m[0m

--- a/internal/test_helpers/fixtures/bind/success
+++ b/internal/test_helpers/fixtures/bind/success
@@ -1,7 +1,6 @@
 Debug = true
-Stage = init
 
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[stage-1] [0m[36m[36mRunning program[0m[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[stage-1] [0m[36m[36mConnection successful[0m[0m

--- a/internal/test_helpers/fixtures/bind/timeout
+++ b/internal/test_helpers/fixtures/bind/timeout
@@ -1,4 +1,4 @@
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[your_program] [0mhey, not going to bind!
 [33m[stage-1] [0m[94m[94mFailed to connect to port 6379, retrying in 1s[0m[0m
 [33m[stage-1] [0m[94m[94mFailed to connect to port 6379, retrying in 1s[0m[0m
@@ -13,4 +13,4 @@
 [33m[stage-1] [0m[94m[94mFailed to connect to port 6379, retrying in 1s[0m[0m
 [33m[stage-1] [0m[94m[94mFailed to connect to port 6379, retrying in 1s[0m[0m
 [33m[stage-1] [0m[91m[91mtimed out, test exceeded 15 seconds[0m[0m
-[33m[stage-1] [0m[91m[91mTest failed (see README.md for instructions on how to pass this stage)[0m[0m
+[33m[stage-1] [0m[91m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m[0m

--- a/internal/test_helpers/fixtures/ping-pong/eof
+++ b/internal/test_helpers/fixtures/ping-pong/eof
@@ -1,7 +1,6 @@
 Debug = true
-Stage = ping-pong
 
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[stage-1] [0m[36m[36mRunning program[0m[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[stage-1] [0m[36m[36mConnection successful[0m[0m
@@ -9,13 +8,13 @@ Stage = ping-pong
 [33m[stage-1] [0m[36m[36mTerminating program[0m[0m
 [33m[stage-1] [0m[36m[36mProgram terminated successfully[0m[0m
 
-[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: Respond to PING[0m[0m
+[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: ping-pong[0m[0m
 [33m[stage-2] [0m[36m[36mRunning program[0m[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[stage-2] [0m[36mConnection established, sending PING command (*1\r\n$4\r\nping\r\n)[0m
 [33m[stage-2] [0m[36mReading response...[0m
 [33m[stage-2] [0m[94m[94mHint: 'connection reset by peer' usually means that your program closed the connection before sending a complete response.[0m[0m
-[33m[stage-2] [0m[91m[91mread tcp 127.0.0.1:63018->127.0.0.1:6379: read: connection reset by peer[0m[0m
+[33m[stage-2] [0m[91m[91mread tcp 127.0.0.1:60566->127.0.0.1:6379: read: connection reset by peer[0m[0m
 [33m[stage-2] [0m[91m[91mTest failed[0m[0m
 [33m[stage-2] [0m[36m[36mTerminating program[0m[0m
 [33m[stage-2] [0m[36m[36mProgram terminated successfully[0m[0m

--- a/internal/test_helpers/fixtures/ping-pong/without_crlf
+++ b/internal/test_helpers/fixtures/ping-pong/without_crlf
@@ -1,8 +1,8 @@
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[stage-1] [0m[92m[92mTest passed.[0m[0m
 
-[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: Respond to PING[0m[0m
+[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: ping-pong[0m[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[stage-2] [0m[91m[91mexpected response to be either "+PONG\r\n" (7 bytes) or "$4\r\nPONG\r\n" (10 bytes), got "+PONG" (5 bytes)[0m[0m
 [33m[stage-2] [0m[91m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m[0m

--- a/internal/test_helpers/fixtures/ping-pong/without_read_multiple_pongs
+++ b/internal/test_helpers/fixtures/ping-pong/without_read_multiple_pongs
@@ -1,8 +1,8 @@
-[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: Bind to a port[0m[0m
+[33m[stage-1] [0m[94m[94mRunning tests for Stage #1: init[0m[0m
 [33m[your_program] [0mLogs from your program will appear here!
 [33m[stage-1] [0m[92m[92mTest passed.[0m[0m
 
-[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: Respond to PING[0m[0m
+[33m[stage-2] [0m[94m[94mRunning tests for Stage #2: ping-pong[0m[0m
 [33m[your_program] [0mLogs from your program will appear here!
 [33m[stage-2] [0m[91m[91mexpected response to be either "+PONG\r\n" (7 bytes) or "$4\r\nPONG\r\n" (10 bytes), got "+PONG\r\n+PONG\r\n+P" (16 bytes)[0m[0m
 [33m[stage-2] [0m[91m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m[0m

--- a/internal/test_ping_pong.go
+++ b/internal/test_ping_pong.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	testerutils "github.com/codecrafters-io/tester-utils"
+	logger "github.com/codecrafters-io/tester-utils/logger"
 	"github.com/go-redis/redis"
 )
 
@@ -137,7 +138,7 @@ func testPingPongConcurrent(stageHarness *testerutils.StageHarness) error {
 	return nil
 }
 
-func runPing(logger *testerutils.Logger, client *redis.Client, clientNum int) error {
+func runPing(logger *logger.Logger, client *redis.Client, clientNum int) error {
 	logger.Debugf("client-%d: Sending ping command...", clientNum)
 	pong, err := client.Ping().Result()
 	if err != nil {

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -6,65 +6,42 @@ import (
 )
 
 var testerDefinition = testerutils.TesterDefinition{
-	AntiCheatStages: []testerutils.Stage{
+	AntiCheatTestCases: []testerutils.TestCase{
 		{
-			Slug:                    "anti-cheat-1",
-			Title:                   "Anti-cheat 1",
-			TestFunc:                antiCheatTest,
-			ShouldRunPreviousStages: true,
+			Slug:     "anti-cheat-1",
+			TestFunc: antiCheatTest,
 		},
 	},
 	ExecutableFileName: "spawn_redis_server.sh",
-	Stages: []testerutils.Stage{
+	TestCases: []testerutils.TestCase{
 		{
-			Slug:                    "init",
-			Number:                  1,
-			Title:                   "Bind to a port",
-			TestFunc:                testBindToPort,
-			ShouldRunPreviousStages: true,
-			Timeout:                 15 * time.Second,
+			Slug:     "init",
+			TestFunc: testBindToPort,
+			Timeout:  15 * time.Second,
 		},
 		{
-			Slug:                    "ping-pong",
-			Number:                  2,
-			Title:                   "Respond to PING",
-			TestFunc:                testPingPongOnce,
-			ShouldRunPreviousStages: true,
+			Slug:     "ping-pong",
+			TestFunc: testPingPongOnce,
 		},
 		{
-			Slug:                    "ping-pong-multiple",
-			Title:                   "Respond to multiple PINGs",
-			Number:                  3,
-			TestFunc:                testPingPongMultiple,
-			ShouldRunPreviousStages: true,
+			Slug:     "ping-pong-multiple",
+			TestFunc: testPingPongMultiple,
 		},
 		{
-			Slug:                    "concurrent-clients",
-			Number:                  4,
-			Title:                   "Handle concurrent clients",
-			TestFunc:                testPingPongConcurrent,
-			ShouldRunPreviousStages: true,
+			Slug:     "concurrent-clients",
+			TestFunc: testPingPongConcurrent,
 		},
 		{
-			Slug:                    "echo",
-			Number:                  5,
-			Title:                   "Implement the ECHO command",
-			TestFunc:                testEcho,
-			ShouldRunPreviousStages: true,
+			Slug:     "echo",
+			TestFunc: testEcho,
 		},
 		{
-			Slug:                    "set_get",
-			Number:                  6,
-			Title:                   "Implement the SET & GET commands",
-			TestFunc:                testGetSet,
-			ShouldRunPreviousStages: true,
+			Slug:     "set_get",
+			TestFunc: testGetSet,
 		},
 		{
-			Slug:                    "expiry",
-			Number:                  7,
-			Title:                   "Expiry",
-			TestFunc:                testExpiry,
-			ShouldRunPreviousStages: true,
+			Slug:     "expiry",
+			TestFunc: testExpiry,
 		},
 	},
 }

--- a/internal/tester_definition_test.go
+++ b/internal/tester_definition_test.go
@@ -2,8 +2,10 @@ package internal
 
 import (
 	"testing"
+
+	tester_utils_testing "github.com/codecrafters-io/tester-utils/testing"
 )
 
 func TestStagesMatchYAML(t *testing.T) {
-	testerDefinition.TestAgainstYAML(t, "test_helpers/course_definition.yml")
+	tester_utils_testing.ValidateTesterDefinitionAgainstYAML(t, testerDefinition, "test_helpers/course_definition.yml")
 }


### PR DESCRIPTION
Rough list of steps for future reference: 

- Run `make update_tester_utils`
- Resolve all the go errors, get the program to compile
- Run `CODECRAFTERS_RECORD_FIXTURES=true make test`
  - The only changes to fixtures should be the stage name (which the tester doesn't have access to anymore)
- Remove all usages of `CODECRAFTERS_CURRENT_STAGE_SLUG`
  - If you want a value for `CODECRAFTERS_TEST_CASES_JSON` that covers all stages, load a backup and run this command in core: `puts Submission.where(course_stage: C("<course_slug>").last_stage).first.test_runs.first.test_cases_for_tester.to_json`
- Upgrade to Go 1.20.x
