### PR TITLE
CC-1059: 2. Refactor `bind_test_case`.

### DIFF
--- a/internal/test_bind.go
+++ b/internal/test_bind.go
@@ -7,8 +7,6 @@ import (
 )
 
 func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
-	port := 6379
-
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	if err := b.Run(); err != nil {
 		return err
@@ -16,10 +14,8 @@ func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	logger.Infof("Connecting to port %d...", port)
-
 	bindTestCase := test_cases.BindTestCase{
-		Port:    port,
+		Port:    6379,
 		Retries: 15,
 	}
 

--- a/internal/test_bind.go
+++ b/internal/test_bind.go
@@ -1,15 +1,14 @@
 package internal
 
 import (
-	"fmt"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
-	"net"
-	"time"
-
+	"github.com/codecrafters-io/redis-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
 func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
+	port := 6379
+
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	if err := b.Run(); err != nil {
 		return err
@@ -17,34 +16,12 @@ func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	logger.Infof("Connecting to port 6379...")
+	logger.Infof("Connecting to port %d...", port)
 
-	retries := 0
-	var err error
-	for {
-		_, err = net.Dial("tcp", "localhost:6379")
-		if err != nil && retries > 15 {
-			logger.Infof("All retries failed.")
-			return err
-		}
-
-		if err != nil {
-			if b.HasExited() {
-				return fmt.Errorf("Looks like your program has terminated. A redis server is expected to be a long-running process.")
-			}
-
-			// Don't print errors in the first second
-			if retries > 2 {
-				logger.Infof("Failed to connect to port 6379, retrying in 1s")
-			}
-
-			retries += 1
-			time.Sleep(1000 * time.Millisecond)
-		} else {
-			break
-		}
+	bindTestCase := test_cases.BindTestCase{
+		Port:    port,
+		Retries: 15,
 	}
 
-	logger.Debugln("Connection successful")
-	return nil
+	return bindTestCase.Run(b, logger)
 }

--- a/internal/test_cases/bind_test_case.go
+++ b/internal/test_cases/bind_test_case.go
@@ -1,0 +1,46 @@
+package test_cases
+
+import (
+	"fmt"
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+	"net"
+	"strconv"
+	"time"
+)
+
+type BindTestCase struct {
+	Port    int
+	Retries int
+}
+
+func (t BindTestCase) Run(executable *redis_executable.RedisExecutable, logger *logger.Logger) error {
+	retries := 0
+	var err error
+	address := "localhost:" + strconv.Itoa(t.Port)
+	for {
+		_, err = net.Dial("tcp", address)
+		if err != nil && retries > t.Retries {
+			logger.Infof("All retries failed.")
+			return err
+		}
+
+		if err != nil {
+			if executable.HasExited() {
+				return fmt.Errorf("Looks like your program has terminated. A redis server is expected to be a long-running process.")
+			}
+
+			// Don't print errors in the first second
+			if retries > 2 {
+				logger.Infof("Failed to connect to port %d, retrying in 1s", t.Port)
+			}
+
+			retries += 1
+			time.Sleep(1000 * time.Millisecond)
+		} else {
+			break
+		}
+	}
+	logger.Debugln("Connection successful")
+	return nil
+}

--- a/internal/test_cases/bind_test_case.go
+++ b/internal/test_cases/bind_test_case.go
@@ -2,11 +2,12 @@ package test_cases
 
 import (
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
-	"github.com/codecrafters-io/tester-utils/logger"
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
 )
 
 type BindTestCase struct {
@@ -15,6 +16,8 @@ type BindTestCase struct {
 }
 
 func (t BindTestCase) Run(executable *redis_executable.RedisExecutable, logger *logger.Logger) error {
+	logger.Infof("Connecting to port %d...", t.Port)
+
 	retries := 0
 	var err error
 	address := "localhost:" + strconv.Itoa(t.Port)

--- a/internal/test_repl_bind.go
+++ b/internal/test_repl_bind.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
+	"strconv"
+
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
-	"strconv"
 )
 
 func testReplBindToCustomPort(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -17,7 +18,6 @@ func testReplBindToCustomPort(stageHarness *test_case_harness.TestCaseHarness) e
 	}
 
 	logger := stageHarness.Logger
-	logger.Infof("Connecting to port %d...", port)
 
 	bindTestCase := test_cases.BindTestCase{
 		Port:    port,

--- a/internal/test_repl_bind.go
+++ b/internal/test_repl_bind.go
@@ -1,14 +1,11 @@
 package internal
 
 import (
-	"fmt"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
-	"net"
-	"strconv"
-	"time"
-
+	"github.com/codecrafters-io/redis-tester/internal/test_cases"
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
+	"strconv"
 )
 
 func testReplBindToCustomPort(stageHarness *test_case_harness.TestCaseHarness) error {
@@ -20,36 +17,12 @@ func testReplBindToCustomPort(stageHarness *test_case_harness.TestCaseHarness) e
 	}
 
 	logger := stageHarness.Logger
-
 	logger.Infof("Connecting to port %d...", port)
-	retries := 0
-	var err error
-	address := "localhost:" + strconv.Itoa(port)
 
-	for {
-		_, err = net.Dial("tcp", address)
-		if err != nil && retries > 15 {
-			logger.Infof("All retries failed.")
-			return err
-		}
-
-		if err != nil {
-			if b.HasExited() {
-				return fmt.Errorf("Looks like your program has terminated. A redis server is expected to be a long-running process.")
-			}
-
-			// Don't print errors in the first second
-			if retries > 2 {
-				logger.Infof("Failed to connect to port %d, retrying in 1s", port)
-			}
-
-			retries += 1
-			time.Sleep(1000 * time.Millisecond)
-		} else {
-			break
-		}
+	bindTestCase := test_cases.BindTestCase{
+		Port:    port,
+		Retries: 15,
 	}
 
-	logger.Debugln("Connection successful")
-	return nil
+	return bindTestCase.Run(b, logger)
 }


### PR DESCRIPTION
Refactor test cases to use a common BindTestCase struct and method for testing connection to ports.