### PR TITLE
Add GitHub Actions workflow for fixture regeneration

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -1,0 +1,18 @@
+name: Trigger Fixture Regeneration
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  regenerate_fixtures:
+    if: github.event.label.name == 'regenerate-fixtures'
+    uses: codecrafters-io/tester-utils/.github/workflows/fixtures.yml@fixture-gen-action
+    with:
+      tester_repo: redis-tester
+    secrets: inherit


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for regenerating fixtures. The workflow is triggered when a pull request is labeled with 'regenerate-fixtures'. The workflow uses the `codecrafters-io/tester-utils` repository and the `redis-tester` tester repository.