### PR TITLE
CC-1357: refactor logger.Infof calls for xread block tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,32 +31,32 @@ update_tester_utils:
 
 test_dev: build
 	cd /Users/ryang/Developer/byox/build-your-own-redis && \
-	CODECRAFTERS_SUBMISSION_DIR=/Users/ryang/Developer/byox/build-your-own-redis  \
+	CODECRAFTERS_REPOSITORY_DIR=/Users/ryang/Developer/byox/build-your-own-redis  \
 	CODECRAFTERS_TEST_CASES_JSON="[]"  \
 	$(shell pwd)/dist/main.out
 
 test_base_with_redis: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"jm1\",\"tester_log_prefix\":\"stage-1\",\"title\":\"Stage #1: Bind to a port\"},{\"slug\":\"rg2\",\"tester_log_prefix\":\"stage-2\",\"title\":\"Stage #2: Respond to PING\"},{\"slug\":\"wy1\",\"tester_log_prefix\":\"stage-3\",\"title\":\"Stage #3: Respond to multiple PINGs\"},{\"slug\":\"zu2\",\"tester_log_prefix\":\"stage-4\",\"title\":\"Stage #4: Handle concurrent clients\"},{\"slug\":\"qq0\",\"tester_log_prefix\":\"stage-5\",\"title\":\"Stage #5: Implement the ECHO command\"},{\"slug\":\"la7\",\"tester_log_prefix\":\"stage-6\",\"title\":\"Stage #6: Implement the SET \u0026 GET commands\"},{\"slug\":\"yz1\",\"tester_log_prefix\":\"stage-7\",\"title\":\"Stage #7: Expiry\"}]" \
 	dist/main.out
 
 test_repl_with_redis: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"bw1\",\"tester_log_prefix\":\"stage-101\",\"title\":\"Stage #101: Replication - Custom Port\"}, {\"slug\":\"ye5\",\"tester_log_prefix\":\"stage-102\",\"title\":\"Stage #102: Replication - Info on Master\"},{\"slug\":\"hc6\",\"tester_log_prefix\":\"stage-103\",\"title\":\"Stage #103: Replication - Info on Replica\"}, {\"slug\":\"xc1\",\"tester_log_prefix\":\"stage-104\",\"title\":\"Stage #104: Replication - Replication ID and Offset\"}, {\"slug\":\"gl7\",\"tester_log_prefix\":\"stage-105\",\"title\":\"Stage #105: Replication - Handshake 1\"},{\"slug\":\"eh4\",\"tester_log_prefix\":\"stage-106\",\"title\":\"Stage #106: Replication - Handshake 2\"},{\"slug\":\"ju6\",\"tester_log_prefix\":\"stage-107\",\"title\":\"Stage #107: Replication - Handshake 3\"},{\"slug\":\"fj0\",\"tester_log_prefix\":\"stage-108\",\"title\":\"Stage #108: Replication - REPLCONF\"},{\"slug\":\"vm3\",\"tester_log_prefix\":\"stage-109\",\"title\":\"Stage #109: Replication - PSYNC\"},{\"slug\":\"cf8\",\"tester_log_prefix\":\"stage-110\",\"title\":\"Stage #110: Replication - PSYNC w RDB file\"},{\"slug\":\"zn8\",\"tester_log_prefix\":\"stage-111\",\"title\":\"Stage #111: Command Propagation\"},{\"slug\":\"hd5\",\"tester_log_prefix\":\"stage-112\",\"title\":\"Stage #112: Command Propagation to multiple Replicas\"},{\"slug\":\"yg4\",\"tester_log_prefix\":\"stage-113\",\"title\":\"Stage #113: Command Processing\"},{\"slug\":\"xv6\",\"tester_log_prefix\":\"stage-114\",\"title\":\"Stage #114: GetAck with 0 offset\"},{\"slug\":\"yd3\",\"tester_log_prefix\":\"stage-115\",\"title\":\"Stage #115: GetAck with non-0 offset\"},{\"slug\":\"my8\",\"tester_log_prefix\":\"stage-116\",\"title\":\"Stage #116: WAIT with 0 replicas\"},{\"slug\":\"tu8\",\"tester_log_prefix\":\"stage-117\",\"title\":\"Stage #117: WAIT with 0 offset\"},{\"slug\":\"na2\",\"tester_log_prefix\":\"stage-118\",\"title\":\"Stage #118: WAIT Command\"}]" \
 	dist/main.out
 
 test_rdb_with_redis: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"zg5\",\"tester_log_prefix\":\"stage-201\",\"title\":\"Stage #1: RDB Config\"}, {\"slug\":\"jz6\",\"tester_log_prefix\":\"stage-202\",\"title\":\"Stage #2: RDB Read Key\"}, {\"slug\":\"gc6\",\"tester_log_prefix\":\"stage-203\",\"title\":\"Stage #3: RDB String Value\"}, {\"slug\":\"jw4\",\"tester_log_prefix\":\"stage-204\",\"title\":\"Stage #4: RDB Read Multiple Keys\"}, {\"slug\":\"dq3\",\"tester_log_prefix\":\"stage-205\",\"title\":\"Stage #5: RDB Read Multiple String Values\"}, {\"slug\":\"sm4\",\"tester_log_prefix\":\"stage-206\",\"title\":\"Stage #6: RDB Read Value With Expiry\"}]" \
 	dist/main.out
 
 test_streams_with_redis: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\": \"cc3\", \"tester_log_prefix\": \"stage-301\", \"title\": \"stage #01: StreamsType\"},{\"slug\": \"cf6\", \"tester_log_prefix\": \"stage-302\", \"title\": \"stage #02: StreamsXadd\"},{\"slug\": \"hq8\", \"tester_log_prefix\": \"stage-303\", \"title\": \"stage #03: StreamsXaddValidateID\"},{\"slug\": \"yh3\", \"tester_log_prefix\": \"stage-304\", \"title\": \"stage #04: StreamsXaddPartialAutoid\"},{\"slug\": \"xu6\", \"tester_log_prefix\": \"stage-305\", \"title\": \"stage #05: StreamsXaddFullAutoid\"},{\"slug\": \"zx1\", \"tester_log_prefix\": \"stage-306\", \"title\": \"stage #06: StreamsXrange\"},{\"slug\": \"yp1\", \"tester_log_prefix\": \"stage-307\", \"title\": \"stage #07: StreamsXrangeMinID\"},{\"slug\": \"fs1\", \"tester_log_prefix\": \"stage-308\", \"title\": \"stage #08: StreamsXrangeMaxID\"},{\"slug\": \"um0\", \"tester_log_prefix\": \"stage-309\", \"title\": \"stage #09: StreamsXread\"},{\"slug\": \"ru9\", \"tester_log_prefix\": \"stage-310\", \"title\": \"stage #10: StreamsXreadMultiple\"},{\"slug\": \"bs1\", \"tester_log_prefix\": \"stage-311\", \"title\": \"stage #11: StreamsXreadBlock\"},{\"slug\": \"hw1\", \"tester_log_prefix\": \"stage-312\", \"title\": \"stage #12: StreamsXreadBlockNoTimeout\"},{\"slug\": \"xu1\", \"tester_log_prefix\": \"stage-313\", \"title\": \"stage #13: StreamsXreadBlockMaxID\"}]"  \
 	dist/main.out
 
 test_txn_with_redis: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"si4\",\"tester_log_prefix\":\"stage-401\",\"title\":\"Stage #401: INCR-1\"},{\"slug\":\"lz8\",\"tester_log_prefix\":\"stage-402\",\"title\":\"Stage #402: INCR-2\"}, {\"slug\":\"mk1\",\"tester_log_prefix\":\"stage-403\",\"title\":\"Stage #403: INCR-3\"}, {\"slug\":\"pn0\",\"tester_log_prefix\":\"stage-404\",\"title\":\"Stage #404: MULTI\"}, {\"slug\":\"lo4\",\"tester_log_prefix\":\"stage-405\",\"title\":\"Stage #405: EXEC\"}, {\"slug\":\"we1\",\"tester_log_prefix\":\"stage-406\",\"title\":\"Stage #406: Empty Transaction\"}, {\"slug\":\"rs9\",\"tester_log_prefix\":\"stage-407\",\"title\":\"Stage #407: Queueing Commands\"}, {\"slug\":\"fy6\",\"tester_log_prefix\":\"stage-408\",\"title\":\"Stage #408: Executing a transaction\"}, {\"slug\":\"rl9\",\"tester_log_prefix\":\"stage-409\",\"title\":\"Stage #409: Discarding a transaction\"}, {\"slug\":\"sg9\",\"tester_log_prefix\":\"stage-410\",\"title\":\"Stage #410: Executing a failed transaction\"}, {\"slug\":\"jf8\",\"tester_log_prefix\":\"stage-411\",\"title\":\"Stage #411: Executing concurrent transactions\"}]" \
 	dist/main.out
 

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -4,7 +4,7 @@ Debug = true
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 70"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-44] [0m[94m$ redis-cli xread block '\x00' streams "pear 0-1"[0m
+[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams "pear 0-1"[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 70"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
@@ -28,7 +28,7 @@ Debug = true
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-1" "temperature 74"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-43] [0m[94m$ redis-cli xread block '\x00' streams "raspberry 0-1"[0m
+[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams "raspberry 0-1"[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-2" "temperature 74"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
@@ -52,7 +52,7 @@ Debug = true
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 30"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 'Ϩ' streams "pear 0-1"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "pear 0-1"[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 30"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
@@ -68,7 +68,7 @@ Debug = true
 [33m[stage-42] [0m[92m    ][0m
 [33m[stage-42] [0m[92m  }[0m
 [33m[stage-42] [0m[92m]"[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 'Ϩ' streams "pear 0-2"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "pear 0-2"[0m
 [33m[stage-42] [0m[92mReceived nil response[0m
 [33m[stage-42] [0m[92mTest passed.[0m
 [33m[stage-42] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -4,7 +4,7 @@ Debug = true
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 70"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams "pear 0-1"[0m
+[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams pear 0-1[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 70"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
@@ -28,7 +28,7 @@ Debug = true
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-1" "temperature 74"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams "raspberry 0-1"[0m
+[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams raspberry 0-1[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-2" "temperature 74"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
@@ -52,7 +52,7 @@ Debug = true
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 30"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "pear 0-1"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams pear 0-1[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 30"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
@@ -68,7 +68,7 @@ Debug = true
 [33m[stage-42] [0m[92m    ][0m
 [33m[stage-42] [0m[92m  }[0m
 [33m[stage-42] [0m[92m]"[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "pear 0-2"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams pear 0-2[0m
 [33m[stage-42] [0m[92mReceived nil response[0m
 [33m[stage-42] [0m[92mTest passed.[0m
 [33m[stage-42] [0m[36mTerminating program[0m
@@ -216,9 +216,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD mango * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1720256572261-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1720256572261-0"[0m
-[33m[stage-36] [0m[92mReceived "1720256572261-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1724055863047-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1724055863047-0"[0m
+[33m[stage-36] [0m[92mReceived "1724055863047-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -335,11 +335,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<\b\x89f\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cb05b0db14573f2e723084a9ee3ac7150ef7a83e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\ak0\xady(["[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc27\x01\xc3f\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(40d4a1b447dde3b526a179b45b7fb3002432bd85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2)doZ\x9b\xee\xb4"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -359,11 +359,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<\b\x89f\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cb05b0db14573f2e723084a9ee3ac7150ef7a83e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\xf4\xcc`\xcb\x1d\\\x02"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc27\x01\xc3f\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(40d4a1b447dde3b526a179b45b7fb3002432bd85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9b<\xf3h\xa26 \x01"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -383,11 +383,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=\b\x89f\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cb05b0db14573f2e723084a9ee3ac7150ef7a83e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.&\fL\xd9c\x9d\xf2"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc27\x01\xc3f\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(40d4a1b447dde3b526a179b45b7fb3002432bd85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa3\x1bk K\xf9\xb7/"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -407,11 +407,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC cb05b0db14573f2e723084a9ee3ac7150ef7a83e 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 40d4a1b447dde3b526a179b45b7fb3002432bd85 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=\b\x89f\xfa\bused-mem\xc2\xf0\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cb05b0db14573f2e723084a9ee3ac7150ef7a83e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xea\x13\x8d;\xcf\x19\x88Z"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc27\x01\xc3f\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(40d4a1b447dde3b526a179b45b7fb3002432bd85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg.\xeaW]\x83\xa2\x87"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -528,7 +528,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2093 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2095 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -554,11 +554,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?\b\x89f\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3baa3caf0594cdce837d87ecb46a6d2d7ffb11be\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\x9f\x89\xb0\xa9\xf0\xaf\xbc"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x01\xc3f\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cec984ba761b6b7cc3429b93e4f81d227020446\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x84\xfcZ\x1c,YA\a"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -578,11 +578,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?\b\x89f\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3baa3caf0594cdce837d87ecb46a6d2d7ffb11be\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffۊ\x1e\xb7Q]a\t"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x01\xc3f\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cec984ba761b6b7cc3429b93e4f81d227020446\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcf\x0f\xfdLJ=5^"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -602,11 +602,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 3baa3caf0594cdce837d87ecb46a6d2d7ffb11be 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 5cec984ba761b6b7cc3429b93e4f81d227020446 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?\b\x89f\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3baa3caf0594cdce837d87ecb46a6d2d7ffb11be\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff㭆\xff\xb8\x92\xf6'"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x01\xc3f\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cec984ba761b6b7cc3429b93e4f81d227020446\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf7(e\x04\xa3\xf2\xa2p"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -810,11 +810,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\b\x89f\xfa\bused-mem\xc2\x00S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ce287ca4892fbdc18ac4c46b0a6f011446be7148\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\xf1:%E\xcd-\xf1"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<\x01\xc3f\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f915e587bcd88a7079959971cf299183c8064e0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffܒ`\n8Gƺ"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -834,11 +834,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\b\x89f\xfa\bused-mem\xc2p:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ce287ca4892fbdc18ac4c46b0a6f011446be7148\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffU<\x02t\xa5;\v\xfa"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<\x01\xc3f\xfa\bused-mem\u0090:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f915e587bcd88a7079959971cf299183c8064e0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffl\xe7\x9e\xfa)\xcdv\xaf"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -858,11 +858,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC ce287ca4892fbdc18ac4c46b0a6f011446be7148 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f915e587bcd88a7079959971cf299183c8064e0c 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\b\x89f\xfa\bused-mem\u0080I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ce287ca4892fbdc18ac4c46b0a6f011446be7148\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff=\x96\x97\x1d\xfd+ʀ"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<\x01\xc3f\xfa\bused-mem\u00a0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f915e587bcd88a7079959971cf299183c8064e0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xf5\xcd2\x80\xa1!\xcb"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -947,11 +947,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 9062054fd54e5593fc7bf42d90368877aeafcdda 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 9062054fd54e5593fc7bf42d90368877aeafcdda 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 9062054fd54e5593fc7bf42d90368877aeafcdda 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 7612da2ea1d0ebdc5f0a77e8ae86a0ed60ad7acc 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 7612da2ea1d0ebdc5f0a77e8ae86a0ed60ad7acc 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 7612da2ea1d0ebdc5f0a77e8ae86a0ed60ad7acc 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2B\b\x89f\xfa\bused-mem\xc2\xc0S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9062054fd54e5593fc7bf42d90368877aeafcdda\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\xef\x13+p-\xc0e"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=\x01\xc3f\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7612da2ea1d0ebdc5f0a77e8ae86a0ed60ad7acc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffXN\xebM\x8c\x8c\xfd\r"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1006,11 +1006,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 91491445d859324704b01da73f4f45218389fa17 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 91491445d859324704b01da73f4f45218389fa17 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 91491445d859324704b01da73f4f45218389fa17 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC e594e4a076378fc6f3f60bb60915964492fcf323 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC e594e4a076378fc6f3f60bb60915964492fcf323 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC e594e4a076378fc6f3f60bb60915964492fcf323 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2B\b\x89f\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(91491445d859324704b01da73f4f45218389fa17\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffu\x91\xbb\xd1\xf1\xeam\x1b"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=\x01\xc3f\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e594e4a076378fc6f3f60bb60915964492fcf323\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffb$\xc8E\x17_{\xc1"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1035,9 +1035,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC bd834f892e35f9f78ff85342946d54f95b9837a9 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC bd834f892e35f9f78ff85342946d54f95b9837a9 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC bd834f892e35f9f78ff85342946d54f95b9837a9 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC cf0b312b1b2cd01f00028678c8a3dae3f20f6430 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC cf0b312b1b2cd01f00028678c8a3dae3f20f6430 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC cf0b312b1b2cd01f00028678c8a3dae3f20f6430 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1136,9 +1136,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:96d430cf73ddbfdf01497767cdc9b24d15484c2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:96d430cf73ddbfdf01497767cdc9b24d15484c2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:96d430cf73ddbfdf01497767cdc9b24d15484c2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6517e86daf14d71ced17879c9885420a14b106db\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6517e86daf14d71ced17879c9885420a14b106db\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6517e86daf14d71ced17879c9885420a14b106db\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:39b4f127e3c09a875cc7e122f91bddf84e902fcc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:39b4f127e3c09a875cc7e122f91bddf84e902fcc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:39b4f127e3c09a875cc7e122f91bddf84e902fcc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a45cf516aee4bd6870ead9f9510966354b75a391\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a45cf516aee4bd6870ead9f9510966354b75a391\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a45cf516aee4bd6870ead9f9510966354b75a391\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1179,7 +1179,7 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles12825401 --dbfilename grape.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles380157410 --dbfilename grape.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -1201,7 +1201,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "banana"="grape", "blueberry"="pear", "apple"="raspberry", "orange"="banana", "mango"="blueberry"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1115490080 --dbfilename strawberry.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles4034198015 --dbfilename strawberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET banana[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1233,19 +1233,19 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
 [33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "strawberry" "apple" "banana" "grape"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2292006195 --dbfilename raspberry.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles89934897 --dbfilename raspberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*5\r\n$5\r\ngrape\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["grape", "strawberry", "banana", "orange", "apple"][0m
-[33m[stage-11] [0m[92mReceived ["grape", "strawberry", "banana", "orange", "apple"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*5\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$5\r\napple\r\n$6\r\norange\r\n$6\r\nbanana\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["strawberry", "grape", "apple", "orange", "banana"][0m
+[33m[stage-11] [0m[92mReceived ["strawberry", "grape", "apple", "orange", "banana"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="pear"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3850008754 --dbfilename pear.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3385911693 --dbfilename pear.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
@@ -1257,7 +1257,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "orange"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1734728862 --dbfilename grape.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2517701214 --dbfilename grape.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\norange\r\n"[0m
@@ -1268,12 +1268,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2216780871 --dbfilename pear.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles852046362 --dbfilename pear.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2216780871\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2216780871"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2216780871"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles852046362\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles852046362"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles852046362"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1285,15 +1285,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 14:33:01.507[0m
-[33m[stage-7] [0m[94mFetching key "pear" at 14:33:01.507 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 13:54:32.457[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 13:54:32.457 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET pear[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[stage-7] [0m[92mReceived "mango"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "pear" at 14:33:01.610 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 13:54:32.560 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET pear[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -371,7 +371,7 @@ Debug = true
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-1" "temperature 10"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-44] [0m[94m$ redis-cli xread block '\x00' streams "apple 0-1"[0m
+[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams "apple 0-1"[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-2" "temperature 10"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
@@ -395,7 +395,7 @@ Debug = true
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-1" "temperature 91"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-43] [0m[94m$ redis-cli xread block '\x00' streams "banana 0-1"[0m
+[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams "banana 0-1"[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-2" "temperature 91"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
@@ -419,7 +419,7 @@ Debug = true
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-1" "temperature 2"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 'Ϩ' streams "orange 0-1"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "orange 0-1"[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-2" "temperature 2"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
@@ -435,7 +435,7 @@ Debug = true
 [33m[stage-42] [0m[92m    ][0m
 [33m[stage-42] [0m[92m  }[0m
 [33m[stage-42] [0m[92m]"[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 'Ϩ' streams "orange 0-2"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "orange 0-2"[0m
 [33m[stage-42] [0m[92mReceived nil response[0m
 [33m[stage-42] [0m[92mTest passed.[0m
 [33m[stage-42] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -371,7 +371,7 @@ Debug = true
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-1" "temperature 10"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams "apple 0-1"[0m
+[33m[stage-44] [0m[94m$ redis-cli xread block 0 streams apple 0-1[0m
 [33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-2" "temperature 10"[0m
 [33m[stage-44] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
@@ -395,7 +395,7 @@ Debug = true
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-1" "temperature 91"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams "banana 0-1"[0m
+[33m[stage-43] [0m[94m$ redis-cli xread block 0 streams banana 0-1[0m
 [33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-2" "temperature 91"[0m
 [33m[stage-43] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
@@ -419,7 +419,7 @@ Debug = true
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-1" "temperature 2"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "orange 0-1"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams orange 0-1[0m
 [33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-2" "temperature 2"[0m
 [33m[stage-42] [0m[92mReceived response: ""0-2""[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
@@ -435,7 +435,7 @@ Debug = true
 [33m[stage-42] [0m[92m    ][0m
 [33m[stage-42] [0m[92m  }[0m
 [33m[stage-42] [0m[92m]"[0m
-[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams "orange 0-2"[0m
+[33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams orange 0-2[0m
 [33m[stage-42] [0m[92mReceived nil response[0m
 [33m[stage-42] [0m[92mTest passed.[0m
 [33m[stage-42] [0m[36mTerminating program[0m
@@ -607,9 +607,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1720256534725-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1720256534725-0"[0m
-[33m[stage-36] [0m[92mReceived "1720256534725-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1724055902759-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1724055902759-0"[0m
+[33m[stage-36] [0m[92mReceived "1724055902759-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -726,11 +726,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\b\x89f\xfa\bused-mem\xc2p\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(081e3292dbb04ce14db68f4059e1190f17cafdc2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\xf4\xce@̬\x1e\x80"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_\x01\xc3f\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(55db050bf6e2ef3d521ca2362a2abc7c45778e98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x05%\x8b\xd3\xf59\xa4["[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -750,11 +750,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\b\x89f\xfa\bused-mem\xc2\x00\xf6\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(081e3292dbb04ce14db68f4059e1190f17cafdc2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffk^\xb56\x9dG\xa5\xbd"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_\x01\xc3f\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(55db050bf6e2ef3d521ca2362a2abc7c45778e98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffN\xd6,\x83\x93]\xd0\x02"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -774,11 +774,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\b\x89f\xfa\bused-mem\xc2\x00A\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(081e3292dbb04ce14db68f4059e1190f17cafdc2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffR\xb6LL>7k&"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_\x01\xc3f\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(55db050bf6e2ef3d521ca2362a2abc7c45778e98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv\xf1\xb4\xcbz\x92G,"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -798,11 +798,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 081e3292dbb04ce14db68f4059e1190f17cafdc2 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 55db050bf6e2ef3d521ca2362a2abc7c45778e98 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\b\x89f\xfa\bused-mem\xc2\x10\x8c\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(081e3292dbb04ce14db68f4059e1190f17cafdc2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfeA\xf85\xa5\xaa\xcdz"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_\x01\xc3f\xfa\bused-mem\xc2\xf0\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(55db050bf6e2ef3d521ca2362a2abc7c45778e98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb2\xc45\xbcl\xe8R\x84"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -919,7 +919,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2004 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2109 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -945,11 +945,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\b\x89f\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\x00\x1b\x16\x19h\x18-"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2b\x01\xc3f\xfa\bused-mem\u0090\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ec8eea77bac0a03c6e5af0e82199dd53f8e675f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff:F|U\xd6G\xa4F"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -969,11 +969,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1a\b\x89f\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x19~²!\xf8\xce="[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2b\x01\xc3f\xfa\bused-mem\xc2 \xf6\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ec8eea77bac0a03c6e5af0e82199dd53f8e675f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffET\xc1\x82vЉe"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -993,11 +993,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1a\b\x89f\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff!YZ\xfa\xc87Y\x13"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2b\x01\xc3f\xfa\bused-mem\xc2 A\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ec8eea77bac0a03c6e5af0e82199dd53f8e675f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff|\xbc8\xf8ՠG\xfe"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -1017,11 +1017,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ec8eea77bac0a03c6e5af0e82199dd53f8e675f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1a\b\x89f\xfa\bused-mem°\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1b173acb9d8b11fa9b8dcd1b9fac7ef4c0dd25a6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe5lۍ\xdeML\xbb"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2b\x01\xc3f\xfa\bused-mem\xc20\x8c\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ec8eea77bac0a03c6e5af0e82199dd53f8e675f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd0K\x8c\x81N=\xe1\xa2"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1230,11 +1230,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\b\x89f\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f20bd15e86d388623439e388299cfc0978f0355a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5\x05;\xbe\v,\xb5\xc6"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2d\x01\xc3f\xfa\bused-mem\xc2\x00S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2981e39d331fdcca0a68c3c59a6e9c9709c963b2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa0\a|\xa5ʹ\x95\xd3"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -1254,11 +1254,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\b\x89f\xfa\bused-mem\xc2\xd0:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f20bd15e86d388623439e388299cfc0978f0355a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x05p\xc5N\x1a\xa6\x05\xd3"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2d\x01\xc3f\xfa\bused-mem\xc2p:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2981e39d331fdcca0a68c3c59a6e9c9709c963b2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]\xcaD\xf4*O\xb3\xd8"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -1278,11 +1278,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC f20bd15e86d388623439e388299cfc0978f0355a 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 2981e39d331fdcca0a68c3c59a6e9c9709c963b2 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\b\x89f\xfa\bused-mem\xc2\xe0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f20bd15e86d388623439e388299cfc0978f0355a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff b\x96\x86\xb3\xcaR\xb7"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2d\x01\xc3f\xfa\bused-mem\u0080I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2981e39d331fdcca0a68c3c59a6e9c9709c963b2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff5`ѝr_r\xa2"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1367,11 +1367,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 2bbb3ee7ede109eaf2d5850b29e563747e38a1f4 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 2bbb3ee7ede109eaf2d5850b29e563747e38a1f4 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 2bbb3ee7ede109eaf2d5850b29e563747e38a1f4 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 63cc898aee8ae70a91177a48121e9262a8e7b741 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 63cc898aee8ae70a91177a48121e9262a8e7b741 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 63cc898aee8ae70a91177a48121e9262a8e7b741 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\b\x89f\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2bbb3ee7ede109eaf2d5850b29e563747e38a1f4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\x8d;\x10\xa6\x15\xff0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2d\x01\xc3f\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(63cc898aee8ae70a91177a48121e9262a8e7b741\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcaϫ\xc7\xf4pY\xf3"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1426,11 +1426,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 47da0391eac86ce5e9988c16fcede2cca06a4aba 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 47da0391eac86ce5e9988c16fcede2cca06a4aba 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 47da0391eac86ce5e9988c16fcede2cca06a4aba 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 31b24d094249429d12af726571081b4b1d8e33f4 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 31b24d094249429d12af726571081b4b1d8e33f4 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 31b24d094249429d12af726571081b4b1d8e33f4 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\b\x89f\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(47da0391eac86ce5e9988c16fcede2cca06a4aba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffc\x92\x97??\xbaV\xfb"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2e\x01\xc3f\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31b24d094249429d12af726571081b4b1d8e33f4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1e\xf1\xe5if\x92IN"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1455,9 +1455,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 0dc770cbe7675f7ec2d921fd8f442cc161043f92 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0dc770cbe7675f7ec2d921fd8f442cc161043f92 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 0dc770cbe7675f7ec2d921fd8f442cc161043f92 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC c6d099029125dd7552d2485d81259f47f7984041 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC c6d099029125dd7552d2485d81259f47f7984041 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC c6d099029125dd7552d2485d81259f47f7984041 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1556,9 +1556,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:47ab6cceb3108a024dc4e6662773fd4a40f688c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:47ab6cceb3108a024dc4e6662773fd4a40f688c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:47ab6cceb3108a024dc4e6662773fd4a40f688c0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2740986c8d83ff2923b749ebfb27154029c5911a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2740986c8d83ff2923b749ebfb27154029c5911a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2740986c8d83ff2923b749ebfb27154029c5911a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1582,9 +1582,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8479b20ad4b4620af30dc9d9a7f343de2d9a35bf\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8479b20ad4b4620af30dc9d9a7f343de2d9a35bf\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8479b20ad4b4620af30dc9d9a7f343de2d9a35bf\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0b11bc99a3ee1966dbc1667a5a4eb42dc953ca74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0b11bc99a3ee1966dbc1667a5a4eb42dc953ca74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0b11bc99a3ee1966dbc1667a5a4eb42dc953ca74\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1599,7 +1599,7 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles323314313 --dbfilename banana.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles51739558 --dbfilename banana.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -1626,7 +1626,7 @@ Debug = true
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
 [33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "pineapple"="raspberry", "banana"="apple", "pear"="banana", "mango"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1521762821 --dbfilename raspberry.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1717426127 --dbfilename raspberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1653,19 +1653,19 @@ Debug = true
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
 [33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["apple" "grape" "mango"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2773625408 --dbfilename pineapple.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles45677214 --dbfilename pineapple.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\ngrape\r\n$5\r\nmango\r\n$5\r\napple\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["grape", "mango", "apple"][0m
-[33m[stage-11] [0m[92mReceived ["grape", "mango", "apple"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\nmango\r\n$5\r\napple\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["mango", "apple", "grape"][0m
+[33m[stage-11] [0m[92mReceived ["mango", "apple", "grape"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
 [33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="banana"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2870581529 --dbfilename grape.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3132212795 --dbfilename grape.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
@@ -1677,7 +1677,7 @@ Debug = true
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
 [33m[stage-9] [0m[94mCreated RDB file with single key: "raspberry"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2099477584 --dbfilename strawberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles4122828369 --dbfilename strawberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
@@ -1688,12 +1688,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles317692431 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1439248652 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles317692431\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles317692431"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles317692431"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1439248652\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1439248652"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1439248652"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1705,15 +1705,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 14:32:23.985[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 14:32:23.985 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 13:55:12.301[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 13:55:12.301 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "strawberry"[0m
 [33m[stage-7] [0m[92mReceived "strawberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 14:32:24.089 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 13:55:12.405 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_streams_xread.go
+++ b/internal/test_streams_xread.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	"github.com/codecrafters-io/tester-utils/logger"
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
@@ -33,7 +34,7 @@ func (t *XREADTest) Run(client *redis.Client, logger *logger.Logger) error {
 			Block:   -1 * time.Millisecond, // Zero value for Block in XReadArgs struct is 0. Need a negative value to indicate no block.
 		}).Result()
 	} else {
-		logger.Infof("$ redis-cli xread block %q streams %q", t.block.Milliseconds(), strings.Join(t.streams, " "))
+		logger.Infof("$ redis-cli xread block %d streams %v", t.block.Milliseconds(), strings.Join(t.streams, " "))
 
 		resp, err = client.XRead(&redis.XReadArgs{
 			Streams: t.streams,

--- a/internal/test_streams_xread_block.go
+++ b/internal/test_streams_xread_block.go
@@ -45,7 +45,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 	done := make(chan bool)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 1000, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams %v", 1000, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err = client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "0-1"},
@@ -111,7 +111,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 		logger.Successf("Received response: \"%v\"", string(respJSON))
 	}
 
-	logger.Infof("$ redis-cli xread block %d streams \"%v\"", 1000, strings.Join([]string{randomKey, "0-2"}, " "))
+	logger.Infof("$ redis-cli xread block %d streams %v", 1000, strings.Join([]string{randomKey, "0-2"}, " "))
 
 	resp, err = client.XRead(&redis.XReadArgs{
 		Streams: []string{randomKey, "0-2"},

--- a/internal/test_streams_xread_block.go
+++ b/internal/test_streams_xread_block.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -44,7 +45,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 	done := make(chan bool)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %q streams %q", 1000, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 1000, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err = client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "0-1"},
@@ -110,7 +111,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 		logger.Successf("Received response: \"%v\"", string(respJSON))
 	}
 
-	logger.Infof("$ redis-cli xread block %q streams %q", 1000, strings.Join([]string{randomKey, "0-2"}, " "))
+	logger.Infof("$ redis-cli xread block %d streams \"%v\"", 1000, strings.Join([]string{randomKey, "0-2"}, " "))
 
 	resp, err = client.XRead(&redis.XReadArgs{
 		Streams: []string{randomKey, "0-2"},

--- a/internal/test_streams_xread_block_max_id.go
+++ b/internal/test_streams_xread_block_max_id.go
@@ -43,7 +43,7 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 	respChan := make(chan *[]redis.XStream, 1)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 0, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams %v", 0, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err := client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "$"},

--- a/internal/test_streams_xread_block_max_id.go
+++ b/internal/test_streams_xread_block_max_id.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -42,7 +43,7 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 	respChan := make(chan *[]redis.XStream, 1)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %q streams %q", 0, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 0, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err := client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "$"},

--- a/internal/test_streams_xread_block_no_timeout.go
+++ b/internal/test_streams_xread_block_no_timeout.go
@@ -43,7 +43,7 @@ func testStreamsXreadBlockNoTimeout(stageHarness *test_case_harness.TestCaseHarn
 	respChan := make(chan *[]redis.XStream, 1)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 0, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams %v", 0, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err := client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "0-1"},

--- a/internal/test_streams_xread_block_no_timeout.go
+++ b/internal/test_streams_xread_block_no_timeout.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -42,7 +43,7 @@ func testStreamsXreadBlockNoTimeout(stageHarness *test_case_harness.TestCaseHarn
 	respChan := make(chan *[]redis.XStream, 1)
 
 	go func() error {
-		logger.Infof("$ redis-cli xread block %q streams %q", 0, strings.Join([]string{randomKey, "0-1"}, " "))
+		logger.Infof("$ redis-cli xread block %d streams \"%v\"", 0, strings.Join([]string{randomKey, "0-1"}, " "))
 
 		resp, err := client.XRead(&redis.XReadArgs{
 			Streams: []string{randomKey, "0-1"},


### PR DESCRIPTION
This pull request refactors the logger.Infof calls in the xread block tests to use formatted strings. This improves code readability and maintainability.