### PR TITLE
CC-1292: Update log prefix dynamically when reusing connection

### DIFF
--- a/internal/instrumented_resp_connection/instrumented_resp_connection.go
+++ b/internal/instrumented_resp_connection/instrumented_resp_connection.go
@@ -11,11 +11,18 @@ import (
 
 func defaultCallbacks(stageHarness *test_case_harness.TestCaseHarness, logPrefix string) resp_connection.RespConnectionCallbacks {
 	return resp_connection.RespConnectionCallbacks{
-		BeforeSendCommand: func(command string, args ...string) {
-			if len(args) > 0 {
-				stageHarness.Logger.Infof("%s$ redis-cli %s %s", logPrefix, command, strings.Join(args, " "))
+		BeforeSendCommand: func(reusedConnection bool, command string, args ...string) {
+			var commandPrefix string
+			if reusedConnection {
+				commandPrefix = ">"
 			} else {
-				stageHarness.Logger.Infof("%s$ redis-cli %s", logPrefix, command)
+				commandPrefix = "$ redis-cli"
+			}
+
+			if len(args) > 0 {
+				stageHarness.Logger.Infof("%s%s %s %s", logPrefix, commandPrefix, command, strings.Join(args, " "))
+			} else {
+				stageHarness.Logger.Infof("%s%s %s", logPrefix, commandPrefix, command)
 			}
 		},
 		BeforeSendValue: func(value resp_value.Value) {

--- a/internal/resp/connection/connection.go
+++ b/internal/resp/connection/connection.go
@@ -14,7 +14,7 @@ import (
 type RespConnectionCallbacks struct {
 	// BeforeSendCommand is called when a command is sent to the server.
 	// This can be useful for info logs.
-	BeforeSendCommand func(command string, args ...string)
+	BeforeSendCommand func(reusedConnection bool, command string, args ...string)
 
 	// BeforeSendValue is called when a value is sent using SendValue.
 	// It is NOT called when using SendCommand
@@ -83,7 +83,10 @@ func (c *RespConnection) Close() error {
 
 func (c *RespConnection) SendCommand(command string, args ...string) error {
 	if c.Callbacks.BeforeSendCommand != nil {
-		c.Callbacks.BeforeSendCommand(command, args...)
+		if c.SentBytes > 0 {
+			c.Callbacks.BeforeSendCommand(true, command, args...)
+		}
+		c.Callbacks.BeforeSendCommand(false, command, args...)
 	}
 
 	encodedValue := resp_encoder.Encode(resp_value.NewStringArrayValue(append([]string{command}, args...)))

--- a/internal/resp/connection/connection.go
+++ b/internal/resp/connection/connection.go
@@ -85,8 +85,9 @@ func (c *RespConnection) SendCommand(command string, args ...string) error {
 	if c.Callbacks.BeforeSendCommand != nil {
 		if c.SentBytes > 0 {
 			c.Callbacks.BeforeSendCommand(true, command, args...)
+		} else {
+			c.Callbacks.BeforeSendCommand(false, command, args...)
 		}
-		c.Callbacks.BeforeSendCommand(false, command, args...)
 	}
 
 	encodedValue := resp_encoder.Encode(resp_value.NewStringArrayValue(append([]string{command}, args...)))

--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -7,16 +7,16 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 20:39:57.019[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 20:39:57.019 (should not be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET apple[0m
+[33m[stage-7] [0m[92mReceived OK at 20:00:25.321[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 20:00:25.321 (should not be expired)[0m
+[33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[stage-7] [0m[92mReceived "blueberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 20:39:57.122 (should be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET apple[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 20:00:25.425 (should be expired)[0m
+[33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
@@ -34,7 +34,7 @@ Debug = true
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
 [33m[stage-6] [0m[36mGetting key blueberry[0m
-[33m[stage-6] [0m[94m$ redis-cli GET blueberry[0m
+[33m[stage-6] [0m[94m> GET blueberry[0m
 [33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP bulk string: "raspberry"[0m
@@ -66,17 +66,17 @@ Debug = true
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-2: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-2: > PING[0m
 [33m[stage-4] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
@@ -100,12 +100,12 @@ Debug = true
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -1,18 +1,18 @@
 Debug = true
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles388319618 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles4019289137 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
 [33m[stage-13] [0m[92mReceived "strawberry"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET mango[0m
+[33m[stage-13] [0m[94mclient: > GET mango[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-13] [0m[92mReceived "$-1\r\n"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET pineapple[0m
+[33m[stage-13] [0m[94mclient: > GET pineapple[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
@@ -23,28 +23,28 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "grape"="pineapple", "apple"="raspberry", "banana"="apple", "mango"="orange", "orange"="pear"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2171782643 --dbfilename raspberry.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles117344466 --dbfilename raspberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
 [33m[stage-12] [0m[92mReceived "pineapple"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET apple[0m
+[33m[stage-12] [0m[94mclient: > GET apple[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
 [33m[stage-12] [0m[92mReceived "raspberry"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET banana[0m
+[33m[stage-12] [0m[94mclient: > GET banana[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "apple"[0m
 [33m[stage-12] [0m[92mReceived "apple"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET mango[0m
+[33m[stage-12] [0m[94mclient: > GET mango[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "orange"[0m
 [33m[stage-12] [0m[92mReceived "orange"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET orange[0m
+[33m[stage-12] [0m[94mclient: > GET orange[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "pear"[0m
@@ -55,19 +55,19 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
 [33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["banana" "apple" "blueberry"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1209284205 --dbfilename blueberry.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2161578068 --dbfilename blueberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "blueberry", "banana"][0m
-[33m[stage-11] [0m[92mReceived ["apple", "blueberry", "banana"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n$5\r\napple\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["blueberry", "banana", "apple"][0m
+[33m[stage-11] [0m[92mReceived ["blueberry", "banana", "apple"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: grape="pineapple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles384942019 --dbfilename orange.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2004705524 --dbfilename orange.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -79,7 +79,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "mango"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3198695930 --dbfilename pear.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1043361946 --dbfilename pear.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -90,12 +90,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles825729594 --dbfilename blueberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1967874176 --dbfilename blueberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles825729594\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles825729594"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles825729594"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1967874176\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1967874176"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1967874176"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -107,16 +107,16 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 20:40:46.013[0m
-[33m[stage-7] [0m[94mFetching key "strawberry" at 20:40:46.013 (should not be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET strawberry[0m
+[33m[stage-7] [0m[92mReceived OK at 20:00:45.594[0m
+[33m[stage-7] [0m[94mFetching key "strawberry" at 20:00:45.594 (should not be expired)[0m
+[33m[stage-7] [0m[94m> GET strawberry[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "pear"[0m
 [33m[stage-7] [0m[92mReceived "pear"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "strawberry" at 20:40:46.116 (should be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET strawberry[0m
+[33m[stage-7] [0m[94mFetching key "strawberry" at 20:00:45.697 (should be expired)[0m
+[33m[stage-7] [0m[94m> GET strawberry[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
@@ -134,7 +134,7 @@ Debug = true
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
 [33m[stage-6] [0m[36mGetting key grape[0m
-[33m[stage-6] [0m[94m$ redis-cli GET grape[0m
+[33m[stage-6] [0m[94m> GET grape[0m
 [33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP bulk string: "raspberry"[0m
@@ -166,17 +166,17 @@ Debug = true
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-2: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-2: > PING[0m
 [33m[stage-4] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
@@ -200,12 +200,12 @@ Debug = true
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -9,23 +9,23 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7\xf3Uf\xfa\bused-mem°\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7871e74a38047e110f80b29c12a4edb7dbe9e171\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffځ\"U\x9f\xa3\x99\xcb"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u0097_hf\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(24afbc3e4024091ea10a51a09e6ff387ca5ecb0b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf1\xd9Q\xda]ܹ\xbd"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -33,23 +33,23 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-31] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7\xf3Uf\xfa\bused-mem\xc2@\xf6\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7871e74a38047e110f80b29c12a4edb7dbe9e171\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffGu\xafա\xfd\x0e\x04"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u0097_hf\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(24afbc3e4024091ea10a51a09e6ff387ca5ecb0b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffX\xcc\xc6ݥqw\b"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -57,23 +57,23 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-31] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7\xf3Uf\xfa\bused-mem\xc2@A\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7871e74a38047e110f80b29c12a4edb7dbe9e171\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~\x9dV\xaf\x02\x8d\xc0\x9f"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u0097_hf\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(24afbc3e4024091ea10a51a09e6ff387ca5ecb0b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff`\xeb^\x95L\xbe\xe0&"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -81,30 +81,30 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-4: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-4: $ redis-cli REPLCONF listening-port 6383[0m
+[33m[stage-31] [0m[94mreplica-4: > REPLCONF listening-port 6383[0m
 [33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
 [33m[stage-31] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-4: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-4: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-4: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 7871e74a38047e110f80b29c12a4edb7dbe9e171 0"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 24afbc3e4024091ea10a51a09e6ff387ca5ecb0b 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7\xf3Uf\xfa\bused-mem\xc2P\x8c\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7871e74a38047e110f80b29c12a4edb7dbe9e171\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd2j\xe2֙\x10f\xc3"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u0097_hf\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(24afbc3e4024091ea10a51a09e6ff387ca5ecb0b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4\xde\xdf\xe2Z\xc4\xf5\x8e"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli WAIT 1 500[0m
+[33m[stage-31] [0m[94mclient: > WAIT 1 500[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET foo 123" to be propagated[0m
@@ -159,12 +159,12 @@ Debug = true
 [33m[stage-31] [0m[36mclient: Received bytes: ":1\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP integer: 1[0m
 [33m[stage-31] [0m[92mPassed first WAIT test.[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-31] [0m[94mclient: > SET baz 789[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli WAIT 4 2000[0m
+[33m[stage-31] [0m[94mclient: > WAIT 4 2000[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET baz 789" to be propagated[0m
@@ -176,7 +176,7 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-1: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[36mreplica-1: Sending ACK to Master[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF ACK 122[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF ACK 122[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 2[0m
 [33m[stage-31] [0m[94mreplica-2: Expecting "SET baz 789" to be propagated[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [0m[94mWAIT command returned after 2096 ms[0m
+[33m[stage-31] [0m[94mWAIT command returned after 2099 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -228,23 +228,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9\xf3Uf\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\xfb\xde\xe0ƝO["[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x872=x\x17\x9d\x1a<"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -252,23 +252,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-30] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9\xf3Uf\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb6\xeeI\xe7>0\x81\xee"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcc\xc1\x9a(q\xf9ne"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -276,23 +276,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-30] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9\xf3Uf\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\xc9ѯ\xd7\xff\x16\xc0"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf4\xe6\x02`\x986\xf9K"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -300,23 +300,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-4: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-4: $ redis-cli REPLCONF listening-port 6383[0m
+[33m[stage-30] [0m[94mreplica-4: > REPLCONF listening-port 6383[0m
 [33m[stage-30] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
 [33m[stage-30] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-4: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-4: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-4: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9\xf3Uf\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffJ\xfcP\xd8\xc1\x85\x03h"[0m
+[33m[stage-30] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem°\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff0Ӄ\x17\x8eL\xec\xe3"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 5[0m
 [33m[stage-30] [0m[94mreplica-5: $ redis-cli PING[0m
@@ -324,23 +324,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-5: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-5: $ redis-cli REPLCONF listening-port 6384[0m
+[33m[stage-30] [0m[94mreplica-5: > REPLCONF listening-port 6384[0m
 [33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
 [33m[stage-30] [0m[36mreplica-5: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-5: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-5: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-5: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-5: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-5: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xca\xf3Uf\xfa\bused-mem\xc2\xe0\xd6\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff?\xf6o\xc1\xaa\xc1qk"[0m
+[33m[stage-30] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\xc2\xc0\xd6\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffӲ\xf2\xad%5\x86E"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 6[0m
 [33m[stage-30] [0m[94mreplica-6: $ redis-cli PING[0m
@@ -348,23 +348,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-6: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-6: $ redis-cli REPLCONF listening-port 6385[0m
+[33m[stage-30] [0m[94mreplica-6: > REPLCONF listening-port 6385[0m
 [33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
 [33m[stage-30] [0m[36mreplica-6: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-6: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-6: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-6: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-6: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-6: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xca\xf3Uf\xfa\bused-mem\xc2\xe0!\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\x8c\xcf\x1a\n\x9f!k"[0m
+[33m[stage-30] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\xc2\xc0!\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\xc8Rv\x85k\xd6E"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 7[0m
 [33m[stage-30] [0m[94mreplica-7: $ redis-cli PING[0m
@@ -372,40 +372,40 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-7: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-7: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-7: $ redis-cli REPLCONF listening-port 6386[0m
+[33m[stage-30] [0m[94mreplica-7: > REPLCONF listening-port 6386[0m
 [33m[stage-30] [0m[36mreplica-7: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6386\r\n"[0m
 [33m[stage-30] [0m[36mreplica-7: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-7: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-7: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-7: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-7: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-7: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-7: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-7: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-7: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-7: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 0904835199f2f5087c1105fc18520540809dfdca 0"[0m
+[33m[stage-30] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 096e7549a50b12a4671ab1c7ea534b13de70b9ce 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xca\xf3Uf\xfa\bused-mem\xc2\xf0l\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0904835199f2f5087c1105fc18520540809dfdca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xec\xde\xd1u\xbf\x0e\\{"[0m
+[33m[stage-30] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009a_hf\xfa\bused-mem\xc2\xd0l\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(096e7549a50b12a4671ab1c7ea534b13de70b9ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\x9aL\x190\xfa\xabU"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":7\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 7[0m
 [33m[stage-30] [0m[92mReceived 7[0m
-[33m[stage-30] [0m[94mclient: $ redis-cli WAIT 5 500[0m
+[33m[stage-30] [0m[94mclient: > WAIT 5 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":7\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 7[0m
 [33m[stage-30] [0m[92mReceived 7[0m
-[33m[stage-30] [0m[94mclient: $ redis-cli WAIT 7 500[0m
+[33m[stage-30] [0m[94mclient: > WAIT 7 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":7\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 7[0m
 [33m[stage-30] [0m[92mReceived 7[0m
-[33m[stage-30] [0m[94mclient: $ redis-cli WAIT 9 500[0m
+[33m[stage-30] [0m[94mclient: > WAIT 9 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n9\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":7\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 7[0m
@@ -460,18 +460,18 @@ Debug = true
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli PING[0m
+[33m[stage-28] [0m[94mmaster: > PING[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli SET mango pear[0m
+[33m[stage-28] [0m[94mmaster: > SET mango pear[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli SET banana blueberry[0m
+[33m[stage-28] [0m[94mmaster: > SET banana blueberry[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n162\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "162"][0m
@@ -510,7 +510,7 @@ Debug = true
 [33m[stage-27] [0m[36mSending RDB file...[0m
 [33m[stage-27] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[stage-27] [0m[92mSent RDB file.[0m
-[33m[stage-27] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-27] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-27] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-27] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
 [33m[stage-27] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
@@ -549,11 +549,11 @@ Debug = true
 [33m[stage-26] [0m[36mSending RDB file...[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[stage-26] [0m[92mSent RDB file.[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET foo 123[0m
+[33m[stage-26] [0m[94mmaster: > SET foo 123[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET bar 456[0m
+[33m[stage-26] [0m[94mmaster: > SET bar 456[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET baz 789[0m
+[33m[stage-26] [0m[94mmaster: > SET baz 789[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-26] [0m[94mGetting key foo[0m
 [33m[stage-26] [0m[94mclient: $ redis-cli GET foo[0m
@@ -562,13 +562,13 @@ Debug = true
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "123"[0m
 [33m[stage-26] [0m[92mReceived "123"[0m
 [33m[stage-26] [0m[94mGetting key bar[0m
-[33m[stage-26] [0m[94mclient: $ redis-cli GET bar[0m
+[33m[stage-26] [0m[94mclient: > GET bar[0m
 [33m[stage-26] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "456"[0m
 [33m[stage-26] [0m[92mReceived "456"[0m
 [33m[stage-26] [0m[94mGetting key baz[0m
-[33m[stage-26] [0m[94mclient: $ redis-cli GET baz[0m
+[33m[stage-26] [0m[94mclient: > GET baz[0m
 [33m[stage-26] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "789"[0m
@@ -585,23 +585,23 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcb\xf3Uf\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(809ae9d19f1c3c991cfd79dd38bed4785a434b92\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\rYa.b#\x01\xd5"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009c_hf\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2f92309a7112859ba1669233fa1a8bac18ca85f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\xc8\xc4\x1fػ%\x90"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -609,23 +609,23 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-25] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcb\xf3Uf\xfa\bused-mem°:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(809ae9d19f1c3c991cfd79dd38bed4785a434b92\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff_ʯ\x89\xed`\v,"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009c_hf\xfa\bused-mem\xc2\xd0:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2f92309a7112859ba1669233fa1a8bac18ca85f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1d\xbd:\xef\xc91\x95\x85"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -633,35 +633,35 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-25] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 809ae9d19f1c3c991cfd79dd38bed4785a434b92 0"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 2f92309a7112859ba1669233fa1a8bac18ca85f5 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcb\xf3Uf\xfa\bused-mem\xc2\xc0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(809ae9d19f1c3c991cfd79dd38bed4785a434b92\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98>\xcc\x16\xda\xc5\xe6\xa4"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009c_hf\xfa\bused-mem\xc2\xe0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2f92309a7112859ba1669233fa1a8bac18ca85f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\xafi'`]\xc2\xe1"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mclient: $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94mclient: > SET bar 456[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94mclient: > SET baz 789[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -722,35 +722,35 @@ Debug = true
 [33m[stage-24] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "PONG"[0m
 [33m[stage-24] [0m[92mReceived "PONG"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-24] [0m[94mreplica: > REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-24] [0m[94mreplica: > REPLCONF capa psync2[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli PSYNC ? -1[0m
+[33m[stage-24] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 320b6e51b254082840f64889822b807faf838310 0\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 320b6e51b254082840f64889822b807faf838310 0"[0m
-[33m[stage-24] [0m[92mReceived "FULLRESYNC 320b6e51b254082840f64889822b807faf838310 0"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 799dcd353de511c5ff8dee60ebb87ab1927c7ae2 0\r\n"[0m
+[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 799dcd353de511c5ff8dee60ebb87ab1927c7ae2 0"[0m
+[33m[stage-24] [0m[92mReceived "FULLRESYNC 799dcd353de511c5ff8dee60ebb87ab1927c7ae2 0"[0m
 [33m[stage-24] [0m[36mReading RDB file...[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcb\xf3Uf\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(320b6e51b254082840f64889822b807faf838310\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcd%,\x98\xedj\xee\xfa"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009c_hf\xfa\bused-mem\xc2\x00S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(799dcd353de511c5ff8dee60ebb87ab1927c7ae2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\x90\xb0\xf7\x96s\xda8"[0m
 [33m[stage-24] [0m[92mReceived RDB file[0m
 [33m[stage-24] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mclient: $ redis-cli SET bar 456[0m
+[33m[stage-24] [0m[94mclient: > SET bar 456[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-24] [0m[94mclient: > SET baz 789[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -781,23 +781,23 @@ Debug = true
 [33m[stage-23] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-23] [0m[92mReceived "PONG"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-23] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-23] [0m[92mReceived "OK"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-23] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-23] [0m[92mReceived "OK"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli PSYNC ? -1[0m
+[33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 9a5ee51d90fcc10a8018c4cb14bd24d8480324e7 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 9a5ee51d90fcc10a8018c4cb14bd24d8480324e7 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 9a5ee51d90fcc10a8018c4cb14bd24d8480324e7 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 8eaf0a44ddbecd7cd2f9cfa901594ff38cc4ee14 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8eaf0a44ddbecd7cd2f9cfa901594ff38cc4ee14 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 8eaf0a44ddbecd7cd2f9cfa901594ff38cc4ee14 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcc\xf3Uf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a5ee51d90fcc10a8018c4cb14bd24d8480324e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\x91\a\xe5C\x93\xc9\xef"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\u009c_hf\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8eaf0a44ddbecd7cd2f9cfa901594ff38cc4ee14\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff/N\x98\x02D7-\r"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -810,21 +810,21 @@ Debug = true
 [33m[stage-22] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-22] [0m[92mReceived "PONG"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-22] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-22] [0m[92mReceived "OK"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-22] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-22] [0m[92mReceived "OK"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli PSYNC ? -1[0m
+[33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 999e6df9ae371537e674509268ddd04d65bee8eb 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 999e6df9ae371537e674509268ddd04d65bee8eb 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 999e6df9ae371537e674509268ddd04d65bee8eb 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 4e114ba0822403a423a5e35083aec08695970168 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 4e114ba0822403a423a5e35083aec08695970168 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 4e114ba0822403a423a5e35083aec08695970168 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -836,12 +836,12 @@ Debug = true
 [33m[stage-21] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-21] [0m[92mReceived "PONG"[0m
-[33m[stage-21] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-21] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-21] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-21] [0m[92mReceived "OK"[0m
-[33m[stage-21] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-21] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-21] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -923,9 +923,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c63381b0d9fdaaa1d25fe7814c73c98bb0d8b3da\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c63381b0d9fdaaa1d25fe7814c73c98bb0d8b3da\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c63381b0d9fdaaa1d25fe7814c73c98bb0d8b3da\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:aaa89de65822a25169983d8635757fe19d04de33\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:aaa89de65822a25169983d8635757fe19d04de33\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:aaa89de65822a25169983d8635757fe19d04de33\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -966,9 +966,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0e1a80761d552fa816bb724eaa26653402090ec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0e1a80761d552fa816bb724eaa26653402090ec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0e1a80761d552fa816bb724eaa26653402090ec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0fb7560c332a13adb558ebeeb7d38d499b3778ce\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0fb7560c332a13adb558ebeeb7d38d499b3778ce\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0fb7560c332a13adb558ebeeb7d38d499b3778ce\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -983,18 +983,18 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2221555389 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2993667888 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
 [33m[stage-13] [0m[92mReceived "blueberry"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[stage-13] [0m[94mclient: > GET raspberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-13] [0m[92mReceived "$-1\r\n"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET pineapple[0m
+[33m[stage-13] [0m[94mclient: > GET pineapple[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "banana"[0m
@@ -1005,28 +1005,28 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "grape"="mango", "orange"="banana", "blueberry"="orange", "pear"="grape", "banana"="blueberry"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2751880624 --dbfilename mango.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2309058679 --dbfilename mango.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "mango"[0m
 [33m[stage-12] [0m[92mReceived "mango"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET orange[0m
+[33m[stage-12] [0m[94mclient: > GET orange[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "banana"[0m
 [33m[stage-12] [0m[92mReceived "banana"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET blueberry[0m
+[33m[stage-12] [0m[94mclient: > GET blueberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "orange"[0m
 [33m[stage-12] [0m[92mReceived "orange"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[stage-12] [0m[94mclient: > GET pear[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "grape"[0m
 [33m[stage-12] [0m[92mReceived "grape"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET banana[0m
+[33m[stage-12] [0m[94mclient: > GET banana[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
@@ -1037,19 +1037,19 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
 [33m[stage-11] [0m[94mCreated RDB file with 4 keys: ["raspberry" "blueberry" "apple" "orange"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3939720432 --dbfilename grape.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3774454719 --dbfilename grape.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$5\r\napple\r\n$9\r\nraspberry\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["blueberry", "orange", "apple", "raspberry"][0m
-[33m[stage-11] [0m[92mReceived ["blueberry", "orange", "apple", "raspberry"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["orange", "apple", "blueberry", "raspberry"][0m
+[33m[stage-11] [0m[92mReceived ["orange", "apple", "blueberry", "raspberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: blueberry="raspberry"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2274521031 --dbfilename strawberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles868424671 --dbfilename strawberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1061,7 +1061,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "grape"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles144008085 --dbfilename orange.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2622991322 --dbfilename orange.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1072,12 +1072,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3408870249 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3011654603 --dbfilename raspberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3408870249\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3408870249"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3408870249"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3011654603\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3011654603"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3011654603"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1089,16 +1089,16 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 20:40:07.488[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 20:40:07.488 (should not be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET mango[0m
+[33m[stage-7] [0m[92mReceived OK at 20:00:55.966[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 20:00:55.966 (should not be expired)[0m
+[33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[stage-7] [0m[92mReceived "orange"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 20:40:07.592 (should be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET mango[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 20:00:56.069 (should be expired)[0m
+[33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
@@ -1116,7 +1116,7 @@ Debug = true
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
 [33m[stage-6] [0m[36mGetting key banana[0m
-[33m[stage-6] [0m[94m$ redis-cli GET banana[0m
+[33m[stage-6] [0m[94m> GET banana[0m
 [33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP bulk string: "raspberry"[0m
@@ -1148,17 +1148,17 @@ Debug = true
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-2: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-2: > PING[0m
 [33m[stage-4] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
@@ -1182,12 +1182,12 @@ Debug = true
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -215,7 +215,7 @@ Debug = true
 [33m[stage-36] [0m[94mRunning tests for Stage #36: xu6[0m
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94m$ redis-cli xadd "mango" * foo bar[0m
-[33m[stage-36] [0m[94mReceived response: ""1716909014249-0""[0m
+[33m[stage-36] [0m[94mReceived response: ""1718116262630-0""[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -281,23 +281,23 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd6\xf3Uf\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ac82415aedc0d400f7eb25ea71ed63481464c6e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbfo\xa7N\xa6#\te"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime§_hf\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621d10f0c496c5a070d10141d7088a1cf31b9f78\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e̟\xd8\xe3\x80Z\xa3"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -305,23 +305,23 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-31] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd6\xf3Uf\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ac82415aedc0d400f7eb25ea71ed63481464c6e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf4\x9c\x00\x1e\xc0G}<"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime§_hf\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621d10f0c496c5a070d10141d7088a1cf31b9f78\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xd9\b\xdf\x1b-\x94\x16"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -329,30 +329,30 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-31] [0m[92mReceived "PONG"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-31] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-31] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-31] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 9ac82415aedc0d400f7eb25ea71ed63481464c6e 0"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 621d10f0c496c5a070d10141d7088a1cf31b9f78 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7\xf3Uf\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ac82415aedc0d400f7eb25ea71ed63481464c6e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9N\xc02\xd29\xbc\xcc"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime§_hf\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621d10f0c496c5a070d10141d7088a1cf31b9f78\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\xfe\x90\x97\xf2\xe2\x038"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli WAIT 1 500[0m
+[33m[stage-31] [0m[94mclient: > WAIT 1 500[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET foo 123" to be propagated[0m
@@ -395,12 +395,12 @@ Debug = true
 [33m[stage-31] [0m[36mclient: Received bytes: ":1\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP integer: 1[0m
 [33m[stage-31] [0m[92mPassed first WAIT test.[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-31] [0m[94mclient: > SET baz 789[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: $ redis-cli WAIT 3 2000[0m
+[33m[stage-31] [0m[94mclient: > WAIT 3 2000[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$4\r\n2000\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET baz 789" to be propagated[0m
@@ -412,7 +412,7 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-1: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[36mreplica-1: Sending ACK to Master[0m
-[33m[stage-31] [0m[94mreplica-1: $ redis-cli REPLCONF ACK 122[0m
+[33m[stage-31] [0m[94mreplica-1: > REPLCONF ACK 122[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 2[0m
 [33m[stage-31] [0m[94mreplica-2: Expecting "SET baz 789" to be propagated[0m
@@ -438,7 +438,7 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Not sending ACK to Master[0m
 [33m[stage-31] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP integer: 2[0m
-[33m[stage-31] [0m[94mWAIT command returned after 2006 ms[0m
+[33m[stage-31] [0m[94mWAIT command returned after 2094 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -452,23 +452,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-30] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd9\xf3Uf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fc0808fcc900059f929d9b8ffca9071f535f2234\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\x00m\xd7>\xf3+\xa5"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime©_hf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(21b4727bf25bc40a9c76ad49d09596b6b035452d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9\xdd\xca\xd5Dp\xec*"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -476,23 +476,23 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-30] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd9\xf3Uf\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fc0808fcc900059f929d9b8ffca9071f535f2234\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\xf3ʇX\x97_\xfc"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime©_hf\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(21b4727bf25bc40a9c76ad49d09596b6b035452d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2.m\x85\"\x14\x98s"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -500,35 +500,35 @@ Debug = true
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-30] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-30] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-30] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC fc0808fcc900059f929d9b8ffca9071f535f2234 0"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 21b4727bf25bc40a9c76ad49d09596b6b035452d 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd9\xf3Uf\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fc0808fcc900059f929d9b8ffca9071f535f2234\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1e\xd4RϱX\xc8\xd2"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime©_hf\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(21b4727bf25bc40a9c76ad49d09596b6b035452d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xda\t\xf5\xcd\xcb\xdb\x0f]"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 3[0m
 [33m[stage-30] [0m[92mReceived 3[0m
-[33m[stage-30] [0m[94mclient: $ redis-cli WAIT 4 500[0m
+[33m[stage-30] [0m[94mclient: > WAIT 4 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 3[0m
 [33m[stage-30] [0m[92mReceived 3[0m
-[33m[stage-30] [0m[94mclient: $ redis-cli WAIT 5 500[0m
+[33m[stage-30] [0m[94mclient: > WAIT 5 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-30] [0m[36mclient: Received RESP integer: 3[0m
@@ -583,18 +583,18 @@ Debug = true
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli PING[0m
+[33m[stage-28] [0m[94mmaster: > PING[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli SET banana pear[0m
+[33m[stage-28] [0m[94mmaster: > SET banana pear[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli SET apple blueberry[0m
+[33m[stage-28] [0m[94mmaster: > SET apple blueberry[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-28] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n162\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "162"][0m
@@ -633,7 +633,7 @@ Debug = true
 [33m[stage-27] [0m[36mSending RDB file...[0m
 [33m[stage-27] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[stage-27] [0m[92mSent RDB file.[0m
-[33m[stage-27] [0m[94mmaster: $ redis-cli REPLCONF GETACK *[0m
+[33m[stage-27] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-27] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-27] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
 [33m[stage-27] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
@@ -672,11 +672,11 @@ Debug = true
 [33m[stage-26] [0m[36mSending RDB file...[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[stage-26] [0m[92mSent RDB file.[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET foo 123[0m
+[33m[stage-26] [0m[94mmaster: > SET foo 123[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET bar 456[0m
+[33m[stage-26] [0m[94mmaster: > SET bar 456[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[stage-26] [0m[94mmaster: $ redis-cli SET baz 789[0m
+[33m[stage-26] [0m[94mmaster: > SET baz 789[0m
 [33m[stage-26] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-26] [0m[94mGetting key foo[0m
 [33m[stage-26] [0m[94mclient: $ redis-cli GET foo[0m
@@ -685,13 +685,13 @@ Debug = true
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "123"[0m
 [33m[stage-26] [0m[92mReceived "123"[0m
 [33m[stage-26] [0m[94mGetting key bar[0m
-[33m[stage-26] [0m[94mclient: $ redis-cli GET bar[0m
+[33m[stage-26] [0m[94mclient: > GET bar[0m
 [33m[stage-26] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "456"[0m
 [33m[stage-26] [0m[92mReceived "456"[0m
 [33m[stage-26] [0m[94mGetting key baz[0m
-[33m[stage-26] [0m[94mclient: $ redis-cli GET baz[0m
+[33m[stage-26] [0m[94mclient: > GET baz[0m
 [33m[stage-26] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
 [33m[stage-26] [0m[36mclient: Received RESP bulk string: "789"[0m
@@ -708,23 +708,23 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-25] [0m[94mreplica-1: > REPLCONF listening-port 6380[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-1: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-1: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xdb\xf3Uf\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b9e31faa537bac495a38cdde3228a98ae10a1fd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbd\xaap\x8ą(K"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime¬_hf\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(99c8652bed12063d6b0c3528c21ced60fe57d6c3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb8\xda\xe6\x91q\x8fk7"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -732,23 +732,23 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli REPLCONF listening-port 6381[0m
+[33m[stage-25] [0m[94mreplica-2: > REPLCONF listening-port 6381[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-2: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-2: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xdb\xf3Uf\xfa\bused-mem\u0090:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b9e31faa537bac495a38cdde3228a98ae10a1fd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\rߎz\xdd\"\x98^"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime¬_hf\xfa\bused-mem\u0090:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(99c8652bed12063d6b0c3528c21ced60fe57d6c3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b\xaf\x18a`\x05\xdb\""[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -756,35 +756,35 @@ Debug = true
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+PONG\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "PONG"[0m
 [33m[stage-25] [0m[92mReceived "PONG"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli REPLCONF listening-port 6382[0m
+[33m[stage-25] [0m[94mreplica-3: > REPLCONF listening-port 6382[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-25] [0m[94mreplica-3: > REPLCONF capa psync2[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mreplica-3: $ redis-cli PSYNC ? -1[0m
+[33m[stage-25] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 8b9e31faa537bac495a38cdde3228a98ae10a1fd 0"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC 99c8652bed12063d6b0c3528c21ced60fe57d6c3 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xdb\xf3Uf\xfa\bused-mem\u00a0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b9e31faa537bac495a38cdde3228a98ae10a1fd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(\xcdݲtN\xcf:"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime¬_hf\xfa\bused-mem\u00a0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(99c8652bed12063d6b0c3528c21ced60fe57d6c3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff-\xbdK\xa9\xc9i\x8cF"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mclient: $ redis-cli SET bar 456[0m
+[33m[stage-25] [0m[94mclient: > SET bar 456[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-25] [0m[92mReceived "OK"[0m
-[33m[stage-25] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-25] [0m[94mclient: > SET baz 789[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-25] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -845,35 +845,35 @@ Debug = true
 [33m[stage-24] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "PONG"[0m
 [33m[stage-24] [0m[92mReceived "PONG"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-24] [0m[94mreplica: > REPLCONF listening-port 6380[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-24] [0m[94mreplica: > REPLCONF capa psync2[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mreplica: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mreplica: $ redis-cli PSYNC ? -1[0m
+[33m[stage-24] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC ad84de9c43d177184d3a49cf83ec2b45fde53d25 0\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC ad84de9c43d177184d3a49cf83ec2b45fde53d25 0"[0m
-[33m[stage-24] [0m[92mReceived "FULLRESYNC ad84de9c43d177184d3a49cf83ec2b45fde53d25 0"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 446bb4a75f064ae3e2b98b55674872078bf38b0a 0\r\n"[0m
+[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 446bb4a75f064ae3e2b98b55674872078bf38b0a 0"[0m
+[33m[stage-24] [0m[92mReceived "FULLRESYNC 446bb4a75f064ae3e2b98b55674872078bf38b0a 0"[0m
 [33m[stage-24] [0m[36mReading RDB file...[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xdb\xf3Uf\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad84de9c43d177184d3a49cf83ec2b45fde53d25\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\xd9KS\xc8\xf4\xa0\xf3"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime¬_hf\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(446bb4a75f064ae3e2b98b55674872078bf38b0a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfffc\xa3\x87[[&\x85"[0m
 [33m[stage-24] [0m[92mReceived RDB file[0m
 [33m[stage-24] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mclient: $ redis-cli SET bar 456[0m
+[33m[stage-24] [0m[94mclient: > SET bar 456[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-24] [0m[92mReceived "OK"[0m
-[33m[stage-24] [0m[94mclient: $ redis-cli SET baz 789[0m
+[33m[stage-24] [0m[94mclient: > SET baz 789[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-24] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -904,23 +904,23 @@ Debug = true
 [33m[stage-23] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-23] [0m[92mReceived "PONG"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-23] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-23] [0m[92mReceived "OK"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-23] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-23] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-23] [0m[92mReceived "OK"[0m
-[33m[stage-23] [0m[94mclient: $ redis-cli PSYNC ? -1[0m
+[33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC f11285daf3a0793a5e9c179a07cb242a1b1d76b1 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC f11285daf3a0793a5e9c179a07cb242a1b1d76b1 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC f11285daf3a0793a5e9c179a07cb242a1b1d76b1 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 528286689160f7bee2c769ca06019c0f899abb1d 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 528286689160f7bee2c769ca06019c0f899abb1d 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 528286689160f7bee2c769ca06019c0f899abb1d 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xdc\xf3Uf\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f11285daf3a0793a5e9c179a07cb242a1b1d76b1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\v\x136\xd1ׁZ"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime¬_hf\xfa\bused-mem°\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(528286689160f7bee2c769ca06019c0f899abb1d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\xd5\\\xc9\xfbS\xde\x1b"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -933,21 +933,21 @@ Debug = true
 [33m[stage-22] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-22] [0m[92mReceived "PONG"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-22] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-22] [0m[92mReceived "OK"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-22] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-22] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-22] [0m[92mReceived "OK"[0m
-[33m[stage-22] [0m[94mclient: $ redis-cli PSYNC ? -1[0m
+[33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 0995c275900ea211a094cbb04f137bbc6ab7c0d9 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0995c275900ea211a094cbb04f137bbc6ab7c0d9 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 0995c275900ea211a094cbb04f137bbc6ab7c0d9 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC e3b1141657b2cc2ffa6f38dbee4e118e8479f1f4 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC e3b1141657b2cc2ffa6f38dbee4e118e8479f1f4 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC e3b1141657b2cc2ffa6f38dbee4e118e8479f1f4 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -959,12 +959,12 @@ Debug = true
 [33m[stage-21] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "PONG"[0m
 [33m[stage-21] [0m[92mReceived "PONG"[0m
-[33m[stage-21] [0m[94mclient: $ redis-cli REPLCONF listening-port 6380[0m
+[33m[stage-21] [0m[94mclient: > REPLCONF listening-port 6380[0m
 [33m[stage-21] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-21] [0m[92mReceived "OK"[0m
-[33m[stage-21] [0m[94mclient: $ redis-cli REPLCONF capa psync2[0m
+[33m[stage-21] [0m[94mclient: > REPLCONF capa psync2[0m
 [33m[stage-21] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-21] [0m[36mclient: Received RESP simple string: "OK"[0m
@@ -1046,9 +1046,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6751a2b8018a7fa116ab0ecbca3da8bd0305a1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6751a2b8018a7fa116ab0ecbca3da8bd0305a1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6751a2b8018a7fa116ab0ecbca3da8bd0305a1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:987bbfeeca4616af6d1291243f53e1a837a757d4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:987bbfeeca4616af6d1291243f53e1a837a757d4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:987bbfeeca4616af6d1291243f53e1a837a757d4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1077,9 +1077,9 @@ Debug = true
 [33m[stage-16] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[stage-16] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-16] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-16] [0m[36mclient: Received bytes: "$613\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-16] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-16] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-16] [0m[36mclient: Received bytes: "$613\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-16] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-16] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-16] [0m[92mFound role:slave in response.[0m
 [33m[stage-16] [0m[92mTest passed.[0m
 [33m[stage-16] [0m[36mTerminating program[0m
@@ -1089,9 +1089,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2046a183cb1b36a77ddaffda3d66244fe19e2039\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2046a183cb1b36a77ddaffda3d66244fe19e2039\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2046a183cb1b36a77ddaffda3d66244fe19e2039\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:898d6da3a136f5920e5ce78a71478a7b795ab380\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:898d6da3a136f5920e5ce78a71478a7b795ab380\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:898d6da3a136f5920e5ce78a71478a7b795ab380\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1106,23 +1106,23 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1795751134 --dbfilename banana.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1104761699 --dbfilename banana.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "pear"[0m
 [33m[stage-13] [0m[92mReceived "pear"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
+[33m[stage-13] [0m[94mclient: > GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-13] [0m[92mReceived "$-1\r\n"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[stage-13] [0m[94mclient: > GET pear[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
 [33m[stage-13] [0m[92mReceived "strawberry"[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET strawberry[0m
+[33m[stage-13] [0m[94mclient: > GET strawberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP bulk string: "mango"[0m
@@ -1133,18 +1133,18 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "pineapple"="pear", "raspberry"="strawberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3606907662 --dbfilename strawberry.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1757425797 --dbfilename strawberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "pear"[0m
 [33m[stage-12] [0m[92mReceived "pear"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[stage-12] [0m[94mclient: > GET raspberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
 [33m[stage-12] [0m[92mReceived "strawberry"[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[stage-12] [0m[94mclient: > GET pear[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
@@ -1155,19 +1155,19 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
 [33m[stage-11] [0m[94mCreated RDB file with 4 keys: ["mango" "pineapple" "blueberry" "apple"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1238660410 --dbfilename strawberry.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2865505801 --dbfilename strawberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\npineapple\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "pineapple", "blueberry", "mango"][0m
-[33m[stage-11] [0m[92mReceived ["apple", "pineapple", "blueberry", "mango"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "pineapple", "mango", "blueberry"][0m
+[33m[stage-11] [0m[92mReceived ["apple", "pineapple", "mango", "blueberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: grape="raspberry"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles4210223303 --dbfilename blueberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3625740230 --dbfilename blueberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1179,7 +1179,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "orange"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3634336741 --dbfilename mango.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles269673552 --dbfilename mango.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\norange\r\n"[0m
@@ -1190,12 +1190,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3849048168 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3106879690 --dbfilename raspberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3849048168\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3849048168"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3849048168"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3106879690\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3106879690"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3106879690"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1207,16 +1207,16 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 20:40:23.066[0m
-[33m[stage-7] [0m[94mFetching key "banana" at 20:40:23.066 (should not be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET banana[0m
+[33m[stage-7] [0m[92mReceived OK at 20:01:11.910[0m
+[33m[stage-7] [0m[94mFetching key "banana" at 20:01:11.910 (should not be expired)[0m
+[33m[stage-7] [0m[94m> GET banana[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[stage-7] [0m[92mReceived "orange"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "banana" at 20:40:23.170 (should be expired)[0m
-[33m[stage-7] [0m[94m$ redis-cli GET banana[0m
+[33m[stage-7] [0m[94mFetching key "banana" at 20:01:12.014 (should be expired)[0m
+[33m[stage-7] [0m[94m> GET banana[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
@@ -1234,7 +1234,7 @@ Debug = true
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
 [33m[stage-6] [0m[36mGetting key mango[0m
-[33m[stage-6] [0m[94m$ redis-cli GET mango[0m
+[33m[stage-6] [0m[94m> GET mango[0m
 [33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP bulk string: "apple"[0m
@@ -1266,17 +1266,17 @@ Debug = true
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-1: > PING[0m
 [33m[stage-4] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-4] [0m[92mReceived "PONG"[0m
-[33m[stage-4] [0m[94mclient-2: $ redis-cli PING[0m
+[33m[stage-4] [0m[94mclient-2: > PING[0m
 [33m[stage-4] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
 [33m[stage-4] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
@@ -1300,12 +1300,12 @@ Debug = true
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
 [33m[stage-3] [0m[92mReceived "PONG"[0m
-[33m[stage-3] [0m[94mclient-1: $ redis-cli PING[0m
+[33m[stage-3] [0m[94mclient-1: > PING[0m
 [33m[stage-3] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
 [33m[stage-3] [0m[36mclient-1: Received RESP simple string: "PONG"[0m


### PR DESCRIPTION
This pull request updates the `BeforeSendCommand` callback in the `RespConnectionCallbacks` struct to include a new parameter `reusedConnection` which indicates whether the connection is being reused or not. The `BeforeSendCommand` callback is used to log the commands being sent to the server. With this change, the command prefix is dynamically set based on whether the connection is being reused or not. If the connection is reused, the command prefix is set to `">"`, otherwise it is set to "`$ redis-cli`". This provides more context in the logs when commands are being sent.