### PR TITLE
Update parameter quoting in Streams extension

### DIFF
--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -2,11 +2,11 @@ Debug = true
 
 [33m[stage-44] [0m[94mRunning tests for Stage #44: xu1[0m
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 70"[0m
-[33m[stage-44] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-44] [0m[94m$ redis-cli xadd pear 0-1 temperature 70[0m
+[33m[stage-44] [0m[92mReceived response: "0-1"[0m
 [33m[stage-44] [0m[94m$ redis-cli xread block 0 streams pear 0-1[0m
-[33m[stage-44] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 70"[0m
-[33m[stage-44] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-44] [0m[94m$ redis-cli xadd pear 0-2 temperature 70[0m
+[33m[stage-44] [0m[92mReceived response: "0-2"[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
 [33m[stage-44] [0m[92m  {[0m
 [33m[stage-44] [0m[92m    "Stream": "pear",[0m
@@ -26,11 +26,11 @@ Debug = true
 
 [33m[stage-43] [0m[94mRunning tests for Stage #43: hw1[0m
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-1" "temperature 74"[0m
-[33m[stage-43] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-43] [0m[94m$ redis-cli xadd raspberry 0-1 temperature 74[0m
+[33m[stage-43] [0m[92mReceived response: "0-1"[0m
 [33m[stage-43] [0m[94m$ redis-cli xread block 0 streams raspberry 0-1[0m
-[33m[stage-43] [0m[94m$ redis-cli xadd "raspberry" "0-2" "temperature 74"[0m
-[33m[stage-43] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-43] [0m[94m$ redis-cli xadd raspberry 0-2 temperature 74[0m
+[33m[stage-43] [0m[92mReceived response: "0-2"[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
 [33m[stage-43] [0m[92m  {[0m
 [33m[stage-43] [0m[92m    "Stream": "raspberry",[0m
@@ -50,11 +50,11 @@ Debug = true
 
 [33m[stage-42] [0m[94mRunning tests for Stage #42: bs1[0m
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-1" "temperature 30"[0m
-[33m[stage-42] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-42] [0m[94m$ redis-cli xadd pear 0-1 temperature 30[0m
+[33m[stage-42] [0m[92mReceived response: "0-1"[0m
 [33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams pear 0-1[0m
-[33m[stage-42] [0m[94m$ redis-cli xadd "pear" "0-2" "temperature 30"[0m
-[33m[stage-42] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-42] [0m[94m$ redis-cli xadd pear 0-2 temperature 30[0m
+[33m[stage-42] [0m[92mReceived response: "0-2"[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
 [33m[stage-42] [0m[92m  {[0m
 [33m[stage-42] [0m[92m    "Stream": "pear",[0m
@@ -76,11 +76,11 @@ Debug = true
 
 [33m[stage-41] [0m[94mRunning tests for Stage #41: ru9[0m
 [33m[stage-41] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-41] [0m[94m$ redis-cli xadd "blueberry" "0-1" "temperature 24"[0m
-[33m[stage-41] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-41] [0m[94m$ redis-cli xadd "banana" "0-2" "humidity 61"[0m
-[33m[stage-41] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-41] [0m[94m$ redis-cli xread streams "blueberry banana 0-0 0-1"[0m
+[33m[stage-41] [0m[94m$ redis-cli xadd blueberry 0-1 temperature 24[0m
+[33m[stage-41] [0m[92mReceived response: "0-1"[0m
+[33m[stage-41] [0m[94m$ redis-cli xadd banana 0-2 humidity 61[0m
+[33m[stage-41] [0m[92mReceived response: "0-2"[0m
+[33m[stage-41] [0m[94m$ redis-cli xread streams blueberry banana 0-0 0-1[0m
 [33m[stage-41] [0m[92mReceived response: "[[0m
 [33m[stage-41] [0m[92m  {[0m
 [33m[stage-41] [0m[92m    "Stream": "blueberry",[0m
@@ -111,9 +111,9 @@ Debug = true
 
 [33m[stage-40] [0m[94mRunning tests for Stage #40: um0[0m
 [33m[stage-40] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-40] [0m[94m$ redis-cli xadd "grape" "0-1" "temperature 54"[0m
-[33m[stage-40] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-40] [0m[94m$ redis-cli xread streams "grape 0-0"[0m
+[33m[stage-40] [0m[94m$ redis-cli xadd grape 0-1 temperature 54[0m
+[33m[stage-40] [0m[92mReceived response: "0-1"[0m
+[33m[stage-40] [0m[94m$ redis-cli xread streams grape 0-0[0m
 [33m[stage-40] [0m[92mReceived response: "[[0m
 [33m[stage-40] [0m[92m  {[0m
 [33m[stage-40] [0m[92m    "Stream": "grape",[0m
@@ -133,13 +133,13 @@ Debug = true
 
 [33m[stage-39] [0m[94mRunning tests for Stage #39: fs1[0m
 [33m[stage-39] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-1" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-2" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-3" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-39] [0m[94m$ redis-cli xrange "apple" 0-2 +[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-1 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-1"[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-2 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-2"[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-3 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-3"[0m
+[33m[stage-39] [0m[94m$ redis-cli xrange apple 0-2 +[0m
 [33m[stage-39] [0m[92mReceived response: "[[0m
 [33m[stage-39] [0m[92m  {[0m
 [33m[stage-39] [0m[92m    "ID": "0-2",[0m
@@ -160,13 +160,13 @@ Debug = true
 
 [33m[stage-38] [0m[94mRunning tests for Stage #38: yp1[0m
 [33m[stage-38] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "banana" "0-1" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "banana" "0-2" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "banana" "0-3" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-38] [0m[94m$ redis-cli xrange "banana" - "0-2"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd banana 0-1 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-1"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd banana 0-2 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-2"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd banana 0-3 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-3"[0m
+[33m[stage-38] [0m[94m$ redis-cli xrange banana - 0-2[0m
 [33m[stage-38] [0m[92mReceived response: "[[0m
 [33m[stage-38] [0m[92m  {[0m
 [33m[stage-38] [0m[92m    "ID": "0-1",[0m
@@ -187,13 +187,13 @@ Debug = true
 
 [33m[stage-37] [0m[94mRunning tests for Stage #37: zx1[0m
 [33m[stage-37] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-1" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-2" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-3" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-37] [0m[94m$ redis-cli xrange "grape" 0-2 "0-3"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-1 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-1"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-2 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-2"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-3 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-3"[0m
+[33m[stage-37] [0m[94m$ redis-cli xrange grape 0-2 0-3[0m
 [33m[stage-37] [0m[92mReceived response: "[[0m
 [33m[stage-37] [0m[92m  {[0m
 [33m[stage-37] [0m[92m    "ID": "0-2",[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -369,11 +369,11 @@ Debug = true
 
 [33m[stage-44] [0m[94mRunning tests for Stage #44: xu1[0m
 [33m[stage-44] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-1" "temperature 10"[0m
-[33m[stage-44] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-44] [0m[94m$ redis-cli xadd apple 0-1 temperature 10[0m
+[33m[stage-44] [0m[92mReceived response: "0-1"[0m
 [33m[stage-44] [0m[94m$ redis-cli xread block 0 streams apple 0-1[0m
-[33m[stage-44] [0m[94m$ redis-cli xadd "apple" "0-2" "temperature 10"[0m
-[33m[stage-44] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-44] [0m[94m$ redis-cli xadd apple 0-2 temperature 10[0m
+[33m[stage-44] [0m[92mReceived response: "0-2"[0m
 [33m[stage-44] [0m[92mReceived response: "[[0m
 [33m[stage-44] [0m[92m  {[0m
 [33m[stage-44] [0m[92m    "Stream": "apple",[0m
@@ -393,11 +393,11 @@ Debug = true
 
 [33m[stage-43] [0m[94mRunning tests for Stage #43: hw1[0m
 [33m[stage-43] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-1" "temperature 91"[0m
-[33m[stage-43] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-43] [0m[94m$ redis-cli xadd banana 0-1 temperature 91[0m
+[33m[stage-43] [0m[92mReceived response: "0-1"[0m
 [33m[stage-43] [0m[94m$ redis-cli xread block 0 streams banana 0-1[0m
-[33m[stage-43] [0m[94m$ redis-cli xadd "banana" "0-2" "temperature 91"[0m
-[33m[stage-43] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-43] [0m[94m$ redis-cli xadd banana 0-2 temperature 91[0m
+[33m[stage-43] [0m[92mReceived response: "0-2"[0m
 [33m[stage-43] [0m[92mReceived response: "[[0m
 [33m[stage-43] [0m[92m  {[0m
 [33m[stage-43] [0m[92m    "Stream": "banana",[0m
@@ -417,11 +417,11 @@ Debug = true
 
 [33m[stage-42] [0m[94mRunning tests for Stage #42: bs1[0m
 [33m[stage-42] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-1" "temperature 2"[0m
-[33m[stage-42] [0m[92mReceived response: ""0-1""[0m
+[33m[stage-42] [0m[94m$ redis-cli xadd orange 0-1 temperature 2[0m
+[33m[stage-42] [0m[92mReceived response: "0-1"[0m
 [33m[stage-42] [0m[94m$ redis-cli xread block 1000 streams orange 0-1[0m
-[33m[stage-42] [0m[94m$ redis-cli xadd "orange" "0-2" "temperature 2"[0m
-[33m[stage-42] [0m[92mReceived response: ""0-2""[0m
+[33m[stage-42] [0m[94m$ redis-cli xadd orange 0-2 temperature 2[0m
+[33m[stage-42] [0m[92mReceived response: "0-2"[0m
 [33m[stage-42] [0m[92mReceived response: "[[0m
 [33m[stage-42] [0m[92m  {[0m
 [33m[stage-42] [0m[92m    "Stream": "orange",[0m
@@ -443,11 +443,11 @@ Debug = true
 
 [33m[stage-41] [0m[94mRunning tests for Stage #41: ru9[0m
 [33m[stage-41] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-41] [0m[94m$ redis-cli xadd "pineapple" "0-1" "temperature 99"[0m
-[33m[stage-41] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-41] [0m[94m$ redis-cli xadd "orange" "0-2" "humidity 37"[0m
-[33m[stage-41] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-41] [0m[94m$ redis-cli xread streams "pineapple orange 0-0 0-1"[0m
+[33m[stage-41] [0m[94m$ redis-cli xadd pineapple 0-1 temperature 99[0m
+[33m[stage-41] [0m[92mReceived response: "0-1"[0m
+[33m[stage-41] [0m[94m$ redis-cli xadd orange 0-2 humidity 37[0m
+[33m[stage-41] [0m[92mReceived response: "0-2"[0m
+[33m[stage-41] [0m[94m$ redis-cli xread streams pineapple orange 0-0 0-1[0m
 [33m[stage-41] [0m[92mReceived response: "[[0m
 [33m[stage-41] [0m[92m  {[0m
 [33m[stage-41] [0m[92m    "Stream": "pineapple",[0m
@@ -478,9 +478,9 @@ Debug = true
 
 [33m[stage-40] [0m[94mRunning tests for Stage #40: um0[0m
 [33m[stage-40] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-40] [0m[94m$ redis-cli xadd "apple" "0-1" "temperature 88"[0m
-[33m[stage-40] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-40] [0m[94m$ redis-cli xread streams "apple 0-0"[0m
+[33m[stage-40] [0m[94m$ redis-cli xadd apple 0-1 temperature 88[0m
+[33m[stage-40] [0m[92mReceived response: "0-1"[0m
+[33m[stage-40] [0m[94m$ redis-cli xread streams apple 0-0[0m
 [33m[stage-40] [0m[92mReceived response: "[[0m
 [33m[stage-40] [0m[92m  {[0m
 [33m[stage-40] [0m[92m    "Stream": "apple",[0m
@@ -500,15 +500,15 @@ Debug = true
 
 [33m[stage-39] [0m[94mRunning tests for Stage #39: fs1[0m
 [33m[stage-39] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-1" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-2" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-3" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-39] [0m[94m$ redis-cli xadd "apple" "0-4" "foo bar"[0m
-[33m[stage-39] [0m[92mReceived response: ""0-4""[0m
-[33m[stage-39] [0m[94m$ redis-cli xrange "apple" 0-2 +[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-1 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-1"[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-2 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-2"[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-3 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-3"[0m
+[33m[stage-39] [0m[94m$ redis-cli xadd apple 0-4 foo bar[0m
+[33m[stage-39] [0m[92mReceived response: "0-4"[0m
+[33m[stage-39] [0m[94m$ redis-cli xrange apple 0-2 +[0m
 [33m[stage-39] [0m[92mReceived response: "[[0m
 [33m[stage-39] [0m[92m  {[0m
 [33m[stage-39] [0m[92m    "ID": "0-2",[0m
@@ -535,15 +535,15 @@ Debug = true
 
 [33m[stage-38] [0m[94mRunning tests for Stage #38: yp1[0m
 [33m[stage-38] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "blueberry" "0-1" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "blueberry" "0-2" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "blueberry" "0-3" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-38] [0m[94m$ redis-cli xadd "blueberry" "0-4" "foo bar"[0m
-[33m[stage-38] [0m[92mReceived response: ""0-4""[0m
-[33m[stage-38] [0m[94m$ redis-cli xrange "blueberry" - "0-3"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd blueberry 0-1 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-1"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd blueberry 0-2 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-2"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd blueberry 0-3 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-3"[0m
+[33m[stage-38] [0m[94m$ redis-cli xadd blueberry 0-4 foo bar[0m
+[33m[stage-38] [0m[92mReceived response: "0-4"[0m
+[33m[stage-38] [0m[94m$ redis-cli xrange blueberry - 0-3[0m
 [33m[stage-38] [0m[92mReceived response: "[[0m
 [33m[stage-38] [0m[92m  {[0m
 [33m[stage-38] [0m[92m    "ID": "0-1",[0m
@@ -570,15 +570,15 @@ Debug = true
 
 [33m[stage-37] [0m[94mRunning tests for Stage #37: zx1[0m
 [33m[stage-37] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-1" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-1""[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-2" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-2""[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-3" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-3""[0m
-[33m[stage-37] [0m[94m$ redis-cli xadd "grape" "0-4" "foo bar"[0m
-[33m[stage-37] [0m[92mReceived response: ""0-4""[0m
-[33m[stage-37] [0m[94m$ redis-cli xrange "grape" 0-2 "0-4"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-1 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-1"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-2 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-2"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-3 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-3"[0m
+[33m[stage-37] [0m[94m$ redis-cli xadd grape 0-4 foo bar[0m
+[33m[stage-37] [0m[92mReceived response: "0-4"[0m
+[33m[stage-37] [0m[94m$ redis-cli xrange grape 0-2 0-4[0m
 [33m[stage-37] [0m[92mReceived response: "[[0m
 [33m[stage-37] [0m[92m  {[0m
 [33m[stage-37] [0m[92m    "ID": "0-2",[0m

--- a/internal/test_streams_xadd.go
+++ b/internal/test_streams_xadd.go
@@ -30,7 +30,7 @@ func (t *XADDTest) Run(client *redis.Client, logger *logger.Logger) error {
 		values = append(values, key, fmt.Sprintf("%v", value))
 	}
 
-	logger.Infof("$ redis-cli xadd %q %q %q", t.streamKey, t.id, strings.Join(values, " "))
+	logger.Infof("$ redis-cli xadd %v %v %v", t.streamKey, t.id, strings.Join(values, " "))
 
 	resp, err := client.XAdd(&redis.XAddArgs{
 		Stream: t.streamKey,
@@ -48,18 +48,18 @@ func (t *XADDTest) Run(client *redis.Client, logger *logger.Logger) error {
 			return fmt.Errorf("Expected %q, got %q", t.expectedError, err.Error())
 		}
 
-		logger.Successf("Received error: \"%q\"", err.Error())
+		logger.Successf("Received error: %q", err.Error())
 		return nil
 	}
 
 	if resp != t.expectedResponse && t.expectedError != "" {
-		logger.Infof("Received response: \"%q\"", resp)
+		logger.Infof("Received response: %q", resp)
 		return fmt.Errorf("Expected an error as the response, got %q", resp)
 	} else if resp != t.expectedResponse {
-		logger.Infof("Received response: \"%q\"", resp)
+		logger.Infof("Received response: %q", resp)
 		return fmt.Errorf("Expected %q, got %q", t.expectedResponse, resp)
 	} else {
-		logger.Successf("Received response: \"%q\"", resp)
+		logger.Successf("Received response: %q", resp)
 	}
 
 	return nil

--- a/internal/test_streams_xrange.go
+++ b/internal/test_streams_xrange.go
@@ -3,9 +3,10 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -55,7 +56,7 @@ func testStreamsXrange(stageHarness *test_case_harness.TestCaseHarness) error {
 	maxID := "0-" + strconv.Itoa(randomNumber)
 	expectedResp = expectedResp[1:]
 
-	logger.Infof("$ redis-cli xrange %q 0-2 %q", randomKey, maxID)
+	logger.Infof("$ redis-cli xrange %v 0-2 %v", randomKey, maxID)
 	resp, err := client.XRange(randomKey, "0-2", maxID).Result()
 
 	if err != nil {

--- a/internal/test_streams_xrange_max_id.go
+++ b/internal/test_streams_xrange_max_id.go
@@ -3,9 +3,10 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -56,7 +57,7 @@ func testStreamsXrangeMaxID(stageHarness *test_case_harness.TestCaseHarness) err
 		})
 	}
 
-	logger.Infof("$ redis-cli xrange %q 0-2 +", randomKey)
+	logger.Infof("$ redis-cli xrange %v 0-2 +", randomKey)
 	resp, err := client.XRange(randomKey, "0-2", "+").Result()
 
 	if err != nil {

--- a/internal/test_streams_xrange_min_id.go
+++ b/internal/test_streams_xrange_min_id.go
@@ -3,9 +3,10 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"reflect"
 	"strconv"
+
+	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -58,7 +59,7 @@ func testStreamsXrangeMinID(stageHarness *test_case_harness.TestCaseHarness) err
 		})
 	}
 
-	logger.Infof("$ redis-cli xrange %q - %q", randomKey, maxID)
+	logger.Infof("$ redis-cli xrange %v - %v", randomKey, maxID)
 	resp, err := client.XRange(randomKey, "-", maxID).Result()
 
 	if err != nil {

--- a/internal/test_streams_xread.go
+++ b/internal/test_streams_xread.go
@@ -27,7 +27,7 @@ func (t *XREADTest) Run(client *redis.Client, logger *logger.Logger) error {
 	var err error
 
 	if t.block == nil {
-		logger.Infof("$ redis-cli xread streams %q", strings.Join(t.streams, " "))
+		logger.Infof("$ redis-cli xread streams %v", strings.Join(t.streams, " "))
 
 		resp, err = client.XRead(&redis.XReadArgs{
 			Streams: t.streams,


### PR DESCRIPTION
This pull request includes several changes to the `internal/test_helpers/fixtures/streams/pass` and `internal/test_helpers/fixtures/transactions/pass` files to correct the syntax of Redis CLI commands and updates to logging format in the `internal/test_streams_xadd.go` and `internal/test_streams_xrange.go` files.

### Syntax Corrections for Redis CLI Commands:

* [`internal/test_helpers/fixtures/streams/pass`](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL5-R9): Modified Redis CLI commands to remove quotes around stream names and IDs. [[1]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL5-R9) [[2]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL29-R33) [[3]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL53-R57) [[4]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL79-R83) [[5]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL114-R116) [[6]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL136-R142) [[7]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL163-R169) [[8]](diffhunk://#diff-14e4044f99adc3a47e99893b8bc61f87ca029ed16e01765bd55e4103f7eba6efL190-R196)
* [`internal/test_helpers/fixtures/transactions/pass`](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL372-R376): Modified Redis CLI commands to remove quotes around stream names and IDs. [[1]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL372-R376) [[2]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL396-R400) [[3]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL420-R424) [[4]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL446-R450) [[5]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL481-R483) [[6]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL503-R511) [[7]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL538-R546) [[8]](diffhunk://#diff-217534054c96d9e91b5c44600bea8a2fdc077abe0375df55566a4f3724ba28dbL573-R581)

### Logging Format Updates:

* [`internal/test_streams_xadd.go`](diffhunk://#diff-fbc32de3830a4d1762af4cd28fa6a21e3f91af333da24a5e7a3713baed780167L33-R33): Updated logging format to remove unnecessary quotes around variables in log messages. [[1]](diffhunk://#diff-fbc32de3830a4d1762af4cd28fa6a21e3f91af333da24a5e7a3713baed780167L33-R33) [[2]](diffhunk://#diff-fbc32de3830a4d1762af4cd28fa6a21e3f91af333da24a5e7a3713baed780167L51-R62)
* [`internal/test_streams_xrange.go`](diffhunk://#diff-cd8f662e2034acae8fb91aeff85427626c5e7dd086d4a62cc87334971aae0bbeL58-R59): Updated logging format to remove unnecessary quotes around variables in log messages.

### Import Order Fixes:

* [`internal/test_streams_xrange.go`](diffhunk://#diff-cd8f662e2034acae8fb91aeff85427626c5e7dd086d4a62cc87334971aae0bbeL6-R10): Fixed the order of import statements.
* [`internal/test_streams_xrange_max_id.go`](diffhunk://#diff-a95e96ea5b8355c0130fa3c516d0df1e2fb0ea54576375022bfa0e7486e4d5a2L6-R10): Fixed the order of import statements.