### PR TITLE
fix the incorrect logic for checking the return value of WAIT command and add check for WAIT command timeout

### DIFF
--- a/internal/fake_redis_master.go
+++ b/internal/fake_redis_master.go
@@ -1,9 +1,11 @@
 package internal
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -66,8 +68,31 @@ func (master FakeRedisMaster) GetAck(offset int) error {
 	return master.SendAndAssertStringArray([]string{"REPLCONF", "GETACK", "*"}, []string{"REPLCONF", "ACK", strconv.Itoa(offset)})
 }
 
-func (master FakeRedisMaster) Wait(replicas string, timeout string, expectedMessage int) error {
-	return master.SendAndAssertInt([]string{"WAIT", replicas, timeout}, expectedMessage)
+func (master FakeRedisMaster) Wait(needReplicas int, timeout time.Duration, maxReplicas int) error {
+	if err := master.Send([]string{"WAIT", strconv.Itoa(needReplicas), strconv.Itoa(int(timeout.Milliseconds()))}); err != nil {
+		return err
+	}
+	begin := time.Now()
+	actualMessage, err := master.readRespInt()
+	if err != nil {
+		return err
+	}
+	// response need timeout
+	if needReplicas > maxReplicas {
+		useTime := time.Now().Sub(begin)
+		if useTime < timeout {
+			return fmt.Errorf("Expected: time out, response too fast")
+		}
+		if actualMessage != maxReplicas {
+			return fmt.Errorf("Expected: '%v' and actual: '%v' messages don't match", maxReplicas, actualMessage)
+		}
+	} else {
+		if actualMessage < needReplicas || actualMessage > needReplicas {
+			return fmt.Errorf("Expected: '[%v, %v]' and actual: '%v' messages don't match", needReplicas, needReplicas, actualMessage)
+		}
+	}
+	master.Logger.Successf(master.LogPrefix + strconv.Itoa(actualMessage) + " received.")
+	return nil
 }
 
 func (master FakeRedisMaster) Handshake() error {

--- a/internal/test_repl_wait_zero_offset.go
+++ b/internal/test_repl_wait_zero_offset.go
@@ -2,10 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"strconv"
-
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
+	"time"
 )
 
 func testWaitZeroOffset(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -54,8 +53,8 @@ func testWaitZeroOffset(stageHarness *test_case_harness.TestCaseHarness) error {
 	diff := ((replicaCount + 3) - 3) / 3
 	safeDiff := max(1, diff) // If diff is 0, it will get stuck in an infinite loop
 	for i := 3; i < replicaCount+3; i += safeDiff {
-		actual, expected := strconv.Itoa(i), replicaCount
-		err = client.Wait(actual, "500", expected)
+		actual, expected := i, replicaCount
+		err = client.Wait(actual, time.Millisecond*500, expected)
 		if err != nil {
 			return err
 		}

--- a/internal/test_repl_wait_zero_replicas.go
+++ b/internal/test_repl_wait_zero_replicas.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -28,7 +29,7 @@ func testWaitZeroReplicas(stageHarness *test_case_harness.TestCaseHarness) error
 	client := NewFakeRedisMaster(conn, logger)
 	client.LogPrefix = "[client] "
 
-	err = client.Wait("0", "60000", 0)
+	err = client.Wait(0, time.Millisecond*60000, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. fix the incorrect logic for checking the return value of WAIT command
2. add check for WAIT command timeout

The first problem comes from https://github.com/codecrafters-io/build-your-own-redis/issues/141
The second improve comes from https://github.com/codecrafters-io/build-your-own-redis/issues/136