### PR TITLE
CC-1040: Updates to replication tests.

### DIFF
--- a/internal/fake_redis_master.go
+++ b/internal/fake_redis_master.go
@@ -19,7 +19,7 @@ func NewFakeRedisMaster(conn net.Conn, logger *logger.Logger) *FakeRedisMaster {
 }
 
 func (master FakeRedisMaster) Assert(receiveMessages []string, sendMessage string, caseSensitiveMatch bool) error {
-	err, _ := master.readAndAssertMessages(receiveMessages, caseSensitiveMatch)
+	_, err := master.readAndAssertMessages(receiveMessages, caseSensitiveMatch)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (master FakeRedisMaster) Assert(receiveMessages []string, sendMessage strin
 }
 
 func (master FakeRedisMaster) AssertWithOr(receiveMessages [][]string, sendMessage string, caseSensitiveMatch bool) error {
-	err, _ := master.readAndAssertMessagesWithOr(receiveMessages, caseSensitiveMatch)
+	_, err := master.readAndAssertMessagesWithOr(receiveMessages, caseSensitiveMatch)
 	if err != nil {
 		return err
 	}

--- a/internal/fake_redis_node.go
+++ b/internal/fake_redis_node.go
@@ -89,7 +89,7 @@ func (node FakeRedisNode) readRespMessages() ([]string, error) {
 	message := resp.SmartResult()
 	slice, ok := message.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("Unexpected message received : %v", message)
+		return nil, fmt.Errorf("Unexpected message received: %v", message)
 	}
 	return convertToStringArray(slice)
 }
@@ -103,7 +103,7 @@ func (node FakeRedisNode) readRespString() (string, error) {
 	message := resp.SmartResult()
 	slice, ok := message.(string)
 	if !ok {
-		return "", fmt.Errorf("Unexpected message received : %v", message)
+		return "", fmt.Errorf("Unexpected message received: %v", message)
 	}
 	return slice, nil
 }
@@ -117,7 +117,7 @@ func (node FakeRedisNode) readRespInt() (int, error) {
 	message := resp.SmartResult()
 	slice, ok := message.(int64)
 	if !ok {
-		return 0, fmt.Errorf("Unexpected message received : %v", message)
+		return 0, fmt.Errorf("Unexpected message received: %v", message)
 	}
 	integer := int(slice)
 	return integer, nil

--- a/internal/fake_redis_node.go
+++ b/internal/fake_redis_node.go
@@ -49,7 +49,7 @@ func (node FakeRedisNode) SendAndAssertStringArray(sendMessage []string, receive
 	if err != nil {
 		return err
 	}
-	err, _ = node.readAndAssertMessages(receiveMessage, false)
+	_, err = node.readAndAssertMessages(receiveMessage, false)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,10 @@ func (node FakeRedisNode) readRespMessages() ([]string, error) {
 		return nil, e
 	}
 	message := resp.SmartResult()
-	slice, _ := message.([]interface{})
+	slice, ok := message.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unexpected message received : %v", message)
+	}
 	return convertToStringArray(slice)
 }
 
@@ -98,7 +101,10 @@ func (node FakeRedisNode) readRespString() (string, error) {
 		return "", e
 	}
 	message := resp.SmartResult()
-	slice, _ := message.(string)
+	slice, ok := message.(string)
+	if !ok {
+		return "", fmt.Errorf("Unexpected message received : %v", message)
+	}
 	return slice, nil
 }
 
@@ -109,65 +115,65 @@ func (node FakeRedisNode) readRespInt() (int, error) {
 		return 0, e
 	}
 	message := resp.SmartResult()
-	slice, err := message.(int64)
-	if err != true {
-		node.Logger.Debugf("Unable to convert %v", message)
+	slice, ok := message.(int64)
+	if !ok {
+		return 0, fmt.Errorf("Unexpected message received : %v", message)
 	}
 	integer := int(slice)
 	return integer, nil
 }
 
-func (node FakeRedisNode) readAndAssertMessagesWithSkip(messages []string, skipMessage string, caseSensitiveMatch bool) (error, int) {
+func (node FakeRedisNode) readAndAssertMessagesWithSkip(messages []string, skipMessage string, caseSensitiveMatch bool) (int, error) {
 	// Reads RESP message, skips assert if the first word matches with
 	// skipMessage (case insensitive), reads next RESP runs match on it.
 	actualMessages, err := node.readRespMessages()
 	offset := 0
 	if err != nil {
-		return err, offset
+		return offset, err
 	}
-	if strings.ToUpper(actualMessages[0]) == strings.ToUpper(skipMessage) {
+	if strings.EqualFold(actualMessages[0], skipMessage) {
 		node.Logger.Successf(node.LogPrefix + strings.Join(actualMessages, " ") + " received.")
 		offset += GetByteOffset(actualMessages)
 		actualMessages, err = node.readRespMessages() // Read next message
 		if err != nil {
-			return err, offset
+			return offset, err
 		}
 	}
 
 	offset += GetByteOffset(actualMessages)
 	err = node.assertMessages(actualMessages, messages, caseSensitiveMatch)
 	if err != nil {
-		return err, offset
+		return offset, err
 	}
-	return nil, offset
+	return offset, err
 }
 
-func (node FakeRedisNode) readAndAssertMessages(messages []string, caseSensitiveMatch bool) (error, int) {
+func (node FakeRedisNode) readAndAssertMessages(messages []string, caseSensitiveMatch bool) (int, error) {
 	actualMessages, err := node.readRespMessages()
 	offset := GetByteOffset(messages)
 	if err != nil {
-		return err, 0
+		return 0, err
 	}
-	// fmt.Println("ACTMSG :", actualMessages)
+	// node.Logger.Errorf("ACTMSG : %v", actualMessages)
 	err = node.assertMessages(actualMessages, messages, caseSensitiveMatch)
 	if err != nil {
-		return err, 0
+		return 0, err
 	}
-	return nil, offset
+	return offset, nil
 }
 
-func (node FakeRedisNode) readAndAssertMessagesWithOr(messages [][]string, caseSensitiveMatch bool) (error, int) {
+func (node FakeRedisNode) readAndAssertMessagesWithOr(messages [][]string, caseSensitiveMatch bool) (int, error) {
 	actualMessages, err := node.readRespMessages()
 	offset := GetByteOffset(actualMessages)
 	if err != nil {
-		return err, 0
+		return 0, err
 	}
 
 	err = node.assertMessagesWithOr(actualMessages, messages, caseSensitiveMatch)
 	if err != nil {
-		return err, 0
+		return 0, err
 	}
-	return nil, offset
+	return offset, nil
 }
 
 func (node FakeRedisNode) assertMessages(actualMessages []string, expectedMessages []string, caseSensitiveMatch bool) error {

--- a/internal/redis_util.go
+++ b/internal/redis_util.go
@@ -10,11 +10,11 @@ import (
 )
 
 func encodeInteger(v Value) ([]byte, error) {
-	int_value, err := strconv.Atoi(string(v.data))
+	intValue, err := strconv.Atoi(string(v.data))
 	if err != nil {
 		return nil, err
 	}
-	return []byte(fmt.Sprintf(":%d\r\n", int_value)), nil
+	return []byte(fmt.Sprintf(":%d\r\n", intValue)), nil
 }
 
 func encodeSimpleString(v Value) []byte {

--- a/internal/test_repl_master_cmd_prop.go
+++ b/internal/test_repl_master_cmd_prop.go
@@ -52,18 +52,18 @@ func testReplMasterCmdProp(stageHarness *testerutils.StageHarness) error {
 	}
 
 	// Redis will send SELECT, but not expected from Users.
-	err, _ = replica.readAndAssertMessagesWithSkip([]string{"SET", "foo", "123"}, "SELECT", true)
+	_, err = replica.readAndAssertMessagesWithSkip([]string{"SET", "foo", "123"}, "SELECT", true)
 
 	if err != nil {
 		return err
 	}
 
-	err, _ = replica.readAndAssertMessages([]string{"SET", "bar", "456"}, true)
+	_, err = replica.readAndAssertMessages([]string{"SET", "bar", "456"}, true)
 	if err != nil {
 		return err
 	}
 
-	err, _ = replica.readAndAssertMessages([]string{"SET", "baz", "789"}, true)
+	_, err = replica.readAndAssertMessages([]string{"SET", "baz", "789"}, true)
 	if err != nil {
 		return err
 	}

--- a/internal/test_repl_multiple_replicas.go
+++ b/internal/test_repl_multiple_replicas.go
@@ -67,7 +67,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 		logger.Infof("Testing Replica : %v", j+1)
 
 		// Redis will send SELECT, but not expected from Users.
-		err, _ = replica.readAndAssertMessagesWithSkip([]string{"SET", "foo", "123"}, "SELECT", true)
+		_, err = replica.readAndAssertMessagesWithSkip([]string{"SET", "foo", "123"}, "SELECT", true)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func testReplMultipleReplicas(stageHarness *testerutils.StageHarness) error {
 			// We need order of commands preserved
 			key, value := kvMap[i][0], kvMap[i][1]
 
-			err, _ = replica.readAndAssertMessages([]string{"SET", key, value}, true)
+			_, err = replica.readAndAssertMessages([]string{"SET", key, value}, true)
 			if err != nil {
 				return err
 			}

--- a/internal/test_repl_wait.go
+++ b/internal/test_repl_wait.go
@@ -133,12 +133,12 @@ func consumeReplicationStreamAndSendPartialAcks(replicas []*FakeRedisReplica, re
 		// Redis will send SELECT, but not expected from Users.
 		// We skip the SELECT command, IF received.
 		// Then check the next received command.
-		err, offsetDeltaFromSetCommand := replica.readAndAssertMessagesWithSkip(firstCommand, "SELECT", true)
+		offsetDeltaFromSetCommand, err := replica.readAndAssertMessagesWithSkip(firstCommand, "SELECT", true)
 		if err != nil {
 			return 0, err
 		}
 
-		err, offsetDeltaFromGetAckCommand := replica.readAndAssertMessages(secondCommand, false)
+		offsetDeltaFromGetAckCommand, err := replica.readAndAssertMessages(secondCommand, false)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/util.go
+++ b/internal/util.go
@@ -25,7 +25,7 @@ func convertToStringArray(interfaceSlice []interface{}) ([]string, error) {
 
 func compareStringSlices(actual, expected []string, caseSensitiveMatch bool) error {
 	if len(actual) != len(expected) {
-		return fmt.Errorf("Length mismatch between actual message and expected message.")
+		return fmt.Errorf("Length mismatch between expected and received messages.\nExpected %v bytes, Received %v bytes.\nExpected : %v.\nReceived : %v.\n", GetByteOffset(expected), GetByteOffset(actual), expected, actual)
 	}
 
 	for i := range actual {
@@ -64,7 +64,7 @@ func compareStringSlicesWithOr(actual []string, expected [][]string, caseSensiti
 		}
 	}
 
-	if foundMatch == true {
+	if foundMatch {
 		return nil
 	}
 	return e // Will return last error. Will accordingly call assert.


### PR DESCRIPTION
1. Fix staticcheck warnings.
2. Update length mismatch error.
3. Add better error handling for wrong type of resp message from client.


Fixes : 
https://github.com/codecrafters-io/build-your-own-redis/issues/131