### PR TITLE
Check for lexicographical comparison in XADD ids

### DIFF
--- a/internal/test_streams_xadd_validate_id.go
+++ b/internal/test_streams_xadd_validate_id.go
@@ -18,9 +18,11 @@ func testStreamsXaddValidateID(stageHarness *test_case_harness.TestCaseHarness) 
 	randomKey := testerutils_random.RandomWord()
 
 	tests := []XADDTest{
-		{streamKey: randomKey, id: "1-1", values: map[string]interface{}{"foo": "bar"}, expectedResponse: "1-1", expectedError: ""},
-		{streamKey: randomKey, id: "1-2", values: map[string]interface{}{"bar": "baz"}, expectedResponse: "1-2", expectedError: ""},
-		{streamKey: randomKey, id: "1-2", values: map[string]interface{}{"baz": "foo"}, expectedResponse: "", expectedError: "ERR The ID specified in XADD is equal or smaller than the target stream top item"},
+		{streamKey: randomKey, id: "100-1", values: map[string]interface{}{"foo": "bar"}, expectedResponse: "1-1", expectedError: ""},
+		{streamKey: randomKey, id: "100-2", values: map[string]interface{}{"bar": "baz"}, expectedResponse: "1-2", expectedError: ""},
+		{streamKey: randomKey, id: "100-2", values: map[string]interface{}{"baz": "foo"}, expectedResponse: "", expectedError: "ERR The ID specified in XADD is equal or smaller than the target stream top item"},
+		// This will catch an incorrect implementation using lexicographical comparison
+		{streamKey: randomKey, id: "11-2", values: map[string]interface{}{"baz": "foo"}, expectedResponse: "", expectedError: "ERR The ID specified in XADD is equal or smaller than the target stream top item"},
 		{streamKey: randomKey, id: "0-3", values: map[string]interface{}{"baz": "foo"}, expectedResponse: "", expectedError: "ERR The ID specified in XADD is equal or smaller than the target stream top item"},
 		{streamKey: randomKey, id: "0-0", values: map[string]interface{}{"baz": "foo"}, expectedResponse: "", expectedError: "ERR The ID specified in XADD must be greater than 0-0"},
 	}


### PR DESCRIPTION
The current checks pass even if the implementation uses lexicographical comparison on the string/bytes directly instead of doing a numerical comparison. This fixes that.