### PR TITLE
CC-1223: Refactor streams extension tests to use RESP framework

### DIFF
--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -214,8 +214,11 @@ Debug = true
 
 [33m[stage-36] [0m[94mRunning tests for Stage #36: xu6[0m
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-36] [0m[94m$ redis-cli xadd "mango" * foo bar[0m
-[33m[stage-36] [0m[94mReceived response: ""1718351938723-0""[0m
+[33m[stage-36] [0m[94mclient: $ redis-cli XADD mango * foo bar[0m
+[33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1718620976077-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1718620976077-0"[0m
+[33m[stage-36] [0m[92mReceived "1718620976077-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -224,57 +227,96 @@ Debug = true
 
 [33m[stage-35] [0m[94mRunning tests for Stage #35: yh3[0m
 [33m[stage-35] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "apple" "0-*" "foo bar"[0m
-[33m[stage-35] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "apple" "1-*" "foo bar"[0m
-[33m[stage-35] [0m[92mReceived response: ""1-0""[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "apple" "1-*" "bar baz"[0m
-[33m[stage-35] [0m[92mReceived response: ""1-1""[0m
+[33m[stage-35] [0m[94mclient: $ redis-cli XADD apple 0-* blueberry mango[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-*\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "0-1"[0m
+[33m[stage-35] [0m[92mReceived "0-1"[0m
+[33m[stage-35] [0m[94mclient: > XADD apple 1-* blueberry mango[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n1-*\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n1-0\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "1-0"[0m
+[33m[stage-35] [0m[92mReceived "1-0"[0m
+[33m[stage-35] [0m[94mclient: > XADD apple 1-* mango banana[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n1-*\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "1-1"[0m
+[33m[stage-35] [0m[92mReceived "1-1"[0m
 [33m[stage-35] [0m[92mTest passed.[0m
 [33m[stage-35] [0m[36mTerminating program[0m
 [33m[stage-35] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-34] [0m[94mRunning tests for Stage #34: hq8[0m
 [33m[stage-34] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "pear" "1-1" "foo bar"[0m
-[33m[stage-34] [0m[92mReceived response: ""1-1""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "pear" "1-2" "bar baz"[0m
-[33m[stage-34] [0m[92mReceived response: ""1-2""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "pear" "1-2" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD is equal or smaller than the target stream top item""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "pear" "0-3" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD is equal or smaller than the target stream top item""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "pear" "0-0" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD must be greater than 0-0""[0m
+[33m[stage-34] [0m[94mclient: $ redis-cli XADD blueberry 1-1 blueberry strawberry[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n1-1\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP bulk string: "1-1"[0m
+[33m[stage-34] [0m[92mReceived "1-1"[0m
+[33m[stage-34] [0m[94mclient: > XADD blueberry 1-2 apple grape[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n1-2\r\n$5\r\napple\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "$3\r\n1-2\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP bulk string: "1-2"[0m
+[33m[stage-34] [0m[92mReceived "1-2"[0m
+[33m[stage-34] [0m[94mclient: > XADD blueberry 1-2 mango pineapple[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n1-2\r\n$5\r\nmango\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[94mclient: > XADD blueberry 0-3 pear banana[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-3\r\n$4\r\npear\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[94mclient: > XADD blueberry 0-0 orange raspberry[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-0\r\n$6\r\norange\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
 [33m[stage-34] [0m[92mTest passed.[0m
 [33m[stage-34] [0m[36mTerminating program[0m
 [33m[stage-34] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-33] [0m[94mRunning tests for Stage #33: cf6[0m
 [33m[stage-33] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-33] [0m[94m$ redis-cli xadd "banana" "0-1" "foo bar"[0m
-[33m[stage-33] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-33] [0m[94m$ redis-cli type "banana"[0m
-[33m[stage-33] [0m[92mType of "banana" is "stream"[0m
+[33m[stage-33] [0m[94mclient: $ redis-cli XADD blueberry 0-1 foo bar[0m
+[33m[stage-33] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received RESP bulk string: "0-1"[0m
+[33m[stage-33] [0m[92mReceived "0-1"[0m
+[33m[stage-33] [0m[94mclient: > TYPE blueberry[0m
+[33m[stage-33] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received bytes: "+stream\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received RESP simple string: "stream"[0m
+[33m[stage-33] [0m[92mReceived "stream"[0m
 [33m[stage-33] [0m[92mTest passed.[0m
 [33m[stage-33] [0m[36mTerminating program[0m
 [33m[stage-33] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-32] [0m[94mRunning tests for Stage #32: cc3[0m
 [33m[stage-32] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-32] [0m[94m$ redis-cli set "pineapple" "raspberry"[0m
-[33m[stage-32] [0m[92mReceived response: ""OK""[0m
-[33m[stage-32] [0m[94m$ redis-cli type "pineapple"[0m
-[33m[stage-32] [0m[92mType of "pineapple" is "string"[0m
-[33m[stage-32] [0m[94m$ redis-cli type "missing_key_raspberry"[0m
-[33m[stage-32] [0m[92mType of missing_key_"raspberry" is "none"[0m
+[33m[stage-32] [0m[94mclient: $ redis-cli SET banana apple[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$5\r\napple\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+OK\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "OK"[0m
+[33m[stage-32] [0m[92mReceived "OK"[0m
+[33m[stage-32] [0m[94mclient: > TYPE banana[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+string\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "string"[0m
+[33m[stage-32] [0m[92mReceived "string"[0m
+[33m[stage-32] [0m[94mclient: > TYPE missing_key_apple[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$17\r\nmissing_key_apple\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+none\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "none"[0m
+[33m[stage-32] [0m[92mReceived "none"[0m
 [33m[stage-32] [0m[92mTest passed.[0m
 [33m[stage-32] [0m[36mTerminating program[0m
 [33m[stage-32] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-31] [0m[94mRunning tests for Stage #31: na2[0m
 [33m[stage-31] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-31] [0m[94mProceeding to create 3 replicas.[0m
+[33m[stage-31] [0m[94mProceeding to create 4 replicas.[0m
 [33m[stage-31] [0m[36mCreating replica: 1[0m
 [33m[stage-31] [0m[94mreplica-1: $ redis-cli PING[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
@@ -293,11 +335,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2C\xf8kf\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8965bde70155f67b71a42d008e93f087ae062fcb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\u0378V\x1f\xdd\x15\\\xff"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x13pf\xfa\bused-mem°\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0ec17c1a04766b45256ee80cce2d495c5a9e1a11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa3\xdc\x10r\xbdu\xbd\x83"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -317,11 +359,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2C\xf8kf\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8965bde70155f67b71a42d008e93f087ae062fcb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x86K\xf1O\xbbq(\xa6"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x13pf\xfa\bused-mem\xc2@\xf6\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0ec17c1a04766b45256ee80cce2d495c5a9e1a11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>(\x9d\xf2\x83+*L"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -341,11 +383,35 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 8965bde70155f67b71a42d008e93f087ae062fcb 0"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2C\xf8kf\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8965bde70155f67b71a42d008e93f087ae062fcb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbeli\aR\xbe\xbf\x88"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x13pf\xfa\bused-mem\xc2@A\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0ec17c1a04766b45256ee80cce2d495c5a9e1a11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\a\xc0d\x88 [\xe4\xd7"[0m
+[33m[stage-31] [0m[92mReceived RDB file[0m
+[33m[stage-31] [0m[36mCreating replica: 4[0m
+[33m[stage-31] [0m[94mreplica-4: $ redis-cli PING[0m
+[33m[stage-31] [0m[36mreplica-4: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+PONG\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "PONG"[0m
+[33m[stage-31] [0m[92mReceived "PONG"[0m
+[33m[stage-31] [0m[94mreplica-4: > REPLCONF listening-port 6383[0m
+[33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
+[33m[stage-31] [0m[92mReceived "OK"[0m
+[33m[stage-31] [0m[94mreplica-4: > REPLCONF capa psync2[0m
+[33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+OK\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "OK"[0m
+[33m[stage-31] [0m[92mReceived "OK"[0m
+[33m[stage-31] [0m[94mreplica-4: > PSYNC ? -1[0m
+[33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 0ec17c1a04766b45256ee80cce2d495c5a9e1a11 0"[0m
+[33m[stage-31] [0m[36mReading RDB file...[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x13pf\xfa\bused-mem\xc2P\x8c\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0ec17c1a04766b45256ee80cce2d495c5a9e1a11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab7\xd0\xf1\xbb\xc6B\x8b"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -392,6 +458,18 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[36mreplica-3: Not sending ACK to Master[0m
+[33m[stage-31] [0m[94mTesting Replica : 4[0m
+[33m[stage-31] [0m[94mreplica-4: Expecting "SET foo 123" to be propagated[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP array: ["SELECT", "0"][0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP array: ["SET", "foo", "123"][0m
+[33m[stage-31] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[stage-31] [0m[94mreplica-4: Expecting "REPLCONF GETACK *" from Master[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[stage-31] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [0m[36mclient: Received bytes: ":1\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP integer: 1[0m
 [33m[stage-31] [0m[92mPassed first WAIT test.[0m
@@ -400,8 +478,8 @@ Debug = true
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: > WAIT 3 2000[0m
-[33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$4\r\n2000\r\n"[0m
+[33m[stage-31] [0m[94mclient: > WAIT 4 2000[0m
+[33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET baz 789" to be propagated[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
@@ -435,10 +513,22 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[stage-31] [0m[36mreplica-3: Not sending ACK to Master[0m
-[33m[stage-31] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[stage-31] [0m[36mclient: Received RESP integer: 2[0m
-[33m[stage-31] [0m[94mWAIT command returned after 2009 ms[0m
+[33m[stage-31] [0m[36mreplica-3: Sending ACK to Master[0m
+[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF ACK 122[0m
+[33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[stage-31] [0m[94mTesting Replica : 4[0m
+[33m[stage-31] [0m[94mreplica-4: Expecting "SET baz 789" to be propagated[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP array: ["SET", "baz", "789"][0m
+[33m[stage-31] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[stage-31] [0m[94mreplica-4: Expecting "REPLCONF GETACK *" from Master[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[stage-31] [0m[36mreplica-4: Not sending ACK to Master[0m
+[33m[stage-31] [0m[36mclient: Received bytes: ":3\r\n"[0m
+[33m[stage-31] [0m[36mclient: Received RESP integer: 3[0m
+[33m[stage-31] [0m[94mWAIT command returned after 2102 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -464,11 +554,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2E\xf8kf\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6a4bad58bfdbc1ed46748a175209b2ec761524ed\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x19m^ \x0e\b-N"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc23\x13pf\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ec245f8528d0b063a49040204e2a7fa3bbcbed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\xfd\xbd\xf4\xae1\x1c\xbd"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -488,11 +578,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2E\xf8kf\xfa\bused-mem\u0080\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6a4bad58bfdbc1ed46748a175209b2ec761524ed\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff+\xc7%V_\xe3\x96s"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc23\x13pf\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ec245f8528d0b063a49040204e2a7fa3bbcbed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\x0e\x1a\xa4\xc8Uh\xe4"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -512,11 +602,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 6a4bad58bfdbc1ed46748a175209b2ec761524ed 0"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC 9ec245f8528d0b063a49040204e2a7fa3bbcbed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2E\xf8kf\xfa\bused-mem\u0080@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6a4bad58bfdbc1ed46748a175209b2ec761524ed\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xe0\xbd\x1e\xb6,\x01]"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc23\x13pf\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ec245f8528d0b063a49040204e2a7fa3bbcbed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff )\x82\xec!\x9a\xff\xca"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -590,15 +680,15 @@ Debug = true
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[stage-28] [0m[94mmaster: > SET banana pear[0m
-[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[stage-28] [0m[94mmaster: > SET apple blueberry[0m
-[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-28] [0m[94mmaster: > SET raspberry banana[0m
+[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-28] [0m[94mmaster: > SET blueberry apple[0m
+[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$5\r\napple\r\n"[0m
 [33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n162\r\n"[0m
-[33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "162"][0m
-[33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "162"][0m
+[33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n167\r\n"[0m
+[33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "167"][0m
+[33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "167"][0m
 [33m[stage-28] [0m[92mTest passed.[0m
 [33m[stage-28] [0m[36mTerminating program[0m
 [33m[stage-28] [0m[36mProgram terminated successfully[0m
@@ -720,11 +810,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2G\xf8kf\xfa\bused-mem\xc2\xc0S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(076f601d81e979b1530c70e56a413fe84ef9cc43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffq\x14\xd3\xcco\xd7\x1d\x00"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x13pf\xfa\bused-mem\xc2\xe0S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db4f4ba46b71964b22d6e330d8f01173cebb20aa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf1No\xfa\xb0P\xd3\xcf"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -744,11 +834,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xf8kf\xfa\bused-mem\xc20;\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(076f601d81e979b1530c70e56a413fe84ef9cc43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffقu\xa3\x1a\xdbgr"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x13pf\xfa\bused-mem\xc2P;\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db4f4ba46b71964b22d6e330d8f01173cebb20aa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\x15\xea\xbf-\x96c\x15"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -768,11 +858,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 076f601d81e979b1530c70e56a413fe84ef9cc43 0"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC db4f4ba46b71964b22d6e330d8f01173cebb20aa 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xf8kf\xfa\bused-mem\xc2@J\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(076f601d81e979b1530c70e56a413fe84ef9cc43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\xb9w\x0eg\xc1\xd3O"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x13pf\xfa\bused-mem\xc2`J\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db4f4ba46b71964b22d6e330d8f01173cebb20aa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffP\xc8\xd8E\xceEm\xc4"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -857,11 +947,11 @@ Debug = true
 [33m[stage-24] [0m[92mReceived "OK"[0m
 [33m[stage-24] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 341d75e90ca30f190449cdbe9a77e95ac3baf3cc 0\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 341d75e90ca30f190449cdbe9a77e95ac3baf3cc 0"[0m
-[33m[stage-24] [0m[92mReceived "FULLRESYNC 341d75e90ca30f190449cdbe9a77e95ac3baf3cc 0"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 2ad0d9066bdc573db539798471bbaf799d854b7b 0\r\n"[0m
+[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 2ad0d9066bdc573db539798471bbaf799d854b7b 0"[0m
+[33m[stage-24] [0m[92mReceived "FULLRESYNC 2ad0d9066bdc573db539798471bbaf799d854b7b 0"[0m
 [33m[stage-24] [0m[36mReading RDB file...[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xf8kf\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(341d75e90ca30f190449cdbe9a77e95ac3baf3cc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x15)Jxƅg$"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x13pf\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2ad0d9066bdc573db539798471bbaf799d854b7b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffF\x1f\xfdt\xe8\xad\xc0\xf7"[0m
 [33m[stage-24] [0m[92mReceived RDB file[0m
 [33m[stage-24] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -916,11 +1006,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC bec7657fc36ac8fb2f6aeaa2ede91eea6a245b86 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC bec7657fc36ac8fb2f6aeaa2ede91eea6a245b86 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC bec7657fc36ac8fb2f6aeaa2ede91eea6a245b86 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 1c12aae172b67174f07664fccd618d9a3974a6cd 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 1c12aae172b67174f07664fccd618d9a3974a6cd 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 1c12aae172b67174f07664fccd618d9a3974a6cd 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xf8kf\xfa\bused-mem\xc2\xd0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bec7657fc36ac8fb2f6aeaa2ede91eea6a245b86\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x88\xa4\xf4èL^"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\x13pf\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c12aae172b67174f07664fccd618d9a3974a6cd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae\x82\x0f\x9fА\xb2\xbc"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -945,9 +1035,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 7a8142c02c705f559b35195392a38e09b9d7ccd9 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 7a8142c02c705f559b35195392a38e09b9d7ccd9 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 7a8142c02c705f559b35195392a38e09b9d7ccd9 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 5842812d421f037bc2636802a3c889db0fef1d0f 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 5842812d421f037bc2636802a3c889db0fef1d0f 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 5842812d421f037bc2636802a3c889db0fef1d0f 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1046,9 +1136,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:440193ba3ac20e968150152fb60781eb3631e128\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:440193ba3ac20e968150152fb60781eb3631e128\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:440193ba3ac20e968150152fb60781eb3631e128\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:63783026043491aae66afb1142a92a13e7120d74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:63783026043491aae66afb1142a92a13e7120d74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:63783026043491aae66afb1142a92a13e7120d74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1089,97 +1179,102 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:54df69f029f58da533312ef20853623a74aa0919\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:54df69f029f58da533312ef20853623a74aa0919\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:54df69f029f58da533312ef20853623a74aa0919\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:875c5beb6c092da01a5e014c3d404003518dc8f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:875c5beb6c092da01a5e014c3d404003518dc8f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:875c5beb6c092da01a5e014c3d404003518dc8f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-14] [0m[94mRunning tests for Stage #14: bw1[0m
-[33m[stage-14] [0m[94m$ ./spawn_redis_server.sh --port 6386[0m
-[33m[stage-14] [0m[94mConnecting to port 6386...[0m
+[33m[stage-14] [0m[94m$ ./spawn_redis_server.sh --port 6382[0m
+[33m[stage-14] [0m[94mConnecting to port 6382...[0m
 [33m[stage-14] [0m[36mConnection successful[0m
 [33m[stage-14] [0m[92mTest passed.[0m
 [33m[stage-14] [0m[36mTerminating program[0m
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3464846617 --dbfilename banana.rdb[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
-[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[stage-13] [0m[92mReceived "pear"[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3246685996 --dbfilename grape.rdb[0m
+[33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
+[33m[stage-13] [0m[92mReceived "pineapple"[0m
 [33m[stage-13] [0m[94mclient: > GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-13] [0m[92mReceived "$-1\r\n"[0m
-[33m[stage-13] [0m[94mclient: > GET pear[0m
-[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[stage-13] [0m[92mReceived "strawberry"[0m
-[33m[stage-13] [0m[94mclient: > GET strawberry[0m
-[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[stage-13] [0m[92mReceived "mango"[0m
+[33m[stage-13] [0m[94mclient: > GET apple[0m
+[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[stage-13] [0m[92mReceived "raspberry"[0m
 [33m[stage-13] [0m[92mTest passed.[0m
 [33m[stage-13] [0m[36mTerminating program[0m
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "pineapple"="pear", "raspberry"="strawberry", "pear"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1186933777 --dbfilename strawberry.rdb[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "banana"="grape", "blueberry"="pear", "apple"="raspberry", "orange"="banana", "mango"="blueberry"[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles522923839 --dbfilename strawberry.rdb[0m
+[33m[stage-12] [0m[94mclient: $ redis-cli GET banana[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "grape"[0m
+[33m[stage-12] [0m[92mReceived "grape"[0m
+[33m[stage-12] [0m[94mclient: > GET blueberry[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "pear"[0m
 [33m[stage-12] [0m[92mReceived "pear"[0m
-[33m[stage-12] [0m[94mclient: > GET raspberry[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[stage-12] [0m[92mReceived "strawberry"[0m
-[33m[stage-12] [0m[94mclient: > GET pear[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[stage-12] [0m[92mReceived "pineapple"[0m
+[33m[stage-12] [0m[94mclient: > GET apple[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[stage-12] [0m[92mReceived "raspberry"[0m
+[33m[stage-12] [0m[94mclient: > GET orange[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[stage-12] [0m[92mReceived "banana"[0m
+[33m[stage-12] [0m[94mclient: > GET mango[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
+[33m[stage-12] [0m[92mReceived "blueberry"[0m
 [33m[stage-12] [0m[92mTest passed.[0m
 [33m[stage-12] [0m[36mTerminating program[0m
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 4 keys: ["mango" "pineapple" "blueberry" "apple"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1436298453 --dbfilename strawberry.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "strawberry" "apple" "banana" "grape"][0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3039702397 --dbfilename raspberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n$5\r\nmango\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "blueberry", "pineapple", "mango"][0m
-[33m[stage-11] [0m[92mReceived ["apple", "blueberry", "pineapple", "mango"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*5\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$5\r\napple\r\n$6\r\nbanana\r\n$6\r\norange\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["strawberry", "grape", "apple", "banana", "orange"][0m
+[33m[stage-11] [0m[92mReceived ["strawberry", "grape", "apple", "banana", "orange"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: grape="raspberry"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3560698957 --dbfilename blueberry.rdb[0m
-[33m[stage-10] [0m[94mclient: $ redis-cli GET grape[0m
-[33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[stage-10] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[stage-10] [0m[92mReceived "raspberry"[0m
+[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="pear"[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2354418207 --dbfilename pear.rdb[0m
+[33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-10] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
+[33m[stage-10] [0m[36mclient: Received RESP bulk string: "pear"[0m
+[33m[stage-10] [0m[92mReceived "pear"[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "orange"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3889048063 --dbfilename mango.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2737675598 --dbfilename grape.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\norange\r\n"[0m
@@ -1190,34 +1285,34 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2176374416 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3124807128 --dbfilename pear.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2176374416\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2176374416"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2176374416"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3124807128\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3124807128"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3124807128"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: yz1[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-7] [0m[94m$ redis-cli SET banana orange px 100[0m
-[33m[stage-7] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$6\r\norange\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[stage-7] [0m[94m$ redis-cli SET pear mango px 100[0m
+[33m[stage-7] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$4\r\npear\r\n$5\r\nmango\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 13:29:07.724[0m
-[33m[stage-7] [0m[94mFetching key "banana" at 13:29:07.724 (should not be expired)[0m
-[33m[stage-7] [0m[94m> GET banana[0m
-[33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
-[33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
-[33m[stage-7] [0m[92mReceived "orange"[0m
+[33m[stage-7] [0m[92mReceived OK at 16:13:05.278[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 16:13:05.278 (should not be expired)[0m
+[33m[stage-7] [0m[94m> GET pear[0m
+[33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[stage-7] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
+[33m[stage-7] [0m[36mReceived RESP bulk string: "mango"[0m
+[33m[stage-7] [0m[92mReceived "mango"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "banana" at 13:29:07.827 (should be expired)[0m
-[33m[stage-7] [0m[94m> GET banana[0m
-[33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 16:13:05.381 (should be expired)[0m
+[33m[stage-7] [0m[94m> GET pear[0m
+[33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-7] [0m[92mReceived "$-1\r\n"[0m
@@ -1227,29 +1322,29 @@ Debug = true
 
 [33m[stage-6] [0m[94mRunning tests for Stage #6: la7[0m
 [33m[stage-6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-6] [0m[36mSetting key mango to apple[0m
-[33m[stage-6] [0m[94m$ redis-cli SET mango apple[0m
-[33m[stage-6] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$5\r\napple\r\n"[0m
+[33m[stage-6] [0m[36mSetting key blueberry to pineapple[0m
+[33m[stage-6] [0m[94m$ redis-cli SET blueberry pineapple[0m
+[33m[stage-6] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
-[33m[stage-6] [0m[36mGetting key mango[0m
-[33m[stage-6] [0m[94m> GET mango[0m
-[33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[stage-6] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
-[33m[stage-6] [0m[36mReceived RESP bulk string: "apple"[0m
-[33m[stage-6] [0m[92mReceived "apple"[0m
+[33m[stage-6] [0m[36mGetting key blueberry[0m
+[33m[stage-6] [0m[94m> GET blueberry[0m
+[33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-6] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[stage-6] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[stage-6] [0m[92mReceived "pineapple"[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 [33m[stage-6] [0m[36mTerminating program[0m
 [33m[stage-6] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: qq0[0m
 [33m[stage-5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-5] [0m[94m$ redis-cli ECHO banana[0m
-[33m[stage-5] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\nbanana\r\n"[0m
-[33m[stage-5] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
-[33m[stage-5] [0m[36mReceived RESP bulk string: "banana"[0m
-[33m[stage-5] [0m[92mReceived "banana"[0m
+[33m[stage-5] [0m[94m$ redis-cli ECHO raspberry[0m
+[33m[stage-5] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-5] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[stage-5] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[stage-5] [0m[92mReceived "raspberry"[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 [33m[stage-5] [0m[36mTerminating program[0m
 [33m[stage-5] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -605,8 +605,11 @@ Debug = true
 
 [33m[stage-36] [0m[94mRunning tests for Stage #36: xu6[0m
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-36] [0m[94m$ redis-cli xadd "pear" * foo bar[0m
-[33m[stage-36] [0m[94mReceived response: ""1718383812190-0""[0m
+[33m[stage-36] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
+[33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1718621004091-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1718621004091-0"[0m
+[33m[stage-36] [0m[92mReceived "1718621004091-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -615,50 +618,89 @@ Debug = true
 
 [33m[stage-35] [0m[94mRunning tests for Stage #35: yh3[0m
 [33m[stage-35] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "raspberry" "0-*" "foo bar"[0m
-[33m[stage-35] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "raspberry" "1-*" "foo bar"[0m
-[33m[stage-35] [0m[92mReceived response: ""1-0""[0m
-[33m[stage-35] [0m[94m$ redis-cli xadd "raspberry" "1-*" "bar baz"[0m
-[33m[stage-35] [0m[92mReceived response: ""1-1""[0m
+[33m[stage-35] [0m[94mclient: $ redis-cli XADD raspberry 0-* apple banana[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-*\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "0-1"[0m
+[33m[stage-35] [0m[92mReceived "0-1"[0m
+[33m[stage-35] [0m[94mclient: > XADD raspberry 1-* apple banana[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n1-0\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "1-0"[0m
+[33m[stage-35] [0m[92mReceived "1-0"[0m
+[33m[stage-35] [0m[94mclient: > XADD raspberry 1-* banana pineapple[0m
+[33m[stage-35] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
+[33m[stage-35] [0m[36mclient: Received RESP bulk string: "1-1"[0m
+[33m[stage-35] [0m[92mReceived "1-1"[0m
 [33m[stage-35] [0m[92mTest passed.[0m
 [33m[stage-35] [0m[36mTerminating program[0m
 [33m[stage-35] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-34] [0m[94mRunning tests for Stage #34: hq8[0m
 [33m[stage-34] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "blueberry" "1-1" "foo bar"[0m
-[33m[stage-34] [0m[92mReceived response: ""1-1""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "blueberry" "1-2" "bar baz"[0m
-[33m[stage-34] [0m[92mReceived response: ""1-2""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "blueberry" "1-2" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD is equal or smaller than the target stream top item""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "blueberry" "0-3" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD is equal or smaller than the target stream top item""[0m
-[33m[stage-34] [0m[94m$ redis-cli xadd "blueberry" "0-0" "baz foo"[0m
-[33m[stage-34] [0m[92mReceived error: ""ERR The ID specified in XADD must be greater than 0-0""[0m
+[33m[stage-34] [0m[94mclient: $ redis-cli XADD orange 1-1 pineapple apple[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n1-1\r\n$9\r\npineapple\r\n$5\r\napple\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP bulk string: "1-1"[0m
+[33m[stage-34] [0m[92mReceived "1-1"[0m
+[33m[stage-34] [0m[94mclient: > XADD orange 1-2 pear raspberry[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n1-2\r\n$4\r\npear\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "$3\r\n1-2\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP bulk string: "1-2"[0m
+[33m[stage-34] [0m[92mReceived "1-2"[0m
+[33m[stage-34] [0m[94mclient: > XADD orange 1-2 blueberry banana[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n1-2\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[94mclient: > XADD orange 0-3 mango strawberry[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-3\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[stage-34] [0m[94mclient: > XADD orange 0-0 orange grape[0m
+[33m[stage-34] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-0\r\n$6\r\norange\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
+[33m[stage-34] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[stage-34] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
 [33m[stage-34] [0m[92mTest passed.[0m
 [33m[stage-34] [0m[36mTerminating program[0m
 [33m[stage-34] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-33] [0m[94mRunning tests for Stage #33: cf6[0m
 [33m[stage-33] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-33] [0m[94m$ redis-cli xadd "blueberry" "0-1" "foo bar"[0m
-[33m[stage-33] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-33] [0m[94m$ redis-cli type "blueberry"[0m
-[33m[stage-33] [0m[92mType of "blueberry" is "stream"[0m
+[33m[stage-33] [0m[94mclient: $ redis-cli XADD grape 0-1 foo bar[0m
+[33m[stage-33] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received RESP bulk string: "0-1"[0m
+[33m[stage-33] [0m[92mReceived "0-1"[0m
+[33m[stage-33] [0m[94mclient: > TYPE grape[0m
+[33m[stage-33] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received bytes: "+stream\r\n"[0m
+[33m[stage-33] [0m[36mclient: Received RESP simple string: "stream"[0m
+[33m[stage-33] [0m[92mReceived "stream"[0m
 [33m[stage-33] [0m[92mTest passed.[0m
 [33m[stage-33] [0m[36mTerminating program[0m
 [33m[stage-33] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-32] [0m[94mRunning tests for Stage #32: cc3[0m
 [33m[stage-32] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-32] [0m[94m$ redis-cli set "mango" "banana"[0m
-[33m[stage-32] [0m[92mReceived response: ""OK""[0m
-[33m[stage-32] [0m[94m$ redis-cli type "mango"[0m
-[33m[stage-32] [0m[92mType of "mango" is "string"[0m
-[33m[stage-32] [0m[94m$ redis-cli type "missing_key_banana"[0m
-[33m[stage-32] [0m[92mType of missing_key_"banana" is "none"[0m
+[33m[stage-32] [0m[94mclient: $ redis-cli SET pineapple blueberry[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+OK\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "OK"[0m
+[33m[stage-32] [0m[92mReceived "OK"[0m
+[33m[stage-32] [0m[94mclient: > TYPE pineapple[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+string\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "string"[0m
+[33m[stage-32] [0m[92mReceived "string"[0m
+[33m[stage-32] [0m[94mclient: > TYPE missing_key_blueberry[0m
+[33m[stage-32] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$21\r\nmissing_key_blueberry\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received bytes: "+none\r\n"[0m
+[33m[stage-32] [0m[36mclient: Received RESP simple string: "none"[0m
+[33m[stage-32] [0m[92mReceived "none"[0m
 [33m[stage-32] [0m[92mTest passed.[0m
 [33m[stage-32] [0m[36mTerminating program[0m
 [33m[stage-32] [0m[36mProgram terminated successfully[0m
@@ -684,11 +726,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4tlf\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe4\x986i\xa6\x02\xe0\xc3"[0m
+[33m[stage-31] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\x13pf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2531e08230f11faca6de5ea2ba9c6f62b1ae91eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff*oN\xf3\x99f-;"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -708,11 +750,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4tlf\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffM\x8d\xa1n^\xaf.v"[0m
+[33m[stage-31] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\x13pf\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2531e08230f11faca6de5ea2ba9c6f62b1ae91eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\x9c\xe9\xa3\xff\x02Yb"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -732,11 +774,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4tlf\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffu\xaa9&\xb7`\xb9X"[0m
+[33m[stage-31] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\x13pf\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2531e08230f11faca6de5ea2ba9c6f62b1ae91eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\xbbq\xeb\x16\xcd\xceL"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -756,11 +798,11 @@ Debug = true
 [33m[stage-31] [0m[92mReceived "OK"[0m
 [33m[stage-31] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0\r\n"[0m
-[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
-[33m[stage-31] [0m[92mReceived "FULLRESYNC 1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7 0"[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0\r\n"[0m
+[33m[stage-31] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
+[33m[stage-31] [0m[92mReceived "FULLRESYNC 2531e08230f11faca6de5ea2ba9c6f62b1ae91eb 0"[0m
 [33m[stage-31] [0m[36mReading RDB file...[0m
-[33m[stage-31] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5tlf\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c06ed29c4a083a5302082fabaa3a0b91c9a3bf7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffDj\xe05Z\xab\xfa."[0m
+[33m[stage-31] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\x13pf\xfa\bused-mem°\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2531e08230f11faca6de5ea2ba9c6f62b1ae91eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\x8e\xf0\x9c\x00\xb7\xdb\xe4"[0m
 [33m[stage-31] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -827,8 +869,8 @@ Debug = true
 [33m[stage-31] [0m[36mclient: Received bytes: "+OK\r\n"[0m
 [33m[stage-31] [0m[36mclient: Received RESP simple string: "OK"[0m
 [33m[stage-31] [0m[92mReceived "OK"[0m
-[33m[stage-31] [0m[94mclient: > WAIT 3 2000[0m
-[33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$4\r\n2000\r\n"[0m
+[33m[stage-31] [0m[94mclient: > WAIT 4 2000[0m
+[33m[stage-31] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 1[0m
 [33m[stage-31] [0m[94mreplica-1: Expecting "SET baz 789" to be propagated[0m
 [33m[stage-31] [0m[36mreplica-1: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
@@ -862,7 +904,9 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-3: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
 [33m[stage-31] [0m[36mreplica-3: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[stage-31] [0m[36mreplica-3: Not sending ACK to Master[0m
+[33m[stage-31] [0m[36mreplica-3: Sending ACK to Master[0m
+[33m[stage-31] [0m[94mreplica-3: $ redis-cli REPLCONF ACK 122[0m
+[33m[stage-31] [0m[36mreplica-3: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[stage-31] [0m[94mTesting Replica : 4[0m
 [33m[stage-31] [0m[94mreplica-4: Expecting "SET baz 789" to be propagated[0m
 [33m[stage-31] [0m[36mreplica-4: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
@@ -873,8 +917,8 @@ Debug = true
 [33m[stage-31] [0m[36mreplica-4: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
 [33m[stage-31] [0m[36mreplica-4: Not sending ACK to Master[0m
-[33m[stage-31] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[stage-31] [0m[36mclient: Received RESP integer: 2[0m
+[33m[stage-31] [0m[36mclient: Received bytes: ":3\r\n"[0m
+[33m[stage-31] [0m[36mclient: Received RESP integer: 3[0m
 [33m[stage-31] [0m[94mWAIT command returned after 2097 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
@@ -882,7 +926,7 @@ Debug = true
 
 [33m[stage-30] [0m[94mRunning tests for Stage #30: tu8[0m
 [33m[stage-30] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[stage-30] [0m[94mProceeding to create 6 replicas.[0m
+[33m[stage-30] [0m[94mProceeding to create 4 replicas.[0m
 [33m[stage-30] [0m[36mCreating replica: 1[0m
 [33m[stage-30] [0m[94mreplica-1: $ redis-cli PING[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
@@ -901,11 +945,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "+FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\xa4\x1fh\xdd\xc0\x9e\x9e"[0m
+[33m[stage-30] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\x13pf\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x90\xe2\x1d\x1d\xb5\xe5^\f"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -925,11 +969,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "+FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffKW\xb88\xbb\xa4\xea\xc7"[0m
+[33m[stage-30] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\x13pf\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\xf7\x8a\x1aMH\x90\xb9"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -949,11 +993,11 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "+FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffsp pRk}\xe9"[0m
+[33m[stage-30] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\x13pf\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01\xd0\x12R\xa4\x87\a\x97"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -973,75 +1017,32 @@ Debug = true
 [33m[stage-30] [0m[92mReceived "OK"[0m
 [33m[stage-30] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
+[33m[stage-30] [0m[36mreplica-4: Received bytes: "+FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0\r\n"[0m
+[33m[stage-30] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
+[33m[stage-30] [0m[92mReceived "FULLRESYNC c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5 0"[0m
 [33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem°\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7E\xa1\aD\x11hA"[0m
-[33m[stage-30] [0m[92mReceived RDB file[0m
-[33m[stage-30] [0m[36mCreating replica: 5[0m
-[33m[stage-30] [0m[94mreplica-5: $ redis-cli PING[0m
-[33m[stage-30] [0m[36mreplica-5: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "+PONG\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "PONG"[0m
-[33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-5: > REPLCONF listening-port 6384[0m
-[33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "+OK\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "OK"[0m
-[33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-5: > REPLCONF capa psync2[0m
-[33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "+OK\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "OK"[0m
-[33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-5: > PSYNC ? -1[0m
-[33m[stage-30] [0m[36mreplica-5: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem\xc2\xc0\xd6\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffT$н\xefh\x02\xe7"[0m
-[33m[stage-30] [0m[92mReceived RDB file[0m
-[33m[stage-30] [0m[36mCreating replica: 6[0m
-[33m[stage-30] [0m[94mreplica-6: $ redis-cli PING[0m
-[33m[stage-30] [0m[36mreplica-6: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "+PONG\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "PONG"[0m
-[33m[stage-30] [0m[92mReceived "PONG"[0m
-[33m[stage-30] [0m[94mreplica-6: > REPLCONF listening-port 6385[0m
-[33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "+OK\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "OK"[0m
-[33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-6: > REPLCONF capa psync2[0m
-[33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "+OK\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "OK"[0m
-[33m[stage-30] [0m[92mReceived "OK"[0m
-[33m[stage-30] [0m[94mreplica-6: > PSYNC ? -1[0m
-[33m[stage-30] [0m[36mreplica-6: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0\r\n"[0m
-[33m[stage-30] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[92mReceived "FULLRESYNC 5375b7c06be89997dbda6de1083a664bddf749a7 0"[0m
-[33m[stage-30] [0m[36mReading RDB file...[0m
-[33m[stage-30] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc7tlf\xfa\bused-mem\xc2\xc0!\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5375b7c06be89997dbda6de1083a664bddf749a7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8^pfO6R\xe7"[0m
+[33m[stage-30] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\x13pf\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c621c3ab4aa06b9bef45b0f29025fc6ba7777ed5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5\xe5\x93%\xb2\xfd\x12?"[0m
 [33m[stage-30] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received bytes: ":6\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received RESP integer: 6[0m
-[33m[stage-30] [0m[92mReceived 6[0m
+[33m[stage-30] [0m[36mclient: Received bytes: ":4\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received RESP integer: 4[0m
+[33m[stage-30] [0m[92mReceived 4[0m
+[33m[stage-30] [0m[94mclient: > WAIT 4 500[0m
+[33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received bytes: ":4\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received RESP integer: 4[0m
+[33m[stage-30] [0m[92mReceived 4[0m
 [33m[stage-30] [0m[94mclient: > WAIT 5 500[0m
 [33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received bytes: ":6\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received RESP integer: 6[0m
-[33m[stage-30] [0m[92mReceived 6[0m
-[33m[stage-30] [0m[94mclient: > WAIT 7 500[0m
-[33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received bytes: ":6\r\n"[0m
-[33m[stage-30] [0m[36mclient: Received RESP integer: 6[0m
-[33m[stage-30] [0m[92mReceived 6[0m
+[33m[stage-30] [0m[36mclient: Received bytes: ":4\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received RESP integer: 4[0m
+[33m[stage-30] [0m[92mReceived 4[0m
+[33m[stage-30] [0m[94mclient: > WAIT 6 500[0m
+[33m[stage-30] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n6\r\n$3\r\n500\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received bytes: ":4\r\n"[0m
+[33m[stage-30] [0m[36mclient: Received RESP integer: 4[0m
+[33m[stage-30] [0m[92mReceived 4[0m
 [33m[stage-30] [0m[92mTest passed.[0m
 [33m[stage-30] [0m[36mTerminating program[0m
 [33m[stage-30] [0m[36mProgram terminated successfully[0m
@@ -1099,15 +1100,15 @@ Debug = true
 [33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
 [33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
 [33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[stage-28] [0m[94mmaster: > SET banana banana[0m
-[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$6\r\nbanana\r\n"[0m
-[33m[stage-28] [0m[94mmaster: > SET blueberry orange[0m
-[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$6\r\norange\r\n"[0m
+[33m[stage-28] [0m[94mmaster: > SET strawberry blueberry[0m
+[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-28] [0m[94mmaster: > SET strawberry mango[0m
+[33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
 [33m[stage-28] [0m[94mmaster: > REPLCONF GETACK *[0m
 [33m[stage-28] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n165\r\n"[0m
-[33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "165"][0m
-[33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "165"][0m
+[33m[stage-28] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n174\r\n"[0m
+[33m[stage-28] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "174"][0m
+[33m[stage-28] [0m[92mReceived ["REPLCONF", "ACK", "174"][0m
 [33m[stage-28] [0m[92mTest passed.[0m
 [33m[stage-28] [0m[36mTerminating program[0m
 [33m[stage-28] [0m[36mProgram terminated successfully[0m
@@ -1229,11 +1230,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "+FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9tlf\xfa\bused-mem\u00a0S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e58128f42dc607c41d060c0144f89740dd79c29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde0\xf4_xg\x18\xd1"[0m
+[33m[stage-25] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\x13pf\xfa\bused-mem\xc2\x00S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8ae41487ed1704d96af056e417f32d984d9df6a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffԸ\xf9\x92ns\xc43"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -1253,11 +1254,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "+FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9tlf\xfa\bused-mem\xc2\x10;\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e58128f42dc607c41d060c0144f89740dd79c29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff[kq\x1a塨\v"[0m
+[33m[stage-25] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\x13pf\xfa\bused-mem\xc2p:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8ae41487ed1704d96af056e417f32d984d9df6a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)u\xc1Î\x85\xe28"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -1277,11 +1278,11 @@ Debug = true
 [33m[stage-25] [0m[92mReceived "OK"[0m
 [33m[stage-25] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0\r\n"[0m
-[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
-[33m[stage-25] [0m[92mReceived "FULLRESYNC 2e58128f42dc607c41d060c0144f89740dd79c29 0"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "+FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0\r\n"[0m
+[33m[stage-25] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
+[33m[stage-25] [0m[92mReceived "FULLRESYNC e8ae41487ed1704d96af056e417f32d984d9df6a 0"[0m
 [33m[stage-25] [0m[36mReading RDB file...[0m
-[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9tlf\xfa\bused-mem\xc2 J\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e58128f42dc607c41d060c0144f89740dd79c29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\xb6C\xe0\x06r\xa6\xda"[0m
+[33m[stage-25] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\x13pf\xfa\bused-mem\u0080I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8ae41487ed1704d96af056e417f32d984d9df6a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA\xdfT\xaa֕#B"[0m
 [33m[stage-25] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1366,11 +1367,11 @@ Debug = true
 [33m[stage-24] [0m[92mReceived "OK"[0m
 [33m[stage-24] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC fb217523f2c9c301e3804564b643014400411d9b 0\r\n"[0m
-[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC fb217523f2c9c301e3804564b643014400411d9b 0"[0m
-[33m[stage-24] [0m[92mReceived "FULLRESYNC fb217523f2c9c301e3804564b643014400411d9b 0"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "+FULLRESYNC 2d95fca2a615365974b5b3920812ca807cdb5a40 0\r\n"[0m
+[33m[stage-24] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 2d95fca2a615365974b5b3920812ca807cdb5a40 0"[0m
+[33m[stage-24] [0m[92mReceived "FULLRESYNC 2d95fca2a615365974b5b3920812ca807cdb5a40 0"[0m
 [33m[stage-24] [0m[36mReading RDB file...[0m
-[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc9tlf\xfa\bused-mem\xc2\xc0S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fb217523f2c9c301e3804564b643014400411d9b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\xff\b\xcdI\xcb\xc0a"[0m
+[33m[stage-24] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2R\x13pf\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2d95fca2a615365974b5b3920812ca807cdb5a40\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff-]\x9c\xec\xf0\xc8Z\a"[0m
 [33m[stage-24] [0m[92mReceived RDB file[0m
 [33m[stage-24] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1425,11 +1426,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 4a683405a76db69b468112e12b5244236490dbac 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 4a683405a76db69b468112e12b5244236490dbac 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 4a683405a76db69b468112e12b5244236490dbac 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 3b3fedca14ef72470732a2834e25db0e1c4fac00 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3b3fedca14ef72470732a2834e25db0e1c4fac00 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 3b3fedca14ef72470732a2834e25db0e1c4fac00 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xcatlf\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4a683405a76db69b468112e12b5244236490dbac\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xdc\xf5\xc2b\xd08\xfb"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2R\x13pf\xfa\bused-mem\xc2\xd0\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3b3fedca14ef72470732a2834e25db0e1c4fac00\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8c\x1d\xa7\xeb\xb8I8\xa5"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1454,9 +1455,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 378cc0e01a8107822ffb083ff497644efb3d0d21 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 378cc0e01a8107822ffb083ff497644efb3d0d21 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 378cc0e01a8107822ffb083ff497644efb3d0d21 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 1cd392a548a5b2686a097d626aae32a7c9f51b24 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 1cd392a548a5b2686a097d626aae32a7c9f51b24 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 1cd392a548a5b2686a097d626aae32a7c9f51b24 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1555,9 +1556,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9c5dddb64daca5c0a600308f4e3d66d424043344\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9c5dddb64daca5c0a600308f4e3d66d424043344\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9c5dddb64daca5c0a600308f4e3d66d424043344\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75931943b31aaa33c7c96f47b167d6091bc4b3aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75931943b31aaa33c7c96f47b167d6091bc4b3aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75931943b31aaa33c7c96f47b167d6091bc4b3aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1598,133 +1599,138 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e6651c8a5c2e8dd0a7ad1b4ac62ffcc84fb639fb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e6651c8a5c2e8dd0a7ad1b4ac62ffcc84fb639fb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e6651c8a5c2e8dd0a7ad1b4ac62ffcc84fb639fb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:71538be97a7329d984df10aac195733a56e1b5c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:71538be97a7329d984df10aac195733a56e1b5c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:71538be97a7329d984df10aac195733a56e1b5c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
 [33m[stage-15] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-14] [0m[94mRunning tests for Stage #14: bw1[0m
-[33m[stage-14] [0m[94m$ ./spawn_redis_server.sh --port 6380[0m
-[33m[stage-14] [0m[94mConnecting to port 6380...[0m
+[33m[stage-14] [0m[94m$ ./spawn_redis_server.sh --port 6389[0m
+[33m[stage-14] [0m[94mConnecting to port 6389...[0m
 [33m[stage-14] [0m[36mConnection successful[0m
 [33m[stage-14] [0m[92mTest passed.[0m
 [33m[stage-14] [0m[36mTerminating program[0m
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles202461335 --dbfilename apple.rdb[0m
-[33m[stage-13] [0m[94mclient: $ redis-cli GET strawberry[0m
-[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3227190898 --dbfilename banana.rdb[0m
+[33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
+[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[stage-13] [0m[92mReceived "$-1\r\n"[0m
-[33m[stage-13] [0m[94mclient: > GET orange[0m
-[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[stage-13] [0m[92mReceived "blueberry"[0m
+[33m[stage-13] [0m[94mclient: > GET pineapple[0m
+[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
+[33m[stage-13] [0m[92mReceived "pineapple"[0m
 [33m[stage-13] [0m[94mclient: > GET apple[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[stage-13] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[stage-13] [0m[92mReceived "orange"[0m
+[33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
+[33m[stage-13] [0m[92mReceived "strawberry"[0m
+[33m[stage-13] [0m[94mclient: > GET blueberry[0m
+[33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[stage-13] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[stage-13] [0m[92mReceived "raspberry"[0m
 [33m[stage-13] [0m[92mTest passed.[0m
 [33m[stage-13] [0m[36mTerminating program[0m
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "apple"="pineapple", "raspberry"="strawberry", "mango"="apple", "strawberry"="grape"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2321023724 --dbfilename grape.rdb[0m
-[33m[stage-12] [0m[94mclient: $ redis-cli GET apple[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[stage-12] [0m[92mReceived "pineapple"[0m
-[33m[stage-12] [0m[94mclient: > GET raspberry[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[stage-12] [0m[92mReceived "strawberry"[0m
-[33m[stage-12] [0m[94mclient: > GET mango[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "pineapple"="raspberry", "banana"="apple", "pear"="banana", "mango"="pineapple"[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3676675137 --dbfilename raspberry.rdb[0m
+[33m[stage-12] [0m[94mclient: $ redis-cli GET pineapple[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[stage-12] [0m[92mReceived "raspberry"[0m
+[33m[stage-12] [0m[94mclient: > GET banana[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received RESP bulk string: "apple"[0m
 [33m[stage-12] [0m[92mReceived "apple"[0m
-[33m[stage-12] [0m[94mclient: > GET strawberry[0m
-[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
-[33m[stage-12] [0m[36mclient: Received RESP bulk string: "grape"[0m
-[33m[stage-12] [0m[92mReceived "grape"[0m
+[33m[stage-12] [0m[94mclient: > GET pear[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[stage-12] [0m[92mReceived "banana"[0m
+[33m[stage-12] [0m[94mclient: > GET mango[0m
+[33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
+[33m[stage-12] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
+[33m[stage-12] [0m[92mReceived "pineapple"[0m
 [33m[stage-12] [0m[92mTest passed.[0m
 [33m[stage-12] [0m[36mTerminating program[0m
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["orange" "banana" "pear"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2091869705 --dbfilename grape.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["apple" "grape" "mango"][0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3738343592 --dbfilename pineapple.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$4\r\npear\r\n$6\r\nbanana\r\n$6\r\norange\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["pear", "banana", "orange"][0m
-[33m[stage-11] [0m[92mReceived ["pear", "banana", "orange"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\nmango\r\n$5\r\ngrape\r\n$5\r\napple\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["mango", "grape", "apple"][0m
+[33m[stage-11] [0m[92mReceived ["mango", "grape", "apple"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: pineapple="blueberry"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1208672642 --dbfilename mango.rdb[0m
-[33m[stage-10] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[stage-10] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[stage-10] [0m[92mReceived "blueberry"[0m
+[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="banana"[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1280259726 --dbfilename grape.rdb[0m
+[33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-10] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[stage-10] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[stage-10] [0m[92mReceived "banana"[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 [33m[stage-10] [0m[36mTerminating program[0m
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
-[33m[stage-9] [0m[94mCreated RDB file with single key: "apple"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles73015925 --dbfilename mango.rdb[0m
+[33m[stage-9] [0m[94mCreated RDB file with single key: "raspberry"[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3138754530 --dbfilename strawberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
-[33m[stage-9] [0m[36mclient: Received RESP array: ["apple"][0m
-[33m[stage-9] [0m[92mReceived ["apple"][0m
+[33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-9] [0m[36mclient: Received RESP array: ["raspberry"][0m
+[33m[stage-9] [0m[92mReceived ["raspberry"][0m
 [33m[stage-9] [0m[92mTest passed.[0m
 [33m[stage-9] [0m[36mTerminating program[0m
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3503538548 --dbfilename blueberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1604276763 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3503538548\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3503538548"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3503538548"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1604276763\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1604276763"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1604276763"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: yz1[0m
 [33m[stage-7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-7] [0m[94m$ redis-cli SET apple banana px 100[0m
-[33m[stage-7] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$6\r\nbanana\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[stage-7] [0m[94m$ redis-cli SET apple strawberry px 100[0m
+[33m[stage-7] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$10\r\nstrawberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 22:20:21.189[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 22:20:21.189 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 16:13:33.415[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 16:13:33.415 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[stage-7] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
-[33m[stage-7] [0m[36mReceived RESP bulk string: "banana"[0m
-[33m[stage-7] [0m[92mReceived "banana"[0m
+[33m[stage-7] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[stage-7] [0m[36mReceived RESP bulk string: "strawberry"[0m
+[33m[stage-7] [0m[92mReceived "strawberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 22:20:21.295 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 16:13:33.517 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -1736,29 +1742,29 @@ Debug = true
 
 [33m[stage-6] [0m[94mRunning tests for Stage #6: la7[0m
 [33m[stage-6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-6] [0m[36mSetting key banana to pear[0m
-[33m[stage-6] [0m[94m$ redis-cli SET banana pear[0m
-[33m[stage-6] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[stage-6] [0m[36mSetting key grape to orange[0m
+[33m[stage-6] [0m[94m$ redis-cli SET grape orange[0m
+[33m[stage-6] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
 [33m[stage-6] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-6] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-6] [0m[92mReceived "OK"[0m
-[33m[stage-6] [0m[36mGetting key banana[0m
-[33m[stage-6] [0m[94m> GET banana[0m
-[33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[stage-6] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[stage-6] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[stage-6] [0m[92mReceived "pear"[0m
+[33m[stage-6] [0m[36mGetting key grape[0m
+[33m[stage-6] [0m[94m> GET grape[0m
+[33m[stage-6] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-6] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[stage-6] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[stage-6] [0m[92mReceived "orange"[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 [33m[stage-6] [0m[36mTerminating program[0m
 [33m[stage-6] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: qq0[0m
 [33m[stage-5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-5] [0m[94m$ redis-cli ECHO pear[0m
-[33m[stage-5] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$4\r\npear\r\n"[0m
-[33m[stage-5] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[stage-5] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[stage-5] [0m[92mReceived "pear"[0m
+[33m[stage-5] [0m[94m$ redis-cli ECHO grape[0m
+[33m[stage-5] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-5] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[stage-5] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[stage-5] [0m[92mReceived "grape"[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 [33m[stage-5] [0m[36mTerminating program[0m
 [33m[stage-5] [0m[36mProgram terminated successfully[0m


### PR DESCRIPTION
This pull request refactors the streams extension tests to use the RESP framework for the Redis client connection. It modifies the test cases to use the MultiCommandTestCase and resp_assertions for assertions. The changes improve the efficiency and readability of the code.