### PR TITLE
Refactor RESP to RESP2 error messages and tests

### DIFF
--- a/internal/resp/decoder/decode.go
+++ b/internal/resp/decoder/decode.go
@@ -24,7 +24,7 @@ func doDecodeValue(reader *bytes.Reader) (resp_value.Value, error) {
 	if err == io.EOF {
 		return resp_value.Value{}, IncompleteInputError{
 			Reader:  reader,
-			Message: "Expected start of a new RESP value (either +, -, :, $ or *)",
+			Message: "Expected start of a new RESP2 value (either +, -, :, $ or *)",
 		}
 	}
 
@@ -44,7 +44,7 @@ func doDecodeValue(reader *bytes.Reader) (resp_value.Value, error) {
 
 		return resp_value.Value{}, InvalidInputError{
 			Reader:  reader,
-			Message: fmt.Sprintf("%q is not a valid start of a RESP value (expected +, -, :, $ or *)", string(firstByte)),
+			Message: fmt.Sprintf("%q is not a valid start of a RESP2 value (expected +, -, :, $ or *)", string(firstByte)),
 		}
 	}
 }

--- a/internal/resp/decoder/decode_error_tests.yml
+++ b/internal/resp/decoder/decode_error_tests.yml
@@ -4,13 +4,13 @@
   error: |
     Received: "" (no content received)
                ^ error
-    Error: Expected start of a new RESP value (either +, -, :, $ or *)
+    Error: Expected start of a new RESP2 value (either +, -, :, $ or *)
 
 - input: "K"
   error: |
     Received: "K"
                ^ error
-    Error: "K" is not a valid start of a RESP value (expected +, -, :, $ or *)
+    Error: "K" is not a valid start of a RESP2 value (expected +, -, :, $ or *)
 
 # Simple Strings
 
@@ -101,7 +101,6 @@
     Received: ":foo\r\n"
                 ^ error
     Error: Invalid integer: "foo", expected a number
-
 
 # Arrays
 

--- a/internal/test_helpers/fixtures/ping-pong/eof
+++ b/internal/test_helpers/fixtures/ping-pong/eof
@@ -8,7 +8,7 @@ Debug = true
 [33m[stage-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-2] [0m[91mReceived: "" (no content received)[0m
 [33m[stage-2] [0m[91m           ^ error[0m
-[33m[stage-2] [0m[91mError: Expected start of a new RESP value (either +, -, :, $ or *)[0m
+[33m[stage-2] [0m[91mError: Expected start of a new RESP2 value (either +, -, :, $ or *)[0m
 [33m[stage-2] [0m[91mTest failed[0m
 [33m[stage-2] [0m[36mTerminating program[0m
 [33m[stage-2] [0m[36mProgram terminated successfully[0m


### PR DESCRIPTION
Clarifies the "expected RESP value" error message to explicitly mention RESP2. 

The Redis docs suggest that `_\r\n` is the default representation but in reality RESP2 (`$-1\r\n`) is still the default, RESP3 is only enabled after a special "upgrade" process using [HELLO](https://redis.io/docs/latest/commands/hello/).