### PR TITLE
Add version check test for RDB writer

### DIFF
--- a/internal/rdb_file_creator_test.go
+++ b/internal/rdb_file_creator_test.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	testerutils_random "github.com/codecrafters-io/tester-utils/random"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRDBFileCreator(t *testing.T) {
+	RDBFileCreator, err := NewRDBFileCreator()
+	if err != nil {
+		t.Fatalf("CodeCrafters Tester Error: %s", err)
+	}
+
+	randomKeyAndValue := testerutils_random.RandomWords(2)
+	randomKey, randomValue := randomKeyAndValue[0], randomKeyAndValue[1]
+
+	if err := RDBFileCreator.Write([]KeyValuePair{{key: randomKey, value: randomValue}}); err != nil {
+		t.Fatalf("CodeCrafters Tester Error: %s", err)
+	}
+
+	fh, _ := os.Open(filepath.Join(RDBFileCreator.Dir, RDBFileCreator.Filename))
+	defer fh.Close()
+	fmt.Println("File content:")
+	data, err := io.ReadAll(fh)
+	if err != nil {
+		t.Fatalf("CodeCrafters Tester Error: %s", err)
+	}
+
+	versionData := string(data[:9])
+	magicString := versionData[0:5]
+	version := versionData[5:9]
+	assert.Equal(t, "REDIS", magicString)
+	assert.Equal(t, "0011", version)
+	t.Logf("Version: %s", version)
+}


### PR DESCRIPTION
This pull request adds a version check for the RDB writer. It includes a new test case that verifies the version of the RDB file created by the writer. The test ensures that the magic string is "REDIS" and the version is "0011". This check helps to ensure the correctness of the RDB writer implementation.