### PR TITLE
Fix issues with Redis Replication extension tests.

### DIFF
--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -69,11 +69,11 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:19:26.152)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:26.152, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:51:24.791)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:24.791, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:26.253, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:24.893, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/ping-pong/eof
+++ b/internal/test_helpers/fixtures/ping-pong/eof
@@ -16,7 +16,7 @@ Debug = true
 [33m[stage-2] [0m[94m$ redis-cli ping[0m
 [33m[stage-2] [0m[36mReading response...[0m
 [33m[stage-2] [0m[94mHint: 'connection reset by peer' usually means that your program closed the connection before sending a complete response.[0m
-[33m[stage-2] [0m[91mread tcp 127.0.0.1:44712->127.0.0.1:6379: read: connection reset by peer[0m
+[33m[stage-2] [0m[91mread tcp 127.0.0.1:36926->127.0.0.1:6379: read: connection reset by peer[0m
 [33m[stage-2] [0m[91mTest failed[0m
 [33m[stage-2] [0m[36mTerminating program[0m
 [33m[stage-2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/rdb-config/pass
+++ b/internal/test_helpers/fixtures/rdb-config/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:18:18.077)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:18.077, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:45:55.221)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:45:55.221, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:18.178, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:45:55.322, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2821543951 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2453435298 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/rdb-read-key/pass
+++ b/internal/test_helpers/fixtures/rdb-read-key/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:13:03.808)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:03.808, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:46:00.269)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:00.269, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:03.909, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:00.370, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1812715900 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2663685552 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles932854361 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2112653960 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/rdb-read-multiple-keys/pass
+++ b/internal/test_helpers/fixtures/rdb-read-multiple-keys/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:13:10.965)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:10.965, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:48:17.472)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:17.472, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:11.066, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:17.573, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3943306056 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4213548725 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2955232870 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2764557421 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles857209564 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles357388602 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2475212012 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles604186444 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/rdb-read-multiple-string-values/pass
+++ b/internal/test_helpers/fixtures/rdb-read-multiple-string-values/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:14:56.499)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:56.499, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:51:27.722)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:27.722, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:56.600, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:27.823, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2249330888 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4154756338 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1442622124 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2588948210 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2402876157 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1250161541 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles69287226 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2275471340 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3444005431 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3718936964 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:14:16.420)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:16.420, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:46:07.415)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:07.415, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:16.521, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:07.516, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3208800161 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1326260254 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3432958175 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1089935667 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles628259002 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles184674477 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2892838144 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3073674735 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2112699836 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2582547524 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3006381122 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles356209747 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m

--- a/internal/test_helpers/fixtures/rdb-string-value/pass
+++ b/internal/test_helpers/fixtures/rdb-string-value/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:17:17.463)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:17.463, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:48:08.219)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:08.219, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:17.564, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:08.320, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3694162994 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles421878518 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1612545614 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3236821878 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2054421396 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3243568350 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/repl-cmd-processing/pass
+++ b/internal/test_helpers/fixtures/repl-cmd-processing/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:16:58.406)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:58.406, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:47:47.088)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:47.088, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:58.507, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:47.190, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4034384917 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1933221632 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4176687001 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1915907847 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2385187752 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles346002835 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1007384118 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3599215975 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles506881710 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles964701836 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2725742556 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles904393124 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 00ad997422784b511be9819da651d14f9e11448c 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC bd4d6f7858e38892ac96f40828e80a4bf9777d8d 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC 26ff5879e4988a9d5675cc4d6ed659b2f7caf0ea 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC c5b5653fca05ebfaf49ce0b832b507e24ff475a6 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 63144fb5b5c8b4f60adcac788c3f5ca61c7143b6 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 32bb2f6b7380b476416acb1658068cd6573fb4f4 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC bc0a001c47a7e931556138fd6df5c743cefd46ab 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC bc0a001c47a7e931556138fd6df5c743cefd46ab 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC bc0a001c47a7e931556138fd6df5c743cefd46ab 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 9fc0602c7046d5a7b3d3fff26955b51fead265bb 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 9fc0602c7046d5a7b3d3fff26955b51fead265bb 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 9fc0602c7046d5a7b3d3fff26955b51fead265bb 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-custom-port/pass
+++ b/internal/test_helpers/fixtures/repl-custom-port/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:15:09.962)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:09.962, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:46:22.975)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:22.975, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:10.064, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:23.077, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles930730636 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2882732831 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles797572854 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2572372115 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1946473796 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3311037097 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2098479864 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1807573295 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2546243194 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3406569281 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles619108836 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1313926574 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m

--- a/internal/test_helpers/fixtures/repl-id/pass
+++ b/internal/test_helpers/fixtures/repl-id/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:17:26.764)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:26.764, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:49:25.125)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:25.125, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:26.865, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:25.227, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4200796523 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1347588020 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2712970255 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles316610407 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2632135272 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4200246040 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2447921142 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3333836963 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2160114247 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1759190986 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2706930852 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles486567807 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/repl-info-replica/pass
+++ b/internal/test_helpers/fixtures/repl-info-replica/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:15:26.571)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:26.571, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:51:41.178)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:41.178, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:26.672, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:41.279, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3923109233 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1709568523 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles866403503 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1883410425 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3565237574 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1624267944 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3712446549 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles415892923 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2135629887 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3760740507 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2807044157 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3598930239 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/repl-info/pass
+++ b/internal/test_helpers/fixtures/repl-info/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:19:29.118)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:29.118, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:46:39.570)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:39.570, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:29.219, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:46:39.672, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3362862378 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2983708772 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2950540300 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3299037804 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2252186298 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles198460322 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4108377721 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles838952700 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3209932825 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1154062030 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1791909257 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2365370446 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m

--- a/internal/test_helpers/fixtures/repl-master-cmd-prop/pass
+++ b/internal/test_helpers/fixtures/repl-master-cmd-prop/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:16:40.049)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:40.049, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:50:21.840)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:21.840, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:40.151, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:21.941, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2187399638 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2818756618 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles543074627 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2171241311 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3082029095 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1839089670 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4173257057 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3579710366 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2801595908 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3575466312 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3696081946 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3331502206 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 1644b4ce5cb32e8b3761a7d3eaddd2686b346f5c 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 81854cd9e76533aa8b23ac2a2cde8d4f1c9a2c21 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC bb10efad7096b69be0091e1feeaa8e0cc77e921e 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC 091fb579c086bb64b205444f451d9e9a8699b0e2 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 707f08cb642ce2bc799d2943dea80573f7f2fb81 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 19558daab823a36f595466c079b5ccec680f8bda 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m

--- a/internal/test_helpers/fixtures/repl-master-psync-rdb/pass
+++ b/internal/test_helpers/fixtures/repl-master-psync-rdb/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:13:39.497)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:39.497, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:48:46.209)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:46.209, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:39.598, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:46.310, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles317888621 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1887325316 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2562378289 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3508868730 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2124538051 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3001734693 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles800259065 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles186279274 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1656029676 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles463012375 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles255017086 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2745829952 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 0af7ebf92c35b9179fb1a46b990777e01c89d7f7 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 69b79c26518fa9a80dc8a2e59c76cad265810c27 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC cf30fd95e4ba9d798cae7809d84d564a2b0608c1 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC ea0b447e679bd7347a02d3a70a7f54a786352a45 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/repl-master-psync/pass
+++ b/internal/test_helpers/fixtures/repl-master-psync/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:15:43.459)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:43.459, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:47:29.436)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:29.436, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:15:43.561, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:29.538, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3012107930 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1342319818 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3571206944 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles446726773 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1523205995 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2409605701 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1619465116 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3939128238 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3246719409 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles627049487 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3446113882 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles716295556 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 2d39a0f12ead35a82cf755ad9e27add1a6a99cb7 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC cad9f2386bdac41e0565f1ef73ec65167d94f9ea 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-master-replconf/pass
+++ b/internal/test_helpers/fixtures/repl-master-replconf/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:19:45.853)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:45.853, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:51:58.036)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:58.036, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:19:45.954, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:51:58.138, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2379742065 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3360814586 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2154136359 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles424363481 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3682123268 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2133847382 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1098098633 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1141866467 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1996404203 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2056891136 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1346032577 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1341095283 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-multiple-replicas/pass
+++ b/internal/test_helpers/fixtures/repl-multiple-replicas/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:13:57.532)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:57.532, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:52:15.546)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:52:15.546, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:57.634, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:52:15.648, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1380963501 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3323406218 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1644570057 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1034596733 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles14938235 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2798370821 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles159786432 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1348336127 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1497818909 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3178976370 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles282065177 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles194116388 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC e32f6cd10b8636adca958b5103721cf69af68e1b 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC a255cc0c647bbe004dfdc75981d63bc23d2eaec2 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC 592fe131c75f2ee55b6dc68a92eeced05162b882 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC 84d2c0cb8857d12631dba525bbe0a102a39ac8d4 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 9a6e4a09c777c2800d4f6cfab955357ba52a46b2 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 893b352d624957bb4b34105e58156a9d65b98a49 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,48 +257,48 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 305c5b1a90d4ae4b115fd3acad47bcb526211c80 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 305c5b1a90d4ae4b115fd3acad47bcb526211c80 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 305c5b1a90d4ae4b115fd3acad47bcb526211c80 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 193c4396bdf9025b289f75e227472c67c056d365 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 193c4396bdf9025b289f75e227472c67c056d365 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 193c4396bdf9025b289f75e227472c67c056d365 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-replica-getack-nonzero/pass
+++ b/internal/test_helpers/fixtures/repl-replica-getack-nonzero/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:17:43.773)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:43.773, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:49:42.120)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:42.120, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:17:43.874, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:42.221, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles458798609 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2158986120 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3365167988 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1251748291 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1192941102 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles681299593 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles363601061 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3775977615 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles337267311 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3395223618 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles756092903 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2742989410 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC ff72b873a63f401145dfc4192a8ad76eb9feffc4 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 3505108274977ecada8c87d429cc792e66dbb848 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC 59138b472679d5a92ef3cf0353a142029608a301 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC 73b06d50adf32242060613f3c8edec8aed919cf7 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC b780afd0d99159c93b22f4e63a4fd1b9f7e6cb22 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC fa866c2ebfeff19e55ca76866c1a041575a3a1cb 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 9dc9bedb1dde50caa4db8ec84731c724b8c26e7c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 9dc9bedb1dde50caa4db8ec84731c724b8c26e7c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 9dc9bedb1dde50caa4db8ec84731c724b8c26e7c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 10778fd6189d801ef50a5cab3b32a974a73e2dba 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 10778fd6189d801ef50a5cab3b32a974a73e2dba 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 10778fd6189d801ef50a5cab3b32a974a73e2dba 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m
@@ -332,7 +332,7 @@ Debug = true
 [33m[stage-26] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-27] [0m[94mRunning tests for Stage #27: repl-replica-getack[0m
-[33m[stage-27] [0m[94mServer is running on port 6379[0m
+[33m[stage-27] [0m[94mMaster is running on port 6379[0m
 [33m[stage-27] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-27] [0m[92mPING received.[0m
 [33m[stage-27] [0m[94m+PONG sent.[0m
@@ -350,7 +350,7 @@ Debug = true
 [33m[stage-27] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-28] [0m[94mRunning tests for Stage #28: repl-replica-getack-nonzero[0m
-[33m[stage-28] [0m[94mServer is running on port 6379[0m
+[33m[stage-28] [0m[94mMaster is running on port 6379[0m
 [33m[stage-28] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-28] [0m[92mPING received.[0m
 [33m[stage-28] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-replica-getack/pass
+++ b/internal/test_helpers/fixtures/repl-replica-getack/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:18:40.409)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:40.409, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:50:40.172)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:40.172, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:40.510, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:40.273, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3737464501 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1001924526 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3887633016 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3999635293 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4165325710 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3036517165 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3072453026 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3503936005 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1085601350 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1201803242 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3653994469 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1322043153 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 4b85db6fa4003a758cee8090695f9bab8c890f14 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 4494cea20159426d786caf0c5a6b2080a2cfef5c 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC 88a2b6246b75d00cd989a607bbf7d6a5a5ad1215 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC d825995a2df2f4126df446858f58e37e3aaddf40 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 599df841481b4465163d5c9380e7b61b46f93ba7 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC d49d7b4a6ec156a5452bf8ab79279ea158fa2a71 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 314c0eee00cf13f30a24efec6a1527a7fb0cf96d 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 314c0eee00cf13f30a24efec6a1527a7fb0cf96d 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 314c0eee00cf13f30a24efec6a1527a7fb0cf96d 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC f39fc61d74fad52b3e4e8ff9a5583e0f7af5f28d 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC f39fc61d74fad52b3e4e8ff9a5583e0f7af5f28d 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC f39fc61d74fad52b3e4e8ff9a5583e0f7af5f28d 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m
@@ -332,7 +332,7 @@ Debug = true
 [33m[stage-26] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-27] [0m[94mRunning tests for Stage #27: repl-replica-getack[0m
-[33m[stage-27] [0m[94mServer is running on port 6379[0m
+[33m[stage-27] [0m[94mMaster is running on port 6379[0m
 [33m[stage-27] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-27] [0m[92mPING received.[0m
 [33m[stage-27] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-replica-ping/pass
+++ b/internal/test_helpers/fixtures/repl-replica-ping/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:13:22.353)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:22.353, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:47:12.310)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:12.310, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:13:22.454, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:47:12.411, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3036050473 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2927802943 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles711103758 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2540082900 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles759659605 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3345932044 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2820977241 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles143574727 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3579957389 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3215438071 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2647422967 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2100532742 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-replica-psync/pass
+++ b/internal/test_helpers/fixtures/repl-replica-psync/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:16:22.738)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:22.738, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:48:28.821)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:28.821, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:22.839, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:48:28.922, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1154765385 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3805255537 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3462382557 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles946725060 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles126008486 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1109306350 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1527594210 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles48799833 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1789790372 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3522603128 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2424842965 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1733903215 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-replica-replconf/pass
+++ b/internal/test_helpers/fixtures/repl-replica-replconf/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:18:23.130)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:23.130, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:52:36.907)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:52:36.907, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:23.232, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:52:37.008, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles664825132 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2911978931 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles753133554 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3058861951 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3406859670 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3831191099 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1867404964 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2205157922 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3220011712 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3245847400 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles351817368 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1068862767 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m

--- a/internal/test_helpers/fixtures/repl-wait-zero-offset/pass
+++ b/internal/test_helpers/fixtures/repl-wait-zero-offset/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:18:59.556)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:59.556, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:49:04.195)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:04.196, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:18:59.657, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:49:04.297, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3044745506 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3549294347 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles332997594 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2472598299 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3079176664 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1727468728 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles218061408 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3878580143 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2465486090 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles65906057 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3680695839 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3217031916 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC e3b1f83d1c9b7b4bbca42429b082a8844ff84592 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 2f32dc21cf001f60b5bae505d7af1b37ee70f377 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC be0ef5f2cd4d4ce70299534eb45c651b8c421643 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC d629cbeda6539c70a7181086854cc0a94e86eb39 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 3b90df3bd9416503459a688545320b67467cdca0 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 6d66054cd53e0a012225225e0fd32c03552583f7 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 67248ad5b543c2d27924a549d7650263e1b55a2a 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 67248ad5b543c2d27924a549d7650263e1b55a2a 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 67248ad5b543c2d27924a549d7650263e1b55a2a 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 9068eaa9a98858f4a138ec008d7d03928512d7b1 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 9068eaa9a98858f4a138ec008d7d03928512d7b1 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 9068eaa9a98858f4a138ec008d7d03928512d7b1 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m
@@ -332,7 +332,7 @@ Debug = true
 [33m[stage-26] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-27] [0m[94mRunning tests for Stage #27: repl-replica-getack[0m
-[33m[stage-27] [0m[94mServer is running on port 6379[0m
+[33m[stage-27] [0m[94mMaster is running on port 6379[0m
 [33m[stage-27] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-27] [0m[92mPING received.[0m
 [33m[stage-27] [0m[94m+PONG sent.[0m
@@ -350,7 +350,7 @@ Debug = true
 [33m[stage-27] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-28] [0m[94mRunning tests for Stage #28: repl-replica-getack-nonzero[0m
-[33m[stage-28] [0m[94mServer is running on port 6379[0m
+[33m[stage-28] [0m[94mMaster is running on port 6379[0m
 [33m[stage-28] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-28] [0m[92mPING received.[0m
 [33m[stage-28] [0m[94m+PONG sent.[0m
@@ -376,8 +376,8 @@ Debug = true
 
 [33m[stage-29] [0m[94mRunning tests for Stage #29: repl-wait-zero-replicas[0m
 [33m[stage-29] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-29] [0m[94m$ redis-cli WAIT 0 60000[0m
-[33m[stage-29] [0m[92m0 received.[0m
+[33m[stage-29] [0m[94m[client] $ redis-cli WAIT 0 60000[0m
+[33m[stage-29] [0m[92m[client] 0 received.[0m
 [33m[stage-29] [0m[92mTest passed.[0m
 [33m[stage-29] [0m[36mTerminating program[0m
 [33m[stage-29] [0m[36mProgram terminated successfully[0m
@@ -386,35 +386,35 @@ Debug = true
 [33m[stage-30] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
 [33m[stage-30] [0m[94mProceeding to create 3 replicas.[0m
 [33m[stage-30] [0m[36mCreating replica : 0.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 335e8dc2f015e2832fd150bc3340a9b934d779f5 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-1] OK received.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-1] FULLRESYNC 12029ac390dfa2c5180b95cab12ce1b2c1a8f6bd 0 received.[0m
+[33m[stage-30] [0m[92m[replica-1] Successfully received RDB file from master.[0m
 [33m[stage-30] [0m[36mCreating replica : 1.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 335e8dc2f015e2832fd150bc3340a9b934d779f5 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-2] OK received.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-2] FULLRESYNC 12029ac390dfa2c5180b95cab12ce1b2c1a8f6bd 0 received.[0m
+[33m[stage-30] [0m[92m[replica-2] Successfully received RDB file from master.[0m
 [33m[stage-30] [0m[36mCreating replica : 2.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 335e8dc2f015e2832fd150bc3340a9b934d779f5 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 3 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 4 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 5 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-3] OK received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-3] FULLRESYNC 12029ac390dfa2c5180b95cab12ce1b2c1a8f6bd 0 received.[0m
+[33m[stage-30] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 3 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 4 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 5 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
 [33m[stage-30] [0m[92mTest passed.[0m
 [33m[stage-30] [0m[36mTerminating program[0m
 [33m[stage-30] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-wait-zero-replicas/pass
+++ b/internal/test_helpers/fixtures/repl-wait-zero-replicas/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:16:01.190)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:01.190, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:50:01.410)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:01.410, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:16:01.291, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:01.511, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles47899627 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3763023271 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles619036226 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1106015633 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3906330116 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3945425010 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3695669796 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2604814890 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles60834972 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3708787077 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1254837008 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1796806387 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 7020d8fc33e2c3b53ee00a5d02115b02abd1e34e 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 1b6b3f63e0d2d5777ba731ebcd8a0e1e9cd0a53f 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC be84647c7bc576eb3a55f9521a64c6615039ce05 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC eaca25f11ca13aba9e40fc4db42726fb5e7f5064 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 40a61ac6e7dd8f2c958e3dbd05d6e678a1e9d0d2 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 0294c1a5c306d065a6968ce413a74202ccbf0a58 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC def14502618f71d7692fda88fb69e1e3bf842c3c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC def14502618f71d7692fda88fb69e1e3bf842c3c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC def14502618f71d7692fda88fb69e1e3bf842c3c 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 1df6c6c79931e83ad4c93527bb19eebea9f3d423 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 1df6c6c79931e83ad4c93527bb19eebea9f3d423 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 1df6c6c79931e83ad4c93527bb19eebea9f3d423 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m
@@ -332,7 +332,7 @@ Debug = true
 [33m[stage-26] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-27] [0m[94mRunning tests for Stage #27: repl-replica-getack[0m
-[33m[stage-27] [0m[94mServer is running on port 6379[0m
+[33m[stage-27] [0m[94mMaster is running on port 6379[0m
 [33m[stage-27] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-27] [0m[92mPING received.[0m
 [33m[stage-27] [0m[94m+PONG sent.[0m
@@ -350,7 +350,7 @@ Debug = true
 [33m[stage-27] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-28] [0m[94mRunning tests for Stage #28: repl-replica-getack-nonzero[0m
-[33m[stage-28] [0m[94mServer is running on port 6379[0m
+[33m[stage-28] [0m[94mMaster is running on port 6379[0m
 [33m[stage-28] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-28] [0m[92mPING received.[0m
 [33m[stage-28] [0m[94m+PONG sent.[0m
@@ -376,8 +376,8 @@ Debug = true
 
 [33m[stage-29] [0m[94mRunning tests for Stage #29: repl-wait-zero-replicas[0m
 [33m[stage-29] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-29] [0m[94m$ redis-cli WAIT 0 60000[0m
-[33m[stage-29] [0m[92m0 received.[0m
+[33m[stage-29] [0m[94m[client] $ redis-cli WAIT 0 60000[0m
+[33m[stage-29] [0m[92m[client] 0 received.[0m
 [33m[stage-29] [0m[92mTest passed.[0m
 [33m[stage-29] [0m[36mTerminating program[0m
 [33m[stage-29] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -69,17 +69,17 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: expiry[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-7] [0m[94m$ redis-cli set grapes apples px 100[0m
-[33m[stage-7] [0m[92mReceived OK (at 16:14:31.988)[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:31.988, key should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK (at 10:50:59.306)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:59.306, key should not be expired)[0m
 [33m[stage-7] [0m[92mReceived "apples"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 16:14:32.090, key should be expired)[0m
+[33m[stage-7] [0m[94m$ redis-cli get grapes (sent at 10:50:59.407, key should be expired)[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 [33m[stage-7] [0m[36mTerminating program[0m
 [33m[stage-7] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: rdb-config[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles840802383 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1674740977 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
@@ -87,7 +87,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: rdb-read-key[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "pear"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1908905599 --dbfilename blueberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4172299219 --dbfilename blueberry.rdb[0m
 [33m[stage-9] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
@@ -95,7 +95,7 @@ Debug = true
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: rdb-read-string-value[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: strawberry="apple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3116724353 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2953273321 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94m$ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
@@ -103,7 +103,7 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: rdb-read-multiple-keys[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "blueberry" "strawberry" "pineapple" "banana"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles961735724 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1310761890 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94m$ redis-cli KEYS *[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
@@ -111,7 +111,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: rdb-read-multiple-string-values[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "orange"="grape", "mango"="pear", "grape"="blueberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1614324402 --dbfilename apple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3297524165 --dbfilename apple.rdb[0m
 [33m[stage-12] [0m[94m$ redis-cli GET orange[0m
 [33m[stage-12] [0m[94m$ redis-cli GET mango[0m
 [33m[stage-12] [0m[94m$ redis-cli GET grape[0m
@@ -121,7 +121,7 @@ Debug = true
 [33m[stage-12] [0m[36mError terminating program: 'program failed to exit in 2 seconds after receiving sigterm'[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: rdb-read-value-with-expiry[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3444750566 --dbfilename apple.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles250733769 --dbfilename apple.rdb[0m
 [33m[stage-13] [0m[94m$ redis-cli GET pineapple[0m
 [33m[stage-13] [0m[94m$ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[94m$ redis-cli GET blueberry[0m
@@ -146,7 +146,7 @@ Debug = true
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-16] [0m[94mRunning tests for Stage #16: repl-info-replica[0m
-[33m[stage-16] [0m[94mServer is running on port 6379[0m
+[33m[stage-16] [0m[94mMaster is running on port 6379[0m
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-16] [0m[94m$ redis-cli INFO replication[0m
 [33m[stage-16] [0m[92mTest passed.[0m
@@ -161,7 +161,7 @@ Debug = true
 [33m[stage-17] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-18] [0m[94mRunning tests for Stage #18: repl-replica-ping[0m
-[33m[stage-18] [0m[94mServer is running on port 6379.[0m
+[33m[stage-18] [0m[94mMaster is running on port 6379.[0m
 [33m[stage-18] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-18] [0m[92mPING received.[0m
 [33m[stage-18] [0m[94m+PONG sent.[0m
@@ -170,7 +170,7 @@ Debug = true
 [33m[stage-18] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-19] [0m[94mRunning tests for Stage #19: repl-replica-replconf[0m
-[33m[stage-19] [0m[94mServer is running on port 6379[0m
+[33m[stage-19] [0m[94mMaster is running on port 6379[0m
 [33m[stage-19] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-19] [0m[92mPING received.[0m
 [33m[stage-19] [0m[94m+PONG sent.[0m
@@ -183,7 +183,7 @@ Debug = true
 [33m[stage-19] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-20] [0m[94mRunning tests for Stage #20: repl-replica-psync[0m
-[33m[stage-20] [0m[94mServer is running on port 6379[0m
+[33m[stage-20] [0m[94mMaster is running on port 6379[0m
 [33m[stage-20] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-20] [0m[92mPING received.[0m
 [33m[stage-20] [0m[94m+PONG sent.[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-22] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[92mOK received.[0m
 [33m[stage-22] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-22] [0m[92mFULLRESYNC 61812f1ff627e5cb14b6f436cdb2b91028bfc01f 0 received.[0m
+[33m[stage-22] [0m[92mFULLRESYNC 901cd3a0c4e4c12fb47cc3a3f24c293a2445dfa6 0 received.[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-23] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[92mOK received.[0m
 [33m[stage-23] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-23] [0m[92mFULLRESYNC 685d844f9d16c7150c9f762c4405fae833594e6e 0 received.[0m
+[33m[stage-23] [0m[92mFULLRESYNC 04dd71793876e03bf3c2a65c6130fd5371052c5c 0 received.[0m
 [33m[stage-23] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -239,7 +239,7 @@ Debug = true
 [33m[stage-24] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[92mOK received.[0m
 [33m[stage-24] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-24] [0m[92mFULLRESYNC 5615c32747c389996f39ab860bd3f96996377546 0 received.[0m
+[33m[stage-24] [0m[92mFULLRESYNC 82738cc795218e3e1cbac8eef43a03ac4032bc84 0 received.[0m
 [33m[stage-24] [0m[92mSuccessfully received RDB file from master.[0m
 [33m[stage-24] [0m[94mSetting key foo to 123[0m
 [33m[stage-24] [0m[94m$ redis-cli SET foo 123[0m
@@ -257,54 +257,54 @@ Debug = true
 
 [33m[stage-25] [0m[94mRunning tests for Stage #25: repl-multiple-replicas[0m
 [33m[stage-25] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 2bc430fc57e0845cf159abdea010acf6134ed7d7 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 2bc430fc57e0845cf159abdea010acf6134ed7d7 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[94m$ redis-cli PING[0m
-[33m[stage-25] [0m[92mPONG received.[0m
-[33m[stage-25] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-25] [0m[92mOK received.[0m
-[33m[stage-25] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-25] [0m[92mFULLRESYNC 2bc430fc57e0845cf159abdea010acf6134ed7d7 0 received.[0m
-[33m[stage-25] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-25] [0m[36mSetting key foo to 123[0m
-[33m[stage-25] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-25] [0m[36mSetting key bar to 456[0m
-[33m[stage-25] [0m[94m$ redis-cli SET bar 456[0m
-[33m[stage-25] [0m[36mSetting key baz to 789[0m
-[33m[stage-25] [0m[94m$ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-1] OK received.[0m
+[33m[stage-25] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-1] FULLRESYNC 00de5a72c879a19ffbfd445c015af573dfeca33a 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-2] OK received.[0m
+[33m[stage-25] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-2] FULLRESYNC 00de5a72c879a19ffbfd445c015af573dfeca33a 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-25] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[92m[replica-3] OK received.[0m
+[33m[stage-25] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[92m[replica-3] FULLRESYNC 00de5a72c879a19ffbfd445c015af573dfeca33a 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-25] [0m[94m[client] Setting key foo to 123[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-25] [0m[94m[client] Setting key bar to 456[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94m[client] Setting key baz to 789[0m
+[33m[stage-25] [0m[94m[client] $ redis-cli SET baz 789[0m
 [33m[stage-25] [0m[94mTesting Replica : 1[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-1] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 2[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-2] SET baz 789 received.[0m
 [33m[stage-25] [0m[94mTesting Replica : 3[0m
-[33m[stage-25] [0m[92mSELECT 0 received.[0m
-[33m[stage-25] [0m[92mSET foo 123 received.[0m
-[33m[stage-25] [0m[92mSET bar 456 received.[0m
-[33m[stage-25] [0m[92mSET baz 789 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET bar 456 received.[0m
+[33m[stage-25] [0m[92m[replica-3] SET baz 789 received.[0m
 [33m[stage-25] [0m[92mTest passed.[0m
 [33m[stage-25] [0m[36mTerminating program[0m
 [33m[stage-25] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-26] [0m[94mRunning tests for Stage #26: repl-cmd-processing[0m
-[33m[stage-26] [0m[94mServer is running on port 6379[0m
+[33m[stage-26] [0m[94mMaster is running on port 6379[0m
 [33m[stage-26] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-26] [0m[92mPING received.[0m
 [33m[stage-26] [0m[94m+PONG sent.[0m
@@ -332,7 +332,7 @@ Debug = true
 [33m[stage-26] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-27] [0m[94mRunning tests for Stage #27: repl-replica-getack[0m
-[33m[stage-27] [0m[94mServer is running on port 6379[0m
+[33m[stage-27] [0m[94mMaster is running on port 6379[0m
 [33m[stage-27] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-27] [0m[92mPING received.[0m
 [33m[stage-27] [0m[94m+PONG sent.[0m
@@ -350,7 +350,7 @@ Debug = true
 [33m[stage-27] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-28] [0m[94mRunning tests for Stage #28: repl-replica-getack-nonzero[0m
-[33m[stage-28] [0m[94mServer is running on port 6379[0m
+[33m[stage-28] [0m[94mMaster is running on port 6379[0m
 [33m[stage-28] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof localhost 6379[0m
 [33m[stage-28] [0m[92mPING received.[0m
 [33m[stage-28] [0m[94m+PONG sent.[0m
@@ -376,8 +376,8 @@ Debug = true
 
 [33m[stage-29] [0m[94mRunning tests for Stage #29: repl-wait-zero-replicas[0m
 [33m[stage-29] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-29] [0m[94m$ redis-cli WAIT 0 60000[0m
-[33m[stage-29] [0m[92m0 received.[0m
+[33m[stage-29] [0m[94m[client] $ redis-cli WAIT 0 60000[0m
+[33m[stage-29] [0m[92m[client] 0 received.[0m
 [33m[stage-29] [0m[92mTest passed.[0m
 [33m[stage-29] [0m[36mTerminating program[0m
 [33m[stage-29] [0m[36mProgram terminated successfully[0m
@@ -386,35 +386,35 @@ Debug = true
 [33m[stage-30] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
 [33m[stage-30] [0m[94mProceeding to create 3 replicas.[0m
 [33m[stage-30] [0m[36mCreating replica : 0.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 67f23c6e732c3f0f58bbbde413babe1672f89c21 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-1] OK received.[0m
+[33m[stage-30] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-1] FULLRESYNC 33261fd2850d69b6803c47f6a5ae36d99ba2db65 0 received.[0m
+[33m[stage-30] [0m[92m[replica-1] Successfully received RDB file from master.[0m
 [33m[stage-30] [0m[36mCreating replica : 1.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 67f23c6e732c3f0f58bbbde413babe1672f89c21 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-2] OK received.[0m
+[33m[stage-30] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-2] FULLRESYNC 33261fd2850d69b6803c47f6a5ae36d99ba2db65 0 received.[0m
+[33m[stage-30] [0m[92m[replica-2] Successfully received RDB file from master.[0m
 [33m[stage-30] [0m[36mCreating replica : 2.[0m
-[33m[stage-30] [0m[94m$ redis-cli PING[0m
-[33m[stage-30] [0m[92mPONG received.[0m
-[33m[stage-30] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-30] [0m[92mOK received.[0m
-[33m[stage-30] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-30] [0m[92mFULLRESYNC 67f23c6e732c3f0f58bbbde413babe1672f89c21 0 received.[0m
-[33m[stage-30] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 3 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 4 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
-[33m[stage-30] [0m[94m$ redis-cli WAIT 5 500[0m
-[33m[stage-30] [0m[92m3 received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-30] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[92m[replica-3] OK received.[0m
+[33m[stage-30] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[92m[replica-3] FULLRESYNC 33261fd2850d69b6803c47f6a5ae36d99ba2db65 0 received.[0m
+[33m[stage-30] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 3 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 4 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
+[33m[stage-30] [0m[94m[client] $ redis-cli WAIT 5 500[0m
+[33m[stage-30] [0m[92m[client] 3 received.[0m
 [33m[stage-30] [0m[92mTest passed.[0m
 [33m[stage-30] [0m[36mTerminating program[0m
 [33m[stage-30] [0m[36mProgram terminated successfully[0m
@@ -423,57 +423,55 @@ Debug = true
 [33m[stage-31] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
 [33m[stage-31] [0m[94mProceeding to create 3 replicas.[0m
 [33m[stage-31] [0m[36mCreating replica : 1.[0m
-[33m[stage-31] [0m[94m$ redis-cli PING[0m
-[33m[stage-31] [0m[92mPONG received.[0m
-[33m[stage-31] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-31] [0m[92mOK received.[0m
-[33m[stage-31] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-31] [0m[92mFULLRESYNC 90d8a5b9717a261e6acb70aa82c14dfc0fc5d45b 0 received.[0m
-[33m[stage-31] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-31] [0m[94m[replica-1] $ redis-cli PING[0m
+[33m[stage-31] [0m[92m[replica-1] PONG received.[0m
+[33m[stage-31] [0m[94m[replica-1] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-31] [0m[92m[replica-1] OK received.[0m
+[33m[stage-31] [0m[94m[replica-1] $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[92m[replica-1] FULLRESYNC 0b0846db44656421a48b88e271ce0dcbcb3b074b 0 received.[0m
+[33m[stage-31] [0m[92m[replica-1] Successfully received RDB file from master.[0m
 [33m[stage-31] [0m[36mCreating replica : 2.[0m
-[33m[stage-31] [0m[94m$ redis-cli PING[0m
-[33m[stage-31] [0m[92mPONG received.[0m
-[33m[stage-31] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-31] [0m[92mOK received.[0m
-[33m[stage-31] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-31] [0m[92mFULLRESYNC 90d8a5b9717a261e6acb70aa82c14dfc0fc5d45b 0 received.[0m
-[33m[stage-31] [0m[92mSuccessfully received RDB file from master.[0m
+[33m[stage-31] [0m[94m[replica-2] $ redis-cli PING[0m
+[33m[stage-31] [0m[92m[replica-2] PONG received.[0m
+[33m[stage-31] [0m[94m[replica-2] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-31] [0m[92m[replica-2] OK received.[0m
+[33m[stage-31] [0m[94m[replica-2] $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[92m[replica-2] FULLRESYNC 0b0846db44656421a48b88e271ce0dcbcb3b074b 0 received.[0m
+[33m[stage-31] [0m[92m[replica-2] Successfully received RDB file from master.[0m
 [33m[stage-31] [0m[36mCreating replica : 3.[0m
-[33m[stage-31] [0m[94m$ redis-cli PING[0m
-[33m[stage-31] [0m[92mPONG received.[0m
-[33m[stage-31] [0m[94m$ redis-cli REPLCONF listening-port 6380[0m
-[33m[stage-31] [0m[92mOK received.[0m
-[33m[stage-31] [0m[94m$ redis-cli PSYNC ? -1[0m
-[33m[stage-31] [0m[92mFULLRESYNC 90d8a5b9717a261e6acb70aa82c14dfc0fc5d45b 0 received.[0m
-[33m[stage-31] [0m[92mSuccessfully received RDB file from master.[0m
-[33m[stage-31] [0m[94m$ redis-cli SET foo 123[0m
-[33m[stage-31] [0m[94m$ redis-cli WAIT 1 500[0m
-[33m[stage-31] [0m[94mStart receiving on Replicas[0m
-[33m[stage-31] [0m[92mSELECT 0 received.[0m
-[33m[stage-31] [0m[92mSET foo 123 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[92mSELECT 0 received.[0m
-[33m[stage-31] [0m[92mSET foo 123 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[92mSELECT 0 received.[0m
-[33m[stage-31] [0m[92mSET foo 123 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[94mREPLCONF ACK 273 sent.[0m
-[33m[stage-31] [0m[92m1 received.[0m
-[33m[stage-31] [0m[94m$ redis-cli SET baz 789[0m
-[33m[stage-31] [0m[94m$ redis-cli WAIT 4 2000[0m
-[33m[stage-31] [0m[94mStart receiving on Replicas[0m
-[33m[stage-31] [0m[92mSET baz 789 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[92mSET baz 789 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[92mSET baz 789 received.[0m
-[33m[stage-31] [0m[92mREPLCONF GETACK * received.[0m
-[33m[stage-31] [0m[94mREPLCONF ACK 341 sent.[0m
-[33m[stage-31] [0m[94mREPLCONF ACK 341 sent.[0m
-[33m[stage-31] [0m[94mREPLCONF ACK 341 sent.[0m
-[33m[stage-31] [0m[92m3 received.[0m
-[33m[stage-31] [0m[94mWAIT command returned after 2005 ms[0m
+[33m[stage-31] [0m[94m[replica-3] $ redis-cli PING[0m
+[33m[stage-31] [0m[92m[replica-3] PONG received.[0m
+[33m[stage-31] [0m[94m[replica-3] $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-31] [0m[92m[replica-3] OK received.[0m
+[33m[stage-31] [0m[94m[replica-3] $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[92m[replica-3] FULLRESYNC 0b0846db44656421a48b88e271ce0dcbcb3b074b 0 received.[0m
+[33m[stage-31] [0m[92m[replica-3] Successfully received RDB file from master.[0m
+[33m[stage-31] [0m[94m[client] $ redis-cli SET foo 123[0m
+[33m[stage-31] [0m[94m[client] $ redis-cli WAIT 1 500[0m
+[33m[stage-31] [0m[92m[replica-1] SELECT 0 received.[0m
+[33m[stage-31] [0m[92m[replica-1] SET foo 123 received.[0m
+[33m[stage-31] [0m[92m[replica-1] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[92m[replica-2] SELECT 0 received.[0m
+[33m[stage-31] [0m[92m[replica-2] SET foo 123 received.[0m
+[33m[stage-31] [0m[92m[replica-2] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[92m[replica-3] SELECT 0 received.[0m
+[33m[stage-31] [0m[92m[replica-3] SET foo 123 received.[0m
+[33m[stage-31] [0m[92m[replica-3] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[94m[replica-1] $ redis-cli REPLCONF ACK 111[0m
+[33m[stage-31] [0m[92m[client] 1 received.[0m
+[33m[stage-31] [0m[94m[client] $ redis-cli SET baz 789[0m
+[33m[stage-31] [0m[94m[client] $ redis-cli WAIT 4 2000[0m
+[33m[stage-31] [0m[92m[replica-1] SET baz 789 received.[0m
+[33m[stage-31] [0m[92m[replica-1] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[92m[replica-2] SET baz 789 received.[0m
+[33m[stage-31] [0m[92m[replica-2] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[92m[replica-3] SET baz 789 received.[0m
+[33m[stage-31] [0m[92m[replica-3] REPLCONF GETACK * received.[0m
+[33m[stage-31] [0m[94m[replica-1] $ redis-cli REPLCONF ACK 179[0m
+[33m[stage-31] [0m[94m[replica-2] $ redis-cli REPLCONF ACK 179[0m
+[33m[stage-31] [0m[94m[replica-3] $ redis-cli REPLCONF ACK 179[0m
+[33m[stage-31] [0m[92m[client] 3 received.[0m
+[33m[stage-31] [0m[94m[client] WAIT command returned after 2004 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m

--- a/internal/test_repl_id.go
+++ b/internal/test_repl_id.go
@@ -31,11 +31,11 @@ func testReplReplicationID(stageHarness *testerutils.StageHarness) error {
 	idKey, offsetKey = "master_replid", "master_repl_offset"
 
 	if infoMap[idKey] == "" {
-		return fmt.Errorf("Expected '%v' key in INFO replication.", idKey)
+		return fmt.Errorf("Expected: '%v' key in INFO replication.", idKey)
 	}
 
 	if infoMap[offsetKey] != "0" {
-		return fmt.Errorf("Expected 0 value for '%v' in INFO replication.", offsetKey)
+		return fmt.Errorf("Expected: 0 value for '%v' in INFO replication.", offsetKey)
 	}
 
 	client.Close()

--- a/internal/test_repl_info.go
+++ b/internal/test_repl_info.go
@@ -30,11 +30,11 @@ func testReplInfo(stageHarness *testerutils.StageHarness) error {
 	}
 
 	if infoMap[key] == "" {
-		return fmt.Errorf("Expected 'role' key in INFO replication.")
+		return fmt.Errorf("Expected: 'role' key in INFO replication.")
 	}
 
 	if role != "master" {
-		return fmt.Errorf("Expected 'role' to be 'master' in INFO replication, got %v", role)
+		return fmt.Errorf("Expected: 'role' to be 'master' in INFO replication, got %v", role)
 	}
 
 	client.Close()

--- a/internal/test_repl_info_replica.go
+++ b/internal/test_repl_info_replica.go
@@ -16,7 +16,7 @@ func testReplInfoReplica(stageHarness *testerutils.StageHarness) error {
 	defer listener.Close()
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_info_replica.go
+++ b/internal/test_repl_info_replica.go
@@ -48,11 +48,11 @@ func testReplInfoReplica(stageHarness *testerutils.StageHarness) error {
 	}
 
 	if key != "role" {
-		return fmt.Errorf("Expected 'role' key in INFO replication, got %v", key)
+		return fmt.Errorf("Expected: 'role' and actual: '%v' keys in INFO replication don't match", key)
 	}
 
 	if role != "slave" {
-		return fmt.Errorf("Expected 'role' to be 'slave' in INFO replication, got %v", role)
+		return fmt.Errorf("Expected: 'role' and actual: '%v' roles in INFO replication don't match", role)
 	}
 
 	client.Close()

--- a/internal/test_repl_master_cmd_prop.go
+++ b/internal/test_repl_master_cmd_prop.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"strings"
 
 	testerutils "github.com/codecrafters-io/tester-utils"
 )
@@ -51,23 +50,9 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 	}
 
 	// Redis will send SELECT, but not expected from Users.
-	var skipFirstAssert bool
-	skipFirstAssert = false
-	actualMessages, err := replica.readRespMessages()
-	if strings.ToUpper(actualMessages[0]) != "SELECT" {
-		skipFirstAssert = true
-		expectedMessages := []string{"SET", "foo", "123"}
-		err = replica.assertMessages(actualMessages, expectedMessages, true)
-		if err != nil {
-			return err
-		}
-	}
-
-	if !skipFirstAssert {
-		err, _ = replica.readAndAssertMessages([]string{"SET", "foo", "123"}, true)
-		if err != nil {
-			return err
-		}
+	err, _ = replica.readAndAssertMessagesWithSkip([]string{"SET", "foo", "123"}, "SELECT", true)
+	if err != nil {
+		return err
 	}
 
 	err, _ = replica.readAndAssertMessages([]string{"SET", "bar", "456"}, true)

--- a/internal/test_repl_master_cmd_prop.go
+++ b/internal/test_repl_master_cmd_prop.go
@@ -53,7 +53,7 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 	// Redis will send SELECT, but not expected from Users.
 	var skipFirstAssert bool
 	skipFirstAssert = false
-	actualMessages, err := readRespMessages(replica.Reader, logger)
+	actualMessages, err := replica.readRespMessages()
 	if strings.ToUpper(actualMessages[0]) != "SELECT" {
 		skipFirstAssert = true
 		expectedMessages := []string{"SET", "foo", "123"}
@@ -64,18 +64,18 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 	}
 
 	if !skipFirstAssert {
-		err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "foo", "123"}, logger, true)
+		err, _ = replica.readAndAssertMessages([]string{"SET", "foo", "123"}, true)
 		if err != nil {
 			return err
 		}
 	}
 
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "bar", "456"}, logger, true)
+	err, _ = replica.readAndAssertMessages([]string{"SET", "bar", "456"}, true)
 	if err != nil {
 		return err
 	}
 
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "baz", "789"}, logger, true)
+	err, _ = replica.readAndAssertMessages([]string{"SET", "baz", "789"}, true)
 	if err != nil {
 		return err
 	}

--- a/internal/test_repl_master_cmd_prop.go
+++ b/internal/test_repl_master_cmd_prop.go
@@ -57,7 +57,7 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 	if strings.ToUpper(actualMessages[0]) != "SELECT" {
 		skipFirstAssert = true
 		expectedMessages := []string{"SET", "foo", "123"}
-		err = assertMessages(actualMessages, expectedMessages, logger, true)
+		err = replica.assertMessages(actualMessages, expectedMessages, true)
 		if err != nil {
 			return err
 		}

--- a/internal/test_repl_master_cmd_prop.go
+++ b/internal/test_repl_master_cmd_prop.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"strings"
 
 	testerutils "github.com/codecrafters-io/tester-utils"
 )
@@ -42,7 +43,6 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 		1: {"foo", "123"},
 		2: {"bar", "456"},
 		3: {"baz", "789"},
-
 	}
 	for i := 1; i <= len(kvMap); i++ { // We need order of commands preserved
 		key, value := kvMap[i][0], kvMap[i][1]
@@ -50,21 +50,32 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 		client.Send([]string{"SET", key, value})
 	}
 
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SELECT", "0"}, logger)
-	// Redis will send SELECT, but not expected from Users, err is not checked
-	// here.
+	// Redis will send SELECT, but not expected from Users.
+	var skipFirstAssert bool
+	skipFirstAssert = false
+	actualMessages, err := readRespMessages(replica.Reader, logger)
+	if strings.ToUpper(actualMessages[0]) != "SELECT" {
+		skipFirstAssert = true
+		expectedMessages := []string{"SET", "foo", "123"}
+		err = assertMessages(actualMessages, expectedMessages, logger, true)
+		if err != nil {
+			return err
+		}
+	}
 
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "foo", "123"}, logger)
+	if !skipFirstAssert {
+		err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "foo", "123"}, logger, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "bar", "456"}, logger, true)
 	if err != nil {
 		return err
 	}
 
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "bar", "456"}, logger)
-	if err != nil {
-		return err
-	}
-
-	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "baz", "789"}, logger)
+	err, _ = readAndAssertMessages(replica.Reader, []string{"SET", "baz", "789"}, logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/test_repl_multiple_replicas.go
+++ b/internal/test_repl_multiple_replicas.go
@@ -68,7 +68,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 		if strings.ToUpper(actualMessages[0]) != "SELECT" {
 			startIndexSetKeyCheck += 1
 			expectedMessages := []string{"SET", "foo", "123"}
-			err = assertMessages(actualMessages, expectedMessages, logger, true)
+			err = replica.assertMessages(actualMessages, expectedMessages, true)
 			if err != nil {
 				return err
 			}

--- a/internal/test_repl_multiple_replicas.go
+++ b/internal/test_repl_multiple_replicas.go
@@ -29,7 +29,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 		defer conn.Close()
 		replica := NewFakeRedisReplica(conn, logger)
 		replicas = append(replicas, replica)
-		replica.LogPrefix = fmt.Sprintf("[Replica: %v] ", j+1)
+		replica.LogPrefix = fmt.Sprintf("[replica-%v] ", j+1)
 	}
 
 	conn, err := NewRedisConn("", "localhost:6379")
@@ -38,7 +38,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 	}
 	defer conn.Close()
 	client := NewFakeRedisMaster(conn, logger)
-	client.LogPrefix = "[Client] "
+	client.LogPrefix = "[client] "
 
 	for i := 0; i < len(replicas); i++ {
 		replica := replicas[i]

--- a/internal/test_repl_multiple_replicas.go
+++ b/internal/test_repl_multiple_replicas.go
@@ -29,6 +29,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 		defer conn.Close()
 		replica := NewFakeRedisReplica(conn, logger)
 		replicas = append(replicas, replica)
+		replica.LogPrefix = fmt.Sprintf("[Replica: %v] ", j+1)
 	}
 
 	conn, err := NewRedisConn("", "localhost:6379")
@@ -37,6 +38,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 	}
 	defer conn.Close()
 	client := NewFakeRedisMaster(conn, logger)
+	client.LogPrefix = "[Client] "
 
 	for i := 0; i < len(replicas); i++ {
 		replica := replicas[i]
@@ -54,7 +56,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 	for i := 1; i <= len(kvMap); i++ {
 		// We need order of commands preserved
 		key, value := kvMap[i][0], kvMap[i][1]
-		logger.Debugf("Setting key %s to %s", key, value)
+		client.Log(fmt.Sprintf("Setting key %s to %s", key, value))
 		client.Send([]string{"SET", key, value})
 	}
 

--- a/internal/test_repl_multiple_replicas.go
+++ b/internal/test_repl_multiple_replicas.go
@@ -64,7 +64,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 		replica := replicas[j]
 		logger.Infof("Testing Replica : %v", j+1)
 		// Redis will send SELECT, but not expected from Users.
-		actualMessages, err := readRespMessages(replica.Reader, logger)
+		actualMessages, err := replica.readRespMessages()
 		if strings.ToUpper(actualMessages[0]) != "SELECT" {
 			startIndexSetKeyCheck += 1
 			expectedMessages := []string{"SET", "foo", "123"}
@@ -78,7 +78,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 			// We need order of commands preserved
 			key, value := kvMap[i][0], kvMap[i][1]
 
-			err, _ = readAndAssertMessages(replica.Reader, []string{"SET", key, value}, logger, true)
+			err, _ = replica.readAndAssertMessages([]string{"SET", key, value}, true)
 			if err != nil {
 				return err
 			}

--- a/internal/test_repl_replica_cmd_processing.go
+++ b/internal/test_repl_replica_cmd_processing.go
@@ -66,7 +66,7 @@ func testReplCmdProcessing(stageHarness *testerutils.StageHarness) error {
 	for i := 1; i <= len(kvMap); i++ {
 		key, value := kvMap[i][0], kvMap[i][1]
 		logger.Infof("Getting key %s", key)
-		err = replicaClient.SendAndAssertString([]string{"GET", key}, value)
+		err = replicaClient.SendAndAssertString([]string{"GET", key}, value, true)
 		if err != nil {
 			return err
 		}

--- a/internal/test_repl_replica_cmd_processing.go
+++ b/internal/test_repl_replica_cmd_processing.go
@@ -16,7 +16,7 @@ func testReplCmdProcessing(stageHarness *testerutils.StageHarness) error {
 
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_replica_getack_nonzero.go
+++ b/internal/test_repl_replica_getack_nonzero.go
@@ -17,7 +17,7 @@ func testReplGetaAckNonZero(stageHarness *testerutils.StageHarness) error {
 
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{
@@ -42,11 +42,6 @@ func testReplGetaAckNonZero(stageHarness *testerutils.StageHarness) error {
 		return err
 	}
 
-	// If I don't read ACK sent by redis replica, it's not buffered
-	// I can easily read the next ACK in the next `stage`
-	// So ideally, I can ignore the ACKs in the `SET`` stages,
-	// and then only check for explicit GETACKs
-
 	offset := 0
 	err = master.GetAck(offset) // 37
 	if err != nil {
@@ -56,8 +51,6 @@ func testReplGetaAckNonZero(stageHarness *testerutils.StageHarness) error {
 
 	cmd := []string{"PING"}
 	master.Send(cmd) // 14
-	// actualMessages, err := readRespMessages(r, logger)
-	// fmt.Println(actualMessages)
 	offset += GetByteOffset(cmd)
 
 	err = master.GetAck(offset) // 37
@@ -70,16 +63,12 @@ func testReplGetaAckNonZero(stageHarness *testerutils.StageHarness) error {
 	value := RandomAlphanumericString(testerutils_random.RandomInt(5, 20))
 	cmd = []string{"SET", key, value}
 	master.Send(cmd) // 31
-	// actualMessages, err = readRespMessages(r, logger)
-	// fmt.Println(actualMessages)
 	offset += GetByteOffset(cmd)
 
 	key = RandomAlphanumericString(testerutils_random.RandomInt(5, 20))
 	value = RandomAlphanumericString(testerutils_random.RandomInt(5, 20))
 	cmd = []string{"SET", key, value}
 	master.Send(cmd) // 31
-	// actualMessages, err = readRespMessages(r, logger)
-	// fmt.Println(actualMessages)
 	offset += GetByteOffset(cmd)
 
 	err = master.GetAck(offset)

--- a/internal/test_repl_replica_getack_zero.go
+++ b/internal/test_repl_replica_getack_zero.go
@@ -16,7 +16,7 @@ func testReplGetaAckZero(stageHarness *testerutils.StageHarness) error {
 
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_replica_ping.go
+++ b/internal/test_repl_replica_ping.go
@@ -14,7 +14,7 @@ func testReplReplicaSendsPing(stageHarness *testerutils.StageHarness) error {
 	}
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379.")
+	logger.Infof("Master is running on port 6379.")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_replica_psync.go
+++ b/internal/test_repl_replica_psync.go
@@ -15,7 +15,7 @@ func testReplReplicaSendsPsync(stageHarness *testerutils.StageHarness) error {
 	}
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_replica_replconf.go
+++ b/internal/test_repl_replica_replconf.go
@@ -14,7 +14,7 @@ func testReplReplicaSendsReplconf(stageHarness *testerutils.StageHarness) error 
 	}
 	logger := stageHarness.Logger
 
-	logger.Infof("Server is running on port 6379")
+	logger.Infof("Master is running on port 6379")
 
 	replica := NewRedisBinary(stageHarness)
 	replica.args = []string{

--- a/internal/test_repl_wait.go
+++ b/internal/test_repl_wait.go
@@ -68,13 +68,28 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 	for i := 0; i < replicaCount; i++ {
 		replica := replicas[i]
 
-		err, o := readAndAssertMessages(replica.Reader, []string{"SELECT", "0"}, logger)
-		offset += o
+		var skipFirstAssert bool
+		skipFirstAssert = false
+		actualMessages, err := readRespMessages(replica.Reader, logger)
+		if strings.ToUpper(actualMessages[0]) != "SELECT" {
+			skipFirstAssert = true
+			expectedMessages := []string{"SET", "foo", "123"}
+			offset += GetByteOffset(expectedMessages)
+			err = assertMessages(actualMessages, expectedMessages, logger, true)
+			if err != nil {
+				return err
+			}
+		}
 
-		err, o = readAndAssertMessages(replica.Reader, []string{"SET", "foo", "123"}, logger)
-		offset += o
+		if !skipFirstAssert {
+			err, o := readAndAssertMessages(replica.Reader, []string{"SET", "foo", "123"}, logger, true)
+			offset += o
+			if err != nil {
+				return err
+			}
+		}
 
-		err, o = readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger)
+		err, o := readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger, true)
 		offset += o
 		if err != nil {
 			return err
@@ -97,47 +112,47 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 
 	//////////////////////////////////////////////////////
 
-	// client.SendAndAssert([]string{"SET", "bar", "456"}, []string{"OK"})
+	client.SendAndAssert([]string{"SET", "bar", "456"}, []string{"OK"})
 
-	// err = client.Send([]string{"WAIT", "3", "500"})
-	// if err != nil {
-	// 	return err
-	// }
+	err = client.Send([]string{"WAIT", "3", "500"})
+	if err != nil {
+		return err
+	}
 
-	// OLD_OFFSET := offset
-	// fmt.Println("Start receiving on Replicas")
-	// ANSWER = 3
-	// // READ STREAM ON ALL REPLICAS
-	// for i := 0; i < replicaCount; i++ {
-	// 	offset = OLD_OFFSET
-	// 	replica := replicas[i]
+	OLD_OFFSET := offset
+	fmt.Println("Start receiving on Replicas")
+	ANSWER = 3
+	// READ STREAM ON ALL REPLICAS
+	for i := 0; i < replicaCount; i++ {
+		offset = OLD_OFFSET
+		replica := replicas[i]
 
-	// 	// err, o := readAndAssertMessages(replica.Reader, []string{"SELECT", "0"}, logger)
-	// 	// offset += o
+		// err, o := readAndAssertMessages(replica.Reader, []string{"SELECT", "0"}, logger)
+		// offset += o
 
-	// 	err, o := readAndAssertMessages(replica.Reader, []string{"SET", "bar", "456"}, logger)
-	// 	offset += o
+		err, o := readAndAssertMessages(replica.Reader, []string{"SET", "bar", "456"}, logger, true)
+		offset += o
 
-	// 	err, o = readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger)
-	// 	offset += o
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
+		err, o = readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger, false)
+		offset += o
+		if err != nil {
+			return err
+		}
+	}
 
-	// for i := 0; i < ANSWER; i++ {
-	// 	replica := replicas[i]
+	for i := 0; i < ANSWER; i++ {
+		replica := replicas[i]
 
-	// 	msg := []string{"REPLCONF", "ACK", strconv.Itoa(offset)}
-	// 	err = replica.Writer.WriteCommand(msg...)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	replica.Writer.Flush()
-	// 	replica.Logger.Infof("%s sent.", strings.ReplaceAll(strings.Join(msg, " "), "\r\n", ""))
-	// }
+		msg := []string{"REPLCONF", "ACK", strconv.Itoa(offset)}
+		err = replica.Writer.WriteCommand(msg...)
+		if err != nil {
+			return err
+		}
+		replica.Writer.Flush()
+		replica.Logger.Infof("%s sent.", strings.ReplaceAll(strings.Join(msg, " "), "\r\n", ""))
+	}
 
-	// readAndAssertIntMessage(client.Reader, ANSWER, logger)
+	readAndAssertIntMessage(client.Reader, ANSWER, logger)
 
 	//////////////////////////////////////////////////////
 
@@ -152,17 +167,17 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 		return err
 	}
 
-	OLD_OFFSET := offset
+	OLD_OFFSET = offset
 	logger.Infof("Start receiving on Replicas")
 	// READ STREAM ON ALL REPLICAS
 	for i := 0; i < replicaCount; i++ {
 		offset = OLD_OFFSET
 		replica := replicas[i]
 
-		err, o := readAndAssertMessages(replica.Reader, []string{"SET", "baz", "789"}, logger)
+		err, o := readAndAssertMessages(replica.Reader, []string{"SET", "baz", "789"}, logger, true)
 		offset += o
 
-		err, o = readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger)
+		err, o = readAndAssertMessages(replica.Reader, []string{"REPLCONF", "GETACK", "*"}, logger, false)
 		offset += o
 		if err != nil {
 			return err

--- a/internal/test_repl_wait.go
+++ b/internal/test_repl_wait.go
@@ -39,7 +39,7 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 
 		replica := NewFakeRedisReplica(conn, logger)
 		replicas = append(replicas, replica)
-		replica.LogPrefix = fmt.Sprintf("[Replica: %v] ", i+1)
+		replica.LogPrefix = fmt.Sprintf("[replica-%v] ", i+1)
 
 		err = replica.Handshake()
 		if err != nil {
@@ -54,7 +54,7 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 	}
 
 	client := NewFakeRedisMaster(conn, logger)
-	client.LogPrefix = "[Client] "
+	client.LogPrefix = "[client] "
 
 	client.SendAndAssert([]string{"SET", "foo", "123"}, []string{"OK"})
 

--- a/internal/test_repl_wait.go
+++ b/internal/test_repl_wait.go
@@ -78,7 +78,7 @@ func testWait(stageHarness *testerutils.StageHarness) error {
 			skipFirstAssert = true
 			expectedMessages := []string{"SET", "foo", "123"}
 			offset += GetByteOffset(expectedMessages)
-			err = assertMessages(actualMessages, expectedMessages, logger, true)
+			err = replica.assertMessages(actualMessages, expectedMessages, true)
 			if err != nil {
 				return err
 			}

--- a/internal/test_repl_wait_zero_offset.go
+++ b/internal/test_repl_wait_zero_offset.go
@@ -35,7 +35,7 @@ func testWaitZeroOffset(stageHarness *testerutils.StageHarness) error {
 		}
 
 		replica := NewFakeRedisReplica(conn, logger)
-		replica.LogPrefix = fmt.Sprintf("[Replica: %v] ", i+1)
+		replica.LogPrefix = fmt.Sprintf("[replica-%v] ", i+1)
 		err = replica.Handshake()
 		if err != nil {
 			return err
@@ -48,7 +48,7 @@ func testWaitZeroOffset(stageHarness *testerutils.StageHarness) error {
 	}
 
 	client := NewFakeRedisMaster(conn, logger)
-	client.LogPrefix = "[Client] "
+	client.LogPrefix = "[client] "
 
 	diff := ((replicaCount + 3) - 3) / 3
 	safeDiff := max(1, diff) // If diff is 0, it will get stuck in an infinite loop

--- a/internal/test_repl_wait_zero_offset.go
+++ b/internal/test_repl_wait_zero_offset.go
@@ -35,6 +35,7 @@ func testWaitZeroOffset(stageHarness *testerutils.StageHarness) error {
 		}
 
 		replica := NewFakeRedisReplica(conn, logger)
+		replica.LogPrefix = fmt.Sprintf("[Replica: %v] ", i+1)
 		err = replica.Handshake()
 		if err != nil {
 			return err
@@ -47,6 +48,7 @@ func testWaitZeroOffset(stageHarness *testerutils.StageHarness) error {
 	}
 
 	client := NewFakeRedisMaster(conn, logger)
+	client.LogPrefix = "[Client] "
 
 	diff := ((replicaCount + 3) - 3) / 3
 	safeDiff := max(1, diff) // If diff is 0, it will get stuck in an infinite loop

--- a/internal/test_repl_wait_zero_replicas.go
+++ b/internal/test_repl_wait_zero_replicas.go
@@ -25,6 +25,7 @@ func testWaitZeroReplicas(stageHarness *testerutils.StageHarness) error {
 	}
 
 	client := NewFakeRedisMaster(conn, logger)
+	client.LogPrefix = "[Client] "
 
 	err = client.Wait("0", "60000", 0)
 	if err != nil {

--- a/internal/test_repl_wait_zero_replicas.go
+++ b/internal/test_repl_wait_zero_replicas.go
@@ -25,7 +25,7 @@ func testWaitZeroReplicas(stageHarness *testerutils.StageHarness) error {
 	}
 
 	client := NewFakeRedisMaster(conn, logger)
-	client.LogPrefix = "[Client] "
+	client.LogPrefix = "[client] "
 
 	err = client.Wait("0", "60000", 0)
 	if err != nil {

--- a/internal/util.go
+++ b/internal/util.go
@@ -234,7 +234,7 @@ func compareStringSlices(actual, expected []string, caseSensitiveMatch bool) err
 			a, e = strings.ToUpper(actual[i]), strings.ToUpper(expected[i])
 		}
 		if a != e {
-			return fmt.Errorf("Expected : '%v' and actual : '%v' messages don't match", e, a)
+			return fmt.Errorf("Expected: '%v' and actual: '%v' messages don't match", e, a)
 		}
 	}
 
@@ -377,7 +377,7 @@ func readAndAssertMessage(reader *resp3.Reader, expectedMessage string, logger *
 			a, e = strings.ToUpper(actualMessage), strings.ToUpper(expectedMessage)
 		}
 		if a != e {
-			err = fmt.Errorf("Expected '%v', got '%v'", expectedMessage, actualMessage)
+			err = fmt.Errorf("Expected: '%v' and actual: '%v' messages don't match", expectedMessage, actualMessage)
 		}
 	}
 	if err != nil {
@@ -393,7 +393,7 @@ func readAndAssertIntMessage(reader *resp3.Reader, expectedMessage int, logger *
 		return err
 	}
 	if actualMessage != expectedMessage {
-		err = fmt.Errorf("Expected '%v', got '%v'", expectedMessage, actualMessage)
+		err = fmt.Errorf("Expected: '%v' and actual: '%v' messages don't match", expectedMessage, actualMessage)
 	}
 	if err != nil {
 		return err

--- a/internal/util.go
+++ b/internal/util.go
@@ -248,6 +248,11 @@ func compareStringSlices(actual, expected []string, caseSensitiveMatch bool) err
 			// Case Insensitive matching
 			a, e = strings.ToUpper(actual[i]), strings.ToUpper(expected[i])
 		}
+		if i == 0 {
+			// First element in the array is the REDIS command
+			// That should always be comapred in a case insensitive manner
+			a, e = strings.ToUpper(actual[i]), strings.ToUpper(expected[i])
+		}
 		if a != e {
 			return fmt.Errorf("Expected: '%v' and actual: '%v' messages don't match", e, a)
 		}

--- a/internal/util.go
+++ b/internal/util.go
@@ -356,21 +356,19 @@ func (node FakeRedisNode) readAndAssertMessages(messages []string, caseSensitive
 		return err, 0
 	}
 	// fmt.Println("ACTMSG :", actualMessages)
-	expectedMessages := []string(messages)
-	err = compareStringSlices(actualMessages, expectedMessages, caseSensitiveMatch)
+	err = node.assertMessages(actualMessages, messages, caseSensitiveMatch)
 	if err != nil {
 		return err, 0
 	}
-	node.Logger.Successf(node.LogPrefix + strings.Join(actualMessages, " ") + " received.")
 	return nil, offset
 }
 
-func assertMessages(actualMessages []string, expectedMessages []string, logger *logger.Logger, caseSensitiveMatch bool) error {
+func (node FakeRedisNode) assertMessages(actualMessages []string, expectedMessages []string, caseSensitiveMatch bool) error {
 	err := compareStringSlices(actualMessages, expectedMessages, caseSensitiveMatch)
 	if err != nil {
 		return err
 	}
-	logger.Successf(strings.Join(actualMessages, " ") + " received.")
+	node.Logger.Successf(node.LogPrefix + strings.Join(actualMessages, " ") + " received.")
 	return nil
 }
 


### PR DESCRIPTION
Fixes : 
1. Properly handle first command sent by User. (Previous test was explicitly waiting and testing for SELECT commands, updated that to skip if SELECT is received, if not proceed with assertion.)
2. Add case sensitive matching for commands propagated. (REDIS commands are excluded.)
3. Update all error statements statements to be more consistent.
4. Remove 2nd WAIT test case. (Makes the entire stage > 10s).
5. Update logs to say "Master is running on XXXX".
6. Create FakeRedisNode to share methods between Replica and Master. (Refactor and create shared struct).
7. Add util method readAndAssertMessagesWithSkip, and refactor code. (re : Point 1)
Same code was used across multiple files.
8. Add LogPrefix for other stages with multiple replicas.
9. Update log prefix to: [replica-N] and [client].
10. Add updated fixtures. 