### PR TITLE
Add HexDump logging for RDB files

### DIFF
--- a/internal/rdb_file_creator.go
+++ b/internal/rdb_file_creator.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/codecrafters-io/tester-utils/logger"
 	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 
@@ -98,5 +99,22 @@ func (r *RDBFileCreator) Write(keyValuePairs []KeyValuePair) error {
 		return err
 	}
 
+	return nil
+}
+
+func (r *RDBFileCreator) Contents() ([]byte, error) {
+	contents, err := os.ReadFile(filepath.Join(r.Dir, r.Filename))
+	if err != nil {
+		return nil, err
+	}
+	return contents, nil
+}
+
+func (r *RDBFileCreator) PrintContentHexdump(logger *logger.Logger) error {
+	contents, err := r.Contents()
+	if err != nil {
+		return err
+	}
+	logger.Debugf("Hexdump of RDB file contents: \n%v\n", GetFormattedHexdump(contents))
 	return nil
 }

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -115,6 +115,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"rdb_bytes":               {regexp.MustCompile(`"\$[0-9]+\\r\\nREDIS.*"`)},
 		"info_replication_bytes":  {regexp.MustCompile(`"\$[0-9]+\\r\\n# Replication\\r\\n[^"]+"`)},
 		"rdb_keys":                {regexp.MustCompile(`\[stage-11\] .*Received .*`)},
+		"hexdump":                 {regexp.MustCompile(`[0-9a-fA-F]{4} \| [0-9a-fA-F ]{47} \| .{0,16}`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -1,7 +1,21 @@
 Debug = true
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2910760570 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94mCreated RDB file with 3 key-value pairs: {"orange": "strawberry", "mango": "apple", "pineapple": "blueberry"}[0m
+[33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
+[33m[stage-13] [0m[36m0030 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 0a 73 | (.......orange.s[0m
+[33m[stage-13] [0m[36m0040 | 74 72 61 77 62 65 72 72 79 fc 00 9c ef 12 7e 01 | trawberry.....~.[0m
+[33m[stage-13] [0m[36m0050 | 00 00 00 05 6d 61 6e 67 6f 05 61 70 70 6c 65 fc | ....mango.apple.[0m
+[33m[stage-13] [0m[36m0060 | 00 0c 28 8a c7 01 00 00 00 09 70 69 6e 65 61 70 | ..(.......pineap[0m
+[33m[stage-13] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff 34 d0 | ple.blueberry.4.[0m
+[33m[stage-13] [0m[36m0080 | 8c 58 51 4a 5d 62 0a                            | .XQJ]b.[0m
+[33m[stage-13] [0m[36m[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles444689312 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -22,8 +36,21 @@ Debug = true
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "grape"="pineapple", "apple"="raspberry", "banana"="apple", "mango"="orange", "orange"="pear"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2724103995 --dbfilename raspberry.rdb[0m
+[33m[stage-12] [0m[94mCreated RDB file with 5 key-value pairs: {"grape": "pineapple", "apple": "raspberry", "banana": "apple", "mango": "orange", "orange": "pear"}[0m
+[33m[stage-12] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-12] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-12] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-12] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-12] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 05 67 | s-bits.@.......g[0m
+[33m[stage-12] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 00 05 | rape.pineapple..[0m
+[33m[stage-12] [0m[36m0040 | 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 00 | apple.raspberry.[0m
+[33m[stage-12] [0m[36m0050 | 06 62 61 6e 61 6e 61 05 61 70 70 6c 65 00 05 6d | .banana.apple..m[0m
+[33m[stage-12] [0m[36m0060 | 61 6e 67 6f 06 6f 72 61 6e 67 65 00 06 6f 72 61 | ango.orange..ora[0m
+[33m[stage-12] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff 33 20 d4 0d 23 b2 9b | nge.pear.3 ..#..[0m
+[33m[stage-12] [0m[36m0080 | af 0a                                           | ..[0m
+[33m[stage-12] [0m[36m[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3255364286 --dbfilename raspberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -54,20 +81,40 @@ Debug = true
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["banana" "apple" "blueberry"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2441645913 --dbfilename blueberry.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["banana", "apple", "blueberry"][0m
+[33m[stage-11] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-11] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-11] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-11] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-11] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-11] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 06 62 | s-bits.@.......b[0m
+[33m[stage-11] [0m[36m0030 | 61 6e 61 6e 61 09 70 69 6e 65 61 70 70 6c 65 00 | anana.pineapple.[0m
+[33m[stage-11] [0m[36m0040 | 05 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 | .apple.raspberry[0m
+[33m[stage-11] [0m[36m0050 | 00 09 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 | ..blueberry.pear[0m
+[33m[stage-11] [0m[36m0060 | ff 5c f3 42 ee 46 08 a6 3f 0a                   | .\.B.F..?.[0m
+[33m[stage-11] [0m[36m[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2441884045 --dbfilename blueberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$5\r\napple\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["banana", "blueberry", "apple"][0m
-[33m[stage-11] [0m[92mReceived ["banana", "blueberry", "apple"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["banana", "apple", "blueberry"][0m
+[33m[stage-11] [0m[92mReceived ["banana", "apple", "blueberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: grape="pineapple"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3729886679 --dbfilename orange.rdb[0m
+[33m[stage-10] [0m[94mCreated RDB file with a single key-value pair: {"grape": "pineapple"}[0m
+[33m[stage-10] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-10] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-10] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-10] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-10] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
+[33m[stage-10] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 ff 12 | rape.pineapple..[0m
+[33m[stage-10] [0m[36m0040 | 7d 54 51 cd 7a 5c 8d 0a                         | }TQ.z\..[0m
+[33m[stage-10] [0m[36m[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3226033919 --dbfilename orange.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -78,8 +125,17 @@ Debug = true
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
-[33m[stage-9] [0m[94mCreated RDB file with single key: "mango"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3049301350 --dbfilename pear.rdb[0m
+[33m[stage-9] [0m[94mCreated RDB file with a single key: ["mango"][0m
+[33m[stage-9] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-9] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-9] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-9] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-9] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-9] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 6d | s-bits.@.......m[0m
+[33m[stage-9] [0m[36m0030 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 ff 0c | ango.pineapple..[0m
+[33m[stage-9] [0m[36m0040 | 1b cb 91 b2 ed f6 19 0a                         | ........[0m
+[33m[stage-9] [0m[36m[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1527538990 --dbfilename pear.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -90,12 +146,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles778895138 --dbfilename blueberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2714192117 --dbfilename blueberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles778895138\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles778895138"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles778895138"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2714192117\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2714192117"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2714192117"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -107,15 +163,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 16:13:08.183[0m
-[33m[stage-7] [0m[94mFetching key "strawberry" at 16:13:08.183 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 16:31:40.207[0m
+[33m[stage-7] [0m[94mFetching key "strawberry" at 16:31:40.207 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET strawberry[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "pear"[0m
 [33m[stage-7] [0m[92mReceived "pear"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "strawberry" at 16:13:08.286 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "strawberry" at 16:31:40.311 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET strawberry[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -21,11 +21,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>\xea\x10g\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ec6088d709101d477f58a3c2550306004a7d71f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]<\xa22yT\x92\x9e"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05o\x1fg\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffUd\x1fn\xca,\x93y"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -45,11 +45,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>\xea\x10g\xfa\bused-mem\xc2\xe0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ec6088d709101d477f58a3c2550306004a7d71f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16\xcf\x05b\x1f0\xe6\xc7"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05o\x1fg\xfa\bused-mem\u00a0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1e\x97\xb8>\xacH\xe7 "[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -69,11 +69,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>\xea\x10g\xfa\bused-mem\xc2\xe0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ec6088d709101d477f58a3c2550306004a7d71f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.\xe8\x9d*\xf6\xffq\xe9"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05o\x1fg\xfa\bused-mem\u00a0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\xb0 vE\x87p\x0e"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -93,11 +93,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ec6088d709101d477f58a3c2550306004a7d71f5 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>\xea\x10g\xfa\bused-mem\xc2\xf0\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ec6088d709101d477f58a3c2550306004a7d71f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xea\xdd\x1c]\xe0\x85dA"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05o\x1fg\xfa\bused-mem°\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d1f9ee5fbfef72570f6ec6625c1b90c1f8bf87d1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffⅡ\x01S\xfde\xa6"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2108 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2102 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -240,11 +240,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2@\xea\x10g\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\xcdta\x1f\xb3\x19\xcb"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\x03\xcc|\xfa\xa3\x8b\xbf"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -264,11 +264,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2@\xea\x10g\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16\xd8\xe3f\xe7\x1e\xd7~"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16\x16[{\x02\x0eE\n"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -288,11 +288,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2@\xea\x10g\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.\xff{.\x0e\xd1@P"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.1\xc33\xeb\xc1\xd2$"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -312,11 +312,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\xea\x10g\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f?\xa2=\xe3\x1a\x03&"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xea\x04BD\xfd\xbbǌ"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 5[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: $ redis-cli PING[0m
@@ -336,11 +336,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-5: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\xea\x10g\xfa\bused-mem\xc2\xe0\xd6\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1e\xb8\xe3\xd0֪\xd3l"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2\xe0\xd6\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeb\x83\x03\xa9\xc8\v\x17\xc6"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 6[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: $ redis-cli PING[0m
@@ -360,11 +360,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-6: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\xea\x10g\xfa\bused-mem\xc2\xe0!\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\xc2C\vv\xf4\x83l"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2\xe0!\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\xf9\xa3rhUG\xc6"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 7[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: $ redis-cli PING[0m
@@ -384,11 +384,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-7: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 15fa45ba688e28fc342d3023b9b7a8695824c43d 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ceb138d3d19a154d7b75162d32410f6a82ff0e63 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2A\xea\x10g\xfa\bused-mem\xc2\xf0l\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(15fa45ba688e28fc342d3023b9b7a8695824c43d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff͐]d\xc3e\xfe|"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\bo\x1fg\xfa\bused-mem\xc2\xf0l\x14\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ceb138d3d19a154d7b75162d32410f6a82ff0e63\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\xab\xbd\x1d\xdd\xc4:\xd6"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -597,11 +597,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2B\xea\x10g\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffJ\xcf؋@\x7f\"\xe7"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\no\x1fg\xfa\bused-mem\xc2\x00S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(984adf0e4026b56d6e3a8d4a0422217beb818605\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\xcb\x16\x01\x0e\x9a\xa8\x93"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -621,11 +621,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2B\xea\x10g\xfa\bused-mem°:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\\\x16,\xcf<(\x1e"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\no\x1fg\xfa\bused-mem\xc2p:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(984adf0e4026b56d6e3a8d4a0422217beb818605\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2\x06.P\xeel\x8e\x98"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -645,11 +645,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 984adf0e4026b56d6e3a8d4a0422217beb818605 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2B\xea\x10g\xfa\bused-mem\xc2\xc0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7a3a3254f687f1eb4c97c2f8a3a3d2296d604a35\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffߨu\xb3\xf8\x99Ŗ"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\no\x1fg\xfa\bused-mem\u0080I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(984adf0e4026b56d6e3a8d4a0422217beb818605\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8a\xac\xbb9\xb6|O\xe2"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -734,11 +734,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 09eea84493aa13e24ed2469f6dc155a5aad80e49 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 09eea84493aa13e24ed2469f6dc155a5aad80e49 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 09eea84493aa13e24ed2469f6dc155a5aad80e49 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC cb3f5dd2b57952a9dcf3204ab6e9e842b2ca5857 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC cb3f5dd2b57952a9dcf3204ab6e9e842b2ca5857 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC cb3f5dd2b57952a9dcf3204ab6e9e842b2ca5857 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2C\xea\x10g\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(09eea84493aa13e24ed2469f6dc155a5aad80e49\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffH\x84\xd0?\x85\xd2,-"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\no\x1fg\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cb3f5dd2b57952a9dcf3204ab6e9e842b2ca5857\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\bvȢ\x82\xc3Ӽ"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -793,11 +793,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 8b0c5b993a6a674443fe5eb84d00ed6a1fb9642f 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8b0c5b993a6a674443fe5eb84d00ed6a1fb9642f 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 8b0c5b993a6a674443fe5eb84d00ed6a1fb9642f 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 7506970034707f15207c790ce091a8bfebd87961 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 7506970034707f15207c790ce091a8bfebd87961 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 7506970034707f15207c790ce091a8bfebd87961 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2C\xea\x10g\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b0c5b993a6a674443fe5eb84d00ed6a1fb9642f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xccBk\x9e\x84\x1c\xa4\xde"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\vo\x1fg\xfa\bused-mem\u0090\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7506970034707f15207c790ce091a8bfebd87961\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\f'\xd2\xd4}\f\r\xe1"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -822,9 +822,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC fdfcbfedb6c79c50352f2f84535148d2eb0f2fae 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC fdfcbfedb6c79c50352f2f84535148d2eb0f2fae 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC fdfcbfedb6c79c50352f2f84535148d2eb0f2fae 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 2ff64fb105fb3baffc433a4b612306214012c78b 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2ff64fb105fb3baffc433a4b612306214012c78b 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 2ff64fb105fb3baffc433a4b612306214012c78b 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -923,9 +923,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c43634e9287597d2810e07f038d131722d623724\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c43634e9287597d2810e07f038d131722d623724\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c43634e9287597d2810e07f038d131722d623724\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe8b7e591f4b37c11f29e812809a455ce7fc50d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe8b7e591f4b37c11f29e812809a455ce7fc50d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe8b7e591f4b37c11f29e812809a455ce7fc50d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -949,9 +949,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:b6a4df638616232d608dcc296aad93f38640049a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:b6a4df638616232d608dcc296aad93f38640049a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:b6a4df638616232d608dcc296aad93f38640049a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e43d04c9962b616b39c7ff0edc7f5557f410e78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e43d04c9962b616b39c7ff0edc7f5557f410e78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e43d04c9962b616b39c7ff0edc7f5557f410e78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -966,7 +966,21 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3394000067 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94mCreated RDB file with 3 key-value pairs: {"blueberry": "blueberry", "raspberry": "mango", "pineapple": "banana"}[0m
+[33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
+[33m[stage-13] [0m[36m0030 | 28 8a c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 | (.......blueberr[0m
+[33m[stage-13] [0m[36m0040 | 79 09 62 6c 75 65 62 65 72 72 79 fc 00 9c ef 12 | y.blueberry.....[0m
+[33m[stage-13] [0m[36m0050 | 7e 01 00 00 00 09 72 61 73 70 62 65 72 72 79 05 | ~.....raspberry.[0m
+[33m[stage-13] [0m[36m0060 | 6d 61 6e 67 6f fc 00 0c 28 8a c7 01 00 00 00 09 | mango...(.......[0m
+[33m[stage-13] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
+[33m[stage-13] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed 0a                   | ..BMI.;{..[0m
+[33m[stage-13] [0m[36m[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3128804725 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
@@ -987,8 +1001,21 @@ Debug = true
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "grape"="mango", "orange"="banana", "blueberry"="orange", "pear"="grape", "banana"="blueberry"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2890679229 --dbfilename mango.rdb[0m
+[33m[stage-12] [0m[94mCreated RDB file with 5 key-value pairs: {"grape": "mango", "orange": "banana", "blueberry": "orange", "pear": "grape", "banana": "blueberry"}[0m
+[33m[stage-12] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-12] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-12] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-12] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[stage-12] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 05 67 | er.7.2.0.......g[0m
+[33m[stage-12] [0m[36m0030 | 72 61 70 65 05 6d 61 6e 67 6f 00 06 6f 72 61 6e | rape.mango..oran[0m
+[33m[stage-12] [0m[36m0040 | 67 65 06 62 61 6e 61 6e 61 00 09 62 6c 75 65 62 | ge.banana..blueb[0m
+[33m[stage-12] [0m[36m0050 | 65 72 72 79 06 6f 72 61 6e 67 65 00 04 70 65 61 | erry.orange..pea[0m
+[33m[stage-12] [0m[36m0060 | 72 05 67 72 61 70 65 00 06 62 61 6e 61 6e 61 09 | r.grape..banana.[0m
+[33m[stage-12] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 53 3c eb fb 3b 60 | blueberry.S<..;`[0m
+[33m[stage-12] [0m[36m0080 | 00 5c 0a                                        | .\.[0m
+[33m[stage-12] [0m[36m[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1294549396 --dbfilename mango.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1019,20 +1046,41 @@ Debug = true
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 4 keys: ["raspberry" "blueberry" "apple" "orange"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles231193722 --dbfilename grape.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 4 keys: ["raspberry", "blueberry", "apple", "orange"][0m
+[33m[stage-11] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-11] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-11] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-11] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-11] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-11] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 72 | s-bits.@.......r[0m
+[33m[stage-11] [0m[36m0030 | 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 65 | aspberry.strawbe[0m
+[33m[stage-11] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 06 6f | rry..blueberry.o[0m
+[33m[stage-11] [0m[36m0050 | 72 61 6e 67 65 00 05 61 70 70 6c 65 05 6d 61 6e | range..apple.man[0m
+[33m[stage-11] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
+[33m[stage-11] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d 0a                   | .:..r.,.=.[0m
+[33m[stage-11] [0m[36m[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2816263476 --dbfilename grape.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "raspberry", "orange", "blueberry"][0m
-[33m[stage-11] [0m[92mReceived ["apple", "raspberry", "orange", "blueberry"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["orange", "apple", "blueberry", "raspberry"][0m
+[33m[stage-11] [0m[92mReceived ["orange", "apple", "blueberry", "raspberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: blueberry="raspberry"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles695493230 --dbfilename strawberry.rdb[0m
+[33m[stage-10] [0m[94mCreated RDB file with a single key-value pair: {"blueberry": "raspberry"}[0m
+[33m[stage-10] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-10] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-10] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-10] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-10] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 62 | s-bits.@.......b[0m
+[33m[stage-10] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
+[33m[stage-10] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7 0a             | ry..2h(,.&..[0m
+[33m[stage-10] [0m[36m[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3366981985 --dbfilename strawberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1043,8 +1091,17 @@ Debug = true
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
-[33m[stage-9] [0m[94mCreated RDB file with single key: "grape"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2630444704 --dbfilename orange.rdb[0m
+[33m[stage-9] [0m[94mCreated RDB file with a single key: ["grape"][0m
+[33m[stage-9] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-9] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-9] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-9] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-9] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-9] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
+[33m[stage-9] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
+[33m[stage-9] [0m[36m0040 | 6b 9a 0a                                        | k..[0m
+[33m[stage-9] [0m[36m[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles872001605 --dbfilename orange.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1055,12 +1112,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1396385253 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1433393649 --dbfilename raspberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1396385253\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1396385253"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1396385253"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1433393649\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1433393649"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1433393649"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1072,15 +1129,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 16:13:18.700[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 16:13:18.700 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 16:31:34.277[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 16:31:34.277 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[stage-7] [0m[92mReceived "orange"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 16:13:18.802 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 16:31:34.380 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -216,9 +216,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD mango * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1729161750468-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1729161750468-0"[0m
-[33m[stage-36] [0m[92mReceived "1729161750468-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1730113307012-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1730113307012-0"[0m
+[33m[stage-36] [0m[92mReceived "1730113307012-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -335,11 +335,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xea\x10g\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(497cc54864e9770e7d139c9acd1b46bc5cef6ced\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\xd3˕X~x\r"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1bo\x1fg\xfa\bused-mem\xc2\xd0\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad6c11e69888e18b30918460d6219bc70d738b70\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'P\x95\xff\x80\xc2\x0f\xaf"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -359,11 +359,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xea\x10g\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(497cc54864e9770e7d139c9acd1b46bc5cef6ced\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaa\xc6\\\x92\xa0Ӷ\xb8"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1bo\x1fg\xfa\bused-mem\xc2`\xf6\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad6c11e69888e18b30918460d6219bc70d738b70\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffXB(( U\"\x8c"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -383,11 +383,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xea\x10g\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(497cc54864e9770e7d139c9acd1b46bc5cef6ced\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x92\xe1\xc4\xdaI\x1c!\x96"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1bo\x1fg\xfa\bused-mem\xc2`A\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad6c11e69888e18b30918460d6219bc70d738b70\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\xaa\xd1R\x83%\xec\x17"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -407,11 +407,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 497cc54864e9770e7d139c9acd1b46bc5cef6ced 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC ad6c11e69888e18b30918460d6219bc70d738b70 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xea\x10g\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(497cc54864e9770e7d139c9acd1b46bc5cef6ced\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffV\xd4E\xad_f4>"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1bo\x1fg\xfa\bused-mem\xc2p\x8c\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad6c11e69888e18b30918460d6219bc70d738b70\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcd]e+\x18\xb8JK"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -528,7 +528,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2108 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2092 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -554,11 +554,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xea\x10g\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcc\xf9\xc3\xd6G\xad\xa9N"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1eo\x1fg\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6b5be3d2bb55b35481406075a4db5b44df8f1283\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\xf6K\xe4\"`;\xac"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -578,11 +578,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xea\x10g\xfa\bused-mem\u0080\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfeS\xb8\xa0\x16F\x12s"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1eo\x1fg\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6b5be3d2bb55b35481406075a4db5b44df8f1283\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xe3\xdc\xe3\xda\xcd\xf5\x19"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -602,11 +602,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 6b5be3d2bb55b35481406075a4db5b44df8f1283 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xea\x10g\xfa\bused-mem\u0080@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ecbba0b15916e4c70bdf3ca5e7a6744b995bc17f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6t \xe8\xff\x89\x85]"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1eo\x1fg\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6b5be3d2bb55b35481406075a4db5b44df8f1283\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffq\xc4D\xab3\x02b7"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -810,11 +810,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xea\x10g\xfa\bused-mem\xc2 S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a01cd6316f0c73e39a29bc32a22bd42098a009e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0\r\xf9\x90\b\xa4\xd3\r"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2 o\x1fg\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(869ef66b9f765e08fbb5408857559f9036e27197\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffl\x10\xfb\xdf9\xa8i\xd0"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -834,11 +834,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xea\x10g\xfa\bused-mem\u0090:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a01cd6316f0c73e39a29bc32a22bd42098a009e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffpx\a`\x19.c\x18"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2 o\x1fg\xfa\bused-mem°:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(869ef66b9f765e08fbb5408857559f9036e27197\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\x835x\xb6\xebc)"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -858,11 +858,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC a01cd6316f0c73e39a29bc32a22bd42098a009e7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 869ef66b9f765e08fbb5408857559f9036e27197 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xea\x10g\xfa\bused-mem\u00a0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a01cd6316f0c73e39a29bc32a22bd42098a009e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffUjT\xa8\xb0B4|"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2 o\x1fg\xfa\bused-mem\xc2\xc0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(869ef66b9f765e08fbb5408857559f9036e27197\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9wV\xe7\x81N\x8e\xa1"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -947,11 +947,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 5185d96340172951e8b692f99fccf61417f6fe4d 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 5185d96340172951e8b692f99fccf61417f6fe4d 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 5185d96340172951e8b692f99fccf61417f6fe4d 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC e1f414d64033f41ae2e9c7056a8daa449cefd7e5 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC e1f414d64033f41ae2e9c7056a8daa449cefd7e5 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC e1f414d64033f41ae2e9c7056a8daa449cefd7e5 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xea\x10g\xfa\bused-mem\u0080S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5185d96340172951e8b692f99fccf61417f6fe4d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffW~\x04\xcdB9\xc6\xc9"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2 o\x1fg\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e1f414d64033f41ae2e9c7056a8daa449cefd7e5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaf\xbcT\xe7\x9bG]L"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1006,11 +1006,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC af0b2564e3c12421db8e26da96761144cfa6ca74 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC af0b2564e3c12421db8e26da96761144cfa6ca74 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC af0b2564e3c12421db8e26da96761144cfa6ca74 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC b57a6e53d681c762e48b4dcae7e4b6e2f7bcb953 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC b57a6e53d681c762e48b4dcae7e4b6e2f7bcb953 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC b57a6e53d681c762e48b4dcae7e4b6e2f7bcb953 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xea\x10g\xfa\bused-mem\xc2\x10\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(af0b2564e3c12421db8e26da96761144cfa6ca74\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab\xe5\xbd\xe1\x99\xf2\xa9\xab"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2!o\x1fg\xfa\bused-mem\xc2P\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b57a6e53d681c762e48b4dcae7e4b6e2f7bcb953\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\x1e\xc3\x11\xb6YC\xab"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1035,9 +1035,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 88fcde615839c911c5a990b8cb7e4cc36c685493 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 88fcde615839c911c5a990b8cb7e4cc36c685493 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 88fcde615839c911c5a990b8cb7e4cc36c685493 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 3632ce506a5789830a0f11ad1eb68bf22e9c9c82 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3632ce506a5789830a0f11ad1eb68bf22e9c9c82 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 3632ce506a5789830a0f11ad1eb68bf22e9c9c82 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1136,9 +1136,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f16530424ecbf3c0a9b9e852f2bf12a6b8845d78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f16530424ecbf3c0a9b9e852f2bf12a6b8845d78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f16530424ecbf3c0a9b9e852f2bf12a6b8845d78\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d7e26c2e0e9282cce0da357b8d26ec3ce2dfa884\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d7e26c2e0e9282cce0da357b8d26ec3ce2dfa884\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d7e26c2e0e9282cce0da357b8d26ec3ce2dfa884\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:14801453d4818c00a183a9c5c59b0f56931a348e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:14801453d4818c00a183a9c5c59b0f56931a348e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:14801453d4818c00a183a9c5c59b0f56931a348e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:efde794870dd0f1a1b25c0dad0ea1f199edc3d62\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:efde794870dd0f1a1b25c0dad0ea1f199edc3d62\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:efde794870dd0f1a1b25c0dad0ea1f199edc3d62\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1179,7 +1179,21 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1448016355 --dbfilename grape.rdb[0m
+[33m[stage-13] [0m[94mCreated RDB file with 3 key-value pairs: {"raspberry": "pineapple", "orange": "pear", "apple": "raspberry"}[0m
+[33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
+[33m[stage-13] [0m[36m0030 | 28 8a c7 01 00 00 00 09 72 61 73 70 62 65 72 72 | (.......raspberr[0m
+[33m[stage-13] [0m[36m0040 | 79 09 70 69 6e 65 61 70 70 6c 65 fc 00 9c ef 12 | y.pineapple.....[0m
+[33m[stage-13] [0m[36m0050 | 7e 01 00 00 00 06 6f 72 61 6e 67 65 04 70 65 61 | ~.....orange.pea[0m
+[33m[stage-13] [0m[36m0060 | 72 fc 00 0c 28 8a c7 01 00 00 00 05 61 70 70 6c | r...(.......appl[0m
+[33m[stage-13] [0m[36m0070 | 65 09 72 61 73 70 62 65 72 72 79 ff f7 d4 d3 00 | e.raspberry.....[0m
+[33m[stage-13] [0m[36m0080 | ab 58 b4 13 0a                                  | .X...[0m
+[33m[stage-13] [0m[36m[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3293649888 --dbfilename grape.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -1200,8 +1214,21 @@ Debug = true
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "banana"="grape", "blueberry"="pear", "apple"="raspberry", "orange"="banana", "mango"="blueberry"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1979481671 --dbfilename strawberry.rdb[0m
+[33m[stage-12] [0m[94mCreated RDB file with 5 key-value pairs: {"banana": "grape", "blueberry": "pear", "apple": "raspberry", "orange": "banana", "mango": "blueberry"}[0m
+[33m[stage-12] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-12] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-12] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-12] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-12] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 06 62 | s-bits.@.......b[0m
+[33m[stage-12] [0m[36m0030 | 61 6e 61 6e 61 05 67 72 61 70 65 00 09 62 6c 75 | anana.grape..blu[0m
+[33m[stage-12] [0m[36m0040 | 65 62 65 72 72 79 04 70 65 61 72 00 05 61 70 70 | eberry.pear..app[0m
+[33m[stage-12] [0m[36m0050 | 6c 65 09 72 61 73 70 62 65 72 72 79 00 06 6f 72 | le.raspberry..or[0m
+[33m[stage-12] [0m[36m0060 | 61 6e 67 65 06 62 61 6e 61 6e 61 00 05 6d 61 6e | ange.banana..man[0m
+[33m[stage-12] [0m[36m0070 | 67 6f 09 62 6c 75 65 62 65 72 72 79 ff af 60 d1 | go.blueberry..`.[0m
+[33m[stage-12] [0m[36m0080 | 2f 14 70 b8 8d 0a                               | /.p...[0m
+[33m[stage-12] [0m[36m[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1165685106 --dbfilename strawberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET banana[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1232,20 +1259,42 @@ Debug = true
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange" "strawberry" "apple" "banana" "grape"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles929339575 --dbfilename raspberry.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 5 keys: ["orange", "strawberry", "apple", "banana", "grape"][0m
+[33m[stage-11] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-11] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-11] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-11] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-11] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-11] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 06 6f | s-bits.@.......o[0m
+[33m[stage-11] [0m[36m0030 | 72 61 6e 67 65 05 6d 61 6e 67 6f 00 0a 73 74 72 | range.mango..str[0m
+[33m[stage-11] [0m[36m0040 | 61 77 62 65 72 72 79 05 67 72 61 70 65 00 05 61 | awberry.grape..a[0m
+[33m[stage-11] [0m[36m0050 | 70 70 6c 65 04 70 65 61 72 00 06 62 61 6e 61 6e | pple.pear..banan[0m
+[33m[stage-11] [0m[36m0060 | 61 09 62 6c 75 65 62 65 72 72 79 00 05 67 72 61 | a.blueberry..gra[0m
+[33m[stage-11] [0m[36m0070 | 70 65 09 72 61 73 70 62 65 72 72 79 ff 38 8d 90 | pe.raspberry.8..[0m
+[33m[stage-11] [0m[36m0080 | f3 22 1e 0f c4 0a                               | ."....[0m
+[33m[stage-11] [0m[36m[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2437623542 --dbfilename raspberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*5\r\n$10\r\nstrawberry\r\n$6\r\norange\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n$5\r\napple\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["strawberry", "orange", "grape", "banana", "apple"][0m
-[33m[stage-11] [0m[92mReceived ["strawberry", "orange", "grape", "banana", "apple"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*5\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$5\r\napple\r\n$6\r\nbanana\r\n$6\r\norange\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["strawberry", "grape", "apple", "banana", "orange"][0m
+[33m[stage-11] [0m[92mReceived ["strawberry", "grape", "apple", "banana", "orange"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="pear"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2166464192 --dbfilename pear.rdb[0m
+[33m[stage-10] [0m[94mCreated RDB file with a single key-value pair: {"raspberry": "pear"}[0m
+[33m[stage-10] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-10] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-10] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-10] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[stage-10] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 72 | er.7.2.0.......r[0m
+[33m[stage-10] [0m[36m0030 | 61 73 70 62 65 72 72 79 04 70 65 61 72 ff 8e fd | aspberry.pear...[0m
+[33m[stage-10] [0m[36m0040 | 39 1a 82 3d b4 c0 0a                            | 9..=...[0m
+[33m[stage-10] [0m[36m[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles23166918 --dbfilename pear.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
@@ -1256,8 +1305,17 @@ Debug = true
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
-[33m[stage-9] [0m[94mCreated RDB file with single key: "orange"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3677995707 --dbfilename grape.rdb[0m
+[33m[stage-9] [0m[94mCreated RDB file with a single key: ["orange"][0m
+[33m[stage-9] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-9] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-9] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-9] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-9] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-9] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 06 6f | s-bits.@.......o[0m
+[33m[stage-9] [0m[36m0030 | 72 61 6e 67 65 05 6d 61 6e 67 6f ff c7 77 bd 73 | range.mango..w.s[0m
+[33m[stage-9] [0m[36m0040 | 84 b6 3a 5d 0a                                  | ..:].[0m
+[33m[stage-9] [0m[36m[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3426670913 --dbfilename grape.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\norange\r\n"[0m
@@ -1268,12 +1326,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1211579902 --dbfilename pear.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2900771858 --dbfilename pear.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1211579902\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1211579902"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1211579902"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2900771858\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2900771858"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2900771858"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1285,15 +1343,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 16:12:39.955[0m
-[33m[stage-7] [0m[94mFetching key "pear" at 16:12:39.955 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 16:31:56.379[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 16:31:56.379 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET pear[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[stage-7] [0m[92mReceived "mango"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "pear" at 16:12:40.058 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "pear" at 16:31:56.482 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET pear[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -607,9 +607,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1729161768291-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1729161768291-0"[0m
-[33m[stage-36] [0m[92mReceived "1729161768291-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1730113324541-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1730113324541-0"[0m
+[33m[stage-36] [0m[92mReceived "1730113324541-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -726,11 +726,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(\xea\x10g\xfa\bused-mem\xc2\xf0\r\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d7e37beac137db2a97389af235c7c5ac4692be6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88sw}\x00\xe1\a\xbf"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-o\x1fg\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1534bef91b562b2058f64e1daf1d21cfc4104cbd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\x17m\xbeˤF\xf5"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -750,11 +750,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xea\x10g\xfa\bused-mem\u0080\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d7e37beac137db2a97389af235c7c5ac4692be6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffO,To\xaa\xbb\xea\\"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-o\x1fg\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1534bef91b562b2058f64e1daf1d21cfc4104cbd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x90\x02\xfa\xb93\t\x88@"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -774,11 +774,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xea\x10g\xfa\bused-mem\u0080@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d7e37beac137db2a97389af235c7c5ac4692be6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw\v\xcc'Ct}r"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-o\x1fg\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1534bef91b562b2058f64e1daf1d21cfc4104cbd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8%b\xf1\xda\xc6\x1fn"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -798,11 +798,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d7e37beac137db2a97389af235c7c5ac4692be6 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 1534bef91b562b2058f64e1daf1d21cfc4104cbd 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xea\x10g\xfa\bused-mem\u0090\x8b\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d7e37beac137db2a97389af235c7c5ac4692be6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb3>MPU\x0eh\xda"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-o\x1fg\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1534bef91b562b2058f64e1daf1d21cfc4104cbd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffl\x10\xe3\x86̼\n\xc6"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -919,7 +919,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2091 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2104 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -945,11 +945,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xea\x10g\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e3aee2a6617f9c487951985f8d371622d3359e2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff|q\xb2\xbf\xd2\x03|\x0f"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2/o\x1fg\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c3f13899d8008f17cf6ea1286df0556203eb444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd2j\xeap\x1f\xb6\x12\xfa"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -969,11 +969,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xea\x10g\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e3aee2a6617f9c487951985f8d371622d3359e2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd5d%\xb8*\xae\xb2\xba"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2/o\x1fg\xfa\bused-mem\xc2\xc0\xf5\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c3f13899d8008f17cf6ea1286df0556203eb444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff{\x7f}w\xe7\x1b\xdcO"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -993,11 +993,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xea\x10g\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e3aee2a6617f9c487951985f8d371622d3359e2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xedC\xbd\xf0\xc3a%\x94"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20o\x1fg\xfa\bused-mem\xc2\xc0@\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c3f13899d8008f17cf6ea1286df0556203eb444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(\xfa\x9b\xa1\x19c\xfd7"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -1017,11 +1017,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 2e3aee2a6617f9c487951985f8d371622d3359e2 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 0c3f13899d8008f17cf6ea1286df0556203eb444 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xea\x10g\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e3aee2a6617f9c487951985f8d371622d3359e2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)v<\x87\xd5\x1b0<"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20o\x1fg\xfa\bused-mem\xc2Ћ\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c3f13899d8008f17cf6ea1286df0556203eb444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xec\xcf\x1a\xd6\x0f\x19\xe8\x9f"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1230,11 +1230,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-\xea\x10g\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x85\x163z\xc8G\x1f\x80"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22o\x1fg\xfa\bused-mem\xc2`S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(214d50af9891816295cb8af4098f9c2c4ac174dd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x84R\xabw\x14\xf4\x8b\xe0"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -1254,11 +1254,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-\xea\x10g\xfa\bused-mem\xc2\xd0:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff5c͊\xd9ͯ\x95"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22o\x1fg\xfa\bused-mem\xc2\xd0:\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(214d50af9891816295cb8af4098f9c2c4ac174dd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4'U\x87\x05~;\xf5"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -1278,11 +1278,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 214d50af9891816295cb8af4098f9c2c4ac174dd 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2.\xea\x10g\xfa\bused-mem\xc2\xe0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0b6ab2d7a0dad8ed89f3a4d64a6bbc268236fc52\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffd\xfc\xe0\xb6.UZ\xb8"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22o\x1fg\xfa\bused-mem\xc2\xe0I\x13\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(214d50af9891816295cb8af4098f9c2c4ac174dd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x115\x06O\xac\x12l\x91"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1367,11 +1367,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 021e6f4be02432273e2496fc85b03c8cd232c0b4 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 021e6f4be02432273e2496fc85b03c8cd232c0b4 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 021e6f4be02432273e2496fc85b03c8cd232c0b4 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC c43c2a65e5b3cbcbe5fa359ba3a4746cc3daf222 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC c43c2a65e5b3cbcbe5fa359ba3a4746cc3daf222 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC c43c2a65e5b3cbcbe5fa359ba3a4746cc3daf222 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2.\xea\x10g\xfa\bused-mem\xc2@S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(021e6f4be02432273e2496fc85b03c8cd232c0b4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\n\xf5\xc1'\x03\xfex"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22o\x1fg\xfa\bused-mem\u0080S\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c43c2a65e5b3cbcbe5fa359ba3a4746cc3daf222\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88\xb8\x92&\xbe3\xf6\x97"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1426,11 +1426,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 2b55bb5b62de311f090a366de2053861a792aea6 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2b55bb5b62de311f090a366de2053861a792aea6 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 2b55bb5b62de311f090a366de2053861a792aea6 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 7ccbd0d11ddb2246a8d0c2f3284a06dd2b2403d6 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 7ccbd0d11ddb2246a8d0c2f3284a06dd2b2403d6 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 7ccbd0d11ddb2246a8d0c2f3284a06dd2b2403d6 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.4\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2.\xea\x10g\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2b55bb5b62de311f090a366de2053861a792aea6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\xad\xb2\xba\xf6\xec\xe9\xdd"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0011\xfa\tredis-ver\x057.2.6\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22o\x1fg\xfa\bused-mem\xc20\x0e\x12\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7ccbd0d11ddb2246a8d0c2f3284a06dd2b2403d6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff%n\xf3cU\xacx"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1455,9 +1455,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC a717b7a278c91aa8cd693e5d9b3678427db24885 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC a717b7a278c91aa8cd693e5d9b3678427db24885 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC a717b7a278c91aa8cd693e5d9b3678427db24885 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC fc419d05c674d53ac8981ada18b2ab005b39b2c6 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC fc419d05c674d53ac8981ada18b2ab005b39b2c6 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC fc419d05c674d53ac8981ada18b2ab005b39b2c6 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1556,9 +1556,9 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8b956b972661aee4d2493d99e7e4b9e57960ea55\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8b956b972661aee4d2493d99e7e4b9e57960ea55\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8b956b972661aee4d2493d99e7e4b9e57960ea55\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:78befe8c744edef423f9fc3722630aaca8c0ba9e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:78befe8c744edef423f9fc3722630aaca8c0ba9e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:78befe8c744edef423f9fc3722630aaca8c0ba9e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
@@ -1582,9 +1582,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ffdec31b42e4aa1f8fac4a6cdd3f7ef494aa6b98\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ffdec31b42e4aa1f8fac4a6cdd3f7ef494aa6b98\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ffdec31b42e4aa1f8fac4a6cdd3f7ef494aa6b98\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:74cde44f9bbd349e7ed001ac28b3f4c1f75280e7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:74cde44f9bbd349e7ed001ac28b3f4c1f75280e7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:74cde44f9bbd349e7ed001ac28b3f4c1f75280e7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1599,7 +1599,23 @@ Debug = true
 [33m[stage-14] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-13] [0m[94mRunning tests for Stage #13: sm4[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2619869745 --dbfilename banana.rdb[0m
+[33m[stage-13] [0m[94mCreated RDB file with 4 key-value pairs: {"orange": "banana", "pineapple": "pineapple", "apple": "strawberry", "blueberry": "raspberry"}[0m
+[33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 9c | s-bits.@........[0m
+[33m[stage-13] [0m[36m0030 | ef 12 7e 01 00 00 00 06 6f 72 61 6e 67 65 06 62 | ..~.....orange.b[0m
+[33m[stage-13] [0m[36m0040 | 61 6e 61 6e 61 fc 00 0c 28 8a c7 01 00 00 00 09 | anana...(.......[0m
+[33m[stage-13] [0m[36m0050 | 70 69 6e 65 61 70 70 6c 65 09 70 69 6e 65 61 70 | pineapple.pineap[0m
+[33m[stage-13] [0m[36m0060 | 70 6c 65 fc 00 0c 28 8a c7 01 00 00 00 05 61 70 | ple...(.......ap[0m
+[33m[stage-13] [0m[36m0070 | 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 fc 00 | ple.strawberry..[0m
+[33m[stage-13] [0m[36m0080 | 0c 28 8a c7 01 00 00 00 09 62 6c 75 65 62 65 72 | .(.......blueber[0m
+[33m[stage-13] [0m[36m0090 | 72 79 09 72 61 73 70 62 65 72 72 79 ff 61 0a a8 | ry.raspberry.a..[0m
+[33m[stage-13] [0m[36m00a0 | 81 34 4f 53 cf 0a                               | .4OS..[0m
+[33m[stage-13] [0m[36m[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1270492762 --dbfilename banana.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -1625,8 +1641,20 @@ Debug = true
 [33m[stage-13] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: dq3[0m
-[33m[stage-12] [0m[94mCreated RDB file with key-value pairs: "pineapple"="raspberry", "banana"="apple", "pear"="banana", "mango"="pineapple"[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles41217541 --dbfilename raspberry.rdb[0m
+[33m[stage-12] [0m[94mCreated RDB file with 4 key-value pairs: {"pineapple": "raspberry", "banana": "apple", "pear": "banana", "mango": "pineapple"}[0m
+[33m[stage-12] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-12] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-12] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-12] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-12] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 70 | s-bits.@.......p[0m
+[33m[stage-12] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 72 | ineapple.raspber[0m
+[33m[stage-12] [0m[36m0040 | 72 79 00 06 62 61 6e 61 6e 61 05 61 70 70 6c 65 | ry..banana.apple[0m
+[33m[stage-12] [0m[36m0050 | 00 04 70 65 61 72 06 62 61 6e 61 6e 61 00 05 6d | ..pear.banana..m[0m
+[33m[stage-12] [0m[36m0060 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 ff e3 | ango.pineapple..[0m
+[33m[stage-12] [0m[36m0070 | 11 39 86 b8 ac e4 be 0a                         | .9......[0m
+[33m[stage-12] [0m[36m[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3378448787 --dbfilename raspberry.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1652,8 +1680,19 @@ Debug = true
 [33m[stage-12] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-11] [0m[94mRunning tests for Stage #11: jw4[0m
-[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["apple" "grape" "mango"][0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles62265312 --dbfilename pineapple.rdb[0m
+[33m[stage-11] [0m[94mCreated RDB file with 3 keys: ["apple", "grape", "mango"][0m
+[33m[stage-11] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-11] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-11] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-11] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-11] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-11] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 05 61 | s-bits.@.......a[0m
+[33m[stage-11] [0m[36m0030 | 70 70 6c 65 05 6d 61 6e 67 6f 00 05 67 72 61 70 | pple.mango..grap[0m
+[33m[stage-11] [0m[36m0040 | 65 09 62 6c 75 65 62 65 72 72 79 00 05 6d 61 6e | e.blueberry..man[0m
+[33m[stage-11] [0m[36m0050 | 67 6f 06 6f 72 61 6e 67 65 ff dc 4d 99 81 37 bf | go.orange..M..7.[0m
+[33m[stage-11] [0m[36m0060 | 76 19 0a                                        | v..[0m
+[33m[stage-11] [0m[36m[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles1923482980 --dbfilename pineapple.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\nmango\r\n$5\r\ngrape\r\n$5\r\napple\r\n"[0m
@@ -1664,8 +1703,17 @@ Debug = true
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-10] [0m[94mRunning tests for Stage #10: gc6[0m
-[33m[stage-10] [0m[94mCreated RDB file with single key-value pair: raspberry="banana"[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3167345688 --dbfilename grape.rdb[0m
+[33m[stage-10] [0m[94mCreated RDB file with a single key-value pair: {"raspberry": "banana"}[0m
+[33m[stage-10] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-10] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-10] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-10] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-10] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 72 | s-bits.@.......r[0m
+[33m[stage-10] [0m[36m0030 | 61 73 70 62 65 72 72 79 06 62 61 6e 61 6e 61 ff | aspberry.banana.[0m
+[33m[stage-10] [0m[36m0040 | ef 79 f1 21 83 dd e4 16 0a                      | .y.!.....[0m
+[33m[stage-10] [0m[36m[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2512970542 --dbfilename grape.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
@@ -1676,8 +1724,17 @@ Debug = true
 [33m[stage-10] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: jz6[0m
-[33m[stage-9] [0m[94mCreated RDB file with single key: "raspberry"[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2316759799 --dbfilename strawberry.rdb[0m
+[33m[stage-9] [0m[94mCreated RDB file with a single key: ["raspberry"][0m
+[33m[stage-9] [0m[36mHexdump of RDB file contents: [0m
+[33m[stage-9] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[stage-9] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[stage-9] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-9] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-9] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 72 | s-bits.@.......r[0m
+[33m[stage-9] [0m[36m0030 | 61 73 70 62 65 72 72 79 06 6f 72 61 6e 67 65 ff | aspberry.orange.[0m
+[33m[stage-9] [0m[36m0040 | d2 ff 75 36 a2 bc 20 ed 0a                      | ..u6.. ..[0m
+[33m[stage-9] [0m[36m[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2449095305 --dbfilename strawberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
@@ -1688,12 +1745,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2426034111 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3410147028 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2426034111\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2426034111"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles2426034111"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3410147028\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3410147028"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/5l/z5y3dkwn68sgb6htzc5w7vnm0000gn/T/rdbfiles3410147028"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1705,15 +1762,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 16:12:57.825[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 16:12:57.825 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 16:32:14.021[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 16:32:14.021 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "strawberry"[0m
 [33m[stage-7] [0m[92mReceived "strawberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "apple" at 16:12:57.928 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "apple" at 16:32:14.124 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET apple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_rdb_read_key.go
+++ b/internal/test_rdb_read_key.go
@@ -26,7 +26,10 @@ func testRdbReadKey(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
-	logger.Infof("Created RDB file with single key: %q", randomKey)
+	logger.Infof("Created RDB file with a single key: [%q]", randomKey)
+	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
+		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
+	}
 
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	stageHarness.RegisterTeardownFunc(func() { RDBFileCreator.Cleanup() })

--- a/internal/test_rdb_read_multiple_keys.go
+++ b/internal/test_rdb_read_multiple_keys.go
@@ -32,7 +32,10 @@ func testRdbReadMultipleKeys(stageHarness *test_case_harness.TestCaseHarness) er
 	}
 
 	logger := stageHarness.Logger
-	logger.Infof("Created RDB file with %d keys: %q", keyCount, keys)
+	logger.Infof("Created RDB file with %d keys: %v", keyCount, FormatKeys(keys))
+	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
+		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
+	}
 
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	stageHarness.RegisterTeardownFunc(func() { RDBFileCreator.Cleanup() })

--- a/internal/test_rdb_read_multiple_string_values.go
+++ b/internal/test_rdb_read_multiple_string_values.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
@@ -28,11 +27,6 @@ func testRdbReadMultipleStringValues(stageHarness *test_case_harness.TestCaseHar
 		keyValuePairs[i] = KeyValuePair{key: keys[i], value: values[i]}
 	}
 
-	formattedKeyValuePairs := make([]string, keyCount)
-	for i := 0; i < keyCount; i++ {
-		formattedKeyValuePairs[i] = fmt.Sprintf("%q=%q", keys[i], values[i])
-	}
-
 	keyValueMap := make(map[string]string)
 	for i := 0; i < keyCount; i++ {
 		key := keys[i]
@@ -40,10 +34,13 @@ func testRdbReadMultipleStringValues(stageHarness *test_case_harness.TestCaseHar
 		keyValueMap[key] = value
 	}
 
-	logger := stageHarness.Logger
-	logger.Infof("Created RDB file with key-value pairs: %s", strings.Join(formattedKeyValuePairs, ", "))
-
 	if err := RDBFileCreator.Write(keyValuePairs); err != nil {
+		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
+	}
+
+	logger := stageHarness.Logger
+	logger.Infof("Created RDB file with %d key-value pairs: %s", len(keys), FormatKeyValuePairs(keys, values))
+	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
 		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
 	}
 

--- a/internal/test_rdb_read_string_value.go
+++ b/internal/test_rdb_read_string_value.go
@@ -26,7 +26,10 @@ func testRdbReadStringValue(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 
 	logger := stageHarness.Logger
-	logger.Infof("Created RDB file with single key-value pair: %s=%q", randomKey, randomValue)
+	logger.Infof("Created RDB file with a single key-value pair: {%q: %q}", randomKey, randomValue)
+	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
+		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
+	}
 
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	stageHarness.RegisterTeardownFunc(func() { RDBFileCreator.Cleanup() })

--- a/internal/test_rdb_read_value_with_expiry.go
+++ b/internal/test_rdb_read_value_with_expiry.go
@@ -48,14 +48,18 @@ func testRdbReadValueWithExpiry(stageHarness *test_case_harness.TestCaseHarness)
 		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
 	}
 
+	logger := stageHarness.Logger
+	logger.Infof("Created RDB file with %d key-value pairs: %s", len(keys), FormatKeyValuePairs(keys, values))
+	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
+		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
+	}
+
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	stageHarness.RegisterTeardownFunc(func() { RDBFileCreator.Cleanup() })
 	if err := b.Run("--dir", RDBFileCreator.Dir,
 		"--dbfilename", RDBFileCreator.Filename); err != nil {
 		return err
 	}
-
-	logger := stageHarness.Logger
 
 	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client")
 	if err != nil {

--- a/internal/util.go
+++ b/internal/util.go
@@ -77,3 +77,74 @@ func SpawnClients(clientCount int, addr string, stageHarness *test_case_harness.
 	}
 	return clients, nil
 }
+
+func GetFormattedHexdump(data []byte) string {
+	// This is used for logs
+	// Contains headers + vertical & horizontal separators + offset
+	// We use a different format for the error logs
+	var formattedHexdump strings.Builder
+	var asciiChars strings.Builder
+
+	formattedHexdump.WriteString("Idx  | Hex                                             | ASCII\n")
+	formattedHexdump.WriteString("-----+-------------------------------------------------+-----------------\n")
+
+	for i, b := range data {
+		if i%16 == 0 && i != 0 {
+			formattedHexdump.WriteString("| " + asciiChars.String() + "\n")
+			asciiChars.Reset()
+		}
+		if i%16 == 0 {
+			formattedHexdump.WriteString(fmt.Sprintf("%04x | ", i))
+		}
+		formattedHexdump.WriteString(fmt.Sprintf("%02x ", b))
+
+		// Add ASCII representation
+		if b >= 32 && b <= 126 {
+			asciiChars.WriteByte(b)
+		} else {
+			asciiChars.WriteByte('.')
+		}
+	}
+
+	// Pad the last line if necessary
+	if len(data)%16 != 0 {
+		padding := 16 - (len(data) % 16)
+		for i := 0; i < padding; i++ {
+			formattedHexdump.WriteString("   ")
+		}
+	}
+
+	// Add the final ASCII representation
+	formattedHexdump.WriteString("| " + asciiChars.String())
+
+	return formattedHexdump.String()
+}
+
+// FormatKeys formats a list of keys as a string, with each key quoted.
+// Used for logging RDB contents.
+func FormatKeys(keys []string) string {
+	return fmt.Sprintf("[%s]", strings.Join(quotedStrings(keys), ", "))
+}
+
+func quotedStrings(ss []string) []string {
+	quoted := make([]string, len(ss))
+	for i, s := range ss {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return quoted
+}
+
+// FormatKeyValuePairs formats a list of key-value pairs as a string, with each key and value quoted.
+// Used for logging RDB contents.
+func FormatKeyValuePairs(keys []string, values []string) string {
+	if len(keys) != len(values) {
+		return "{}"
+	}
+
+	pairs := make([]string, len(keys))
+	for i := range keys {
+		pairs[i] = fmt.Sprintf("%q: %q", keys[i], values[i])
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
+}


### PR DESCRIPTION
This pull request adds logging and hexdump functionality to the codebase. It includes the following changes:

- Added functions required for logging out hexdumps

- Improved logging and hexdump output in test cases

- Updated fixtures in test cases

- Added regex to replace hexdump lines

These changes enhance the logging capabilities of the code and provide a way to visualize the hexdump of RDB file contents.