### PR TITLE
Add fixture regeneration workflow and Redis setup target

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -1,0 +1,18 @@
+name: Trigger Fixture Regeneration
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  regenerate_fixtures:
+    if: github.event.label.name == 'regenerate-fixtures'
+    uses: codecrafters-io/tester-utils/.github/workflows/fixtures.yml@ci-make-setup
+    with:
+      tester_repo: redis-tester
+    secrets: inherit

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   regenerate_fixtures:
     if: github.event.label.name == 'regenerate-fixtures'
-    uses: codecrafters-io/tester-utils/.github/workflows/fixtures.yml@ci-make-setup
+    uses: codecrafters-io/tester-utils/.github/workflows/fixtures.yml@master
     with:
       tester_repo: redis-tester
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           python-version: "3.x" # Version range or exact version of a Python version to use, using SemVer's version range syntax
 
-      - run: make test
+      - name: Run tests
+        run: make test
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,22 @@ test_txn_with_redis: build
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"si4\",\"tester_log_prefix\":\"stage-401\",\"title\":\"Stage #401: INCR-1\"},{\"slug\":\"lz8\",\"tester_log_prefix\":\"stage-402\",\"title\":\"Stage #402: INCR-2\"}, {\"slug\":\"mk1\",\"tester_log_prefix\":\"stage-403\",\"title\":\"Stage #403: INCR-3\"}, {\"slug\":\"pn0\",\"tester_log_prefix\":\"stage-404\",\"title\":\"Stage #404: MULTI\"}, {\"slug\":\"lo4\",\"tester_log_prefix\":\"stage-405\",\"title\":\"Stage #405: EXEC\"}, {\"slug\":\"we1\",\"tester_log_prefix\":\"stage-406\",\"title\":\"Stage #406: Empty Transaction\"}, {\"slug\":\"rs9\",\"tester_log_prefix\":\"stage-407\",\"title\":\"Stage #407: Queueing Commands\"}, {\"slug\":\"fy6\",\"tester_log_prefix\":\"stage-408\",\"title\":\"Stage #408: Executing a transaction\"}, {\"slug\":\"rl9\",\"tester_log_prefix\":\"stage-409\",\"title\":\"Stage #409: Discarding a transaction\"}, {\"slug\":\"sg9\",\"tester_log_prefix\":\"stage-410\",\"title\":\"Stage #410: Executing a failed transaction\"}, {\"slug\":\"jf8\",\"tester_log_prefix\":\"stage-411\",\"title\":\"Stage #411: Executing concurrent transactions\"}]" \
 	dist/main.out
 
-test_all_with_redis: 
+test_all_with_redis:
 	make test_base_with_redis || true
 	make test_repl_with_redis || true
 	make test_rdb_with_redis || true
 	make test_streams_with_redis || true
 	make test_txn_with_redis || true
+
+setup:
+	echo "Setting up redis-tester prerequisites for Linux"
+
+	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+	sudo chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
+	@echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(shell lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+
+	sudo apt-get update && sudo apt-get install redis -y
+
+	sudo service redis-server stop
+
+	echo "Setup complete!"

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -21,11 +21,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf2\xe7\xdf\x04\x8c\xca\u07fb"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x14\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x02\xfe\xe7R\x81`\xe9\r"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -45,11 +45,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1*\xb42\xb7c\xeb6"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4\xc6\xd4\x00Ax\x8b^"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -69,11 +69,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\x84S5\xd2\xd8e\x06"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffkh3\a$\xc3\x05n"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -93,11 +93,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffC\xdc\xc49|V\xac\xe2"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xd2Ih\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(36d48dfe5caacbf0a4d395d33c6f2e41cd7cdc6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffF0\xa4\v\x8aM̊"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2089 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2097 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -240,11 +240,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9\x8e\xcd\xc3;\xbb\xa1V"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffú\b\xe3]\xf3\xad("[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -264,11 +264,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaaC\xa6\xf5\x00\x12\x95\xdb"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x90wc\xd5fZ\x99\xa5"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -288,11 +288,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffe\xedA\xf2e\xa9\x1b\xeb"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff_ل\xd2\x03\xe1\x17\x95"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -312,11 +312,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffH\xb5\xd6\xfe\xcb'\xd2\x0f"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xd2Ih\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\x81\x13ޭo\xdeq"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 5[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: $ redis-cli PING[0m
@@ -336,11 +336,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-5: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(\xfc\xa0\xd7Pf\x18\x06"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xd2Ih\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12\xc8e\xf76.\x14x"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 6[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: $ redis-cli PING[0m
@@ -360,11 +360,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-6: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmf\x02\xd5s\x0fb\x16"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x18\xd2Ih\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98yԈcD\x1e,"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 7[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: $ redis-cli PING[0m
@@ -384,11 +384,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-7: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 26871200455347e8ec00c0401b857945f324b314 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd6m\x8e4P\x9b\xe0\xfe"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x18\xd2Ih\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(26871200455347e8ec00c0401b857945f324b314\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff#rXi@М\xc4"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -597,11 +597,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb9\xb4gb\xc5&\x88\xbc"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb4edf84cf9634f6b223b899bd9251f286d94adf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xda\xe9\x11\\\x03\xeb\x06:"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -621,11 +621,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80H\xcd~\xc9\xc9\x0ev"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xd2Ih\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb4edf84cf9634f6b223b899bd9251f286d94adf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\x15\xbb@\x0f\x04\x80\xf0"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -645,11 +645,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC eb4edf84cf9634f6b223b899bd9251f286d94adf 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffȯ_.ߵ\xa7D"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xd2Ih\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb4edf84cf9634f6b223b899bd9251f286d94adf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab\xf2)\x10\x19x)\xc2"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -734,11 +734,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 76ae4e9b9b865587add304cb8d6e3935b65cf697 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 76ae4e9b9b865587add304cb8d6e3935b65cf697 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 76ae4e9b9b865587add304cb8d6e3935b65cf697 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4a986acb8ffb95769fc85547db94f6f3080a691\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,\xf9\x83\xbf\xa4\x06DZ"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(76ae4e9b9b865587add304cb8d6e3935b65cf697\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\xbf\xf0\xe4ǧш"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -793,11 +793,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 5da5b0a0b3a217615c7af0e7e45280b8c9a9e0eb 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 5da5b0a0b3a217615c7af0e7e45280b8c9a9e0eb 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 5da5b0a0b3a217615c7af0e7e45280b8c9a9e0eb 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e9f03f7ed366e7307dc2995b732088f9af385c80\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc\xf0\xb8y٩\xdd\xf4"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1a\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5da5b0a0b3a217615c7af0e7e45280b8c9a9e0eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x061\xa5\x18o\xc0g\b"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -822,9 +822,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 87cde921cc0a4421f733a74068b4ed318afe5e99 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 87cde921cc0a4421f733a74068b4ed318afe5e99 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 87cde921cc0a4421f733a74068b4ed318afe5e99 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -923,12 +923,10 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3acebb1f79cec71de11af45e4242c60dad7f6479\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3acebb1f79cec71de11af45e4242c60dad7f6479\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3acebb1f79cec71de11af45e4242c60dad7f6479\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -939,9 +937,9 @@ Debug = true
 [33m[stage-16] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
 [33m[stage-16] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-16] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-16] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-16] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-16] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-16] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-16] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-16] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-16] [0m[92mFound role:slave in response.[0m
 [33m[stage-16] [0m[92mTest passed.[0m
 [33m[stage-16] [0m[36mTerminating program[0m
@@ -951,9 +949,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4365a7b9e7f5872466442b8d9f4379ddeead5ee3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4365a7b9e7f5872466442b8d9f4379ddeead5ee3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4365a7b9e7f5872466442b8d9f4379ddeead5ee3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -982,7 +980,7 @@ Debug = true
 [33m[stage-13] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
 [33m[stage-13] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed 0a                   | ..BMI.;{..[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles932667743 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2417550558 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
@@ -1017,7 +1015,7 @@ Debug = true
 [33m[stage-12] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 03 5d d3 a4 75 38 | blueberry..]..u8[0m
 [33m[stage-12] [0m[36m0080 | 83 47 0a                                        | .G.[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4235584202 --dbfilename mango.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2715963484 --dbfilename mango.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1061,12 +1059,12 @@ Debug = true
 [33m[stage-11] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
 [33m[stage-11] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d 0a                   | .:..r.,.=.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3315367980 --dbfilename grape.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles253998596 --dbfilename grape.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["blueberry", "raspberry", "orange", "apple"][0m
-[33m[stage-11] [0m[92mReceived ["blueberry", "raspberry", "orange", "apple"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$9\r\nblueberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["apple", "raspberry", "orange", "blueberry"][0m
+[33m[stage-11] [0m[92mReceived ["apple", "raspberry", "orange", "blueberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
@@ -1076,13 +1074,13 @@ Debug = true
 [33m[stage-10] [0m[36mHexdump of RDB file contents: [0m
 [33m[stage-10] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-10] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[stage-10] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[stage-10] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 62 | er.7.2.0.......b[0m
+[33m[stage-10] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-10] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-10] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 62 | s-bits.@.......b[0m
 [33m[stage-10] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
-[33m[stage-10] [0m[36m0040 | 72 79 ff 1c 00 77 32 d4 0b 28 5c 0a             | ry...w2..(\.[0m
+[33m[stage-10] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7 0a             | ry..2h(,.&..[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1634753782 --dbfilename strawberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2673767282 --dbfilename strawberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1103,7 +1101,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
 [33m[stage-9] [0m[36m0040 | 6b 9a 0a                                        | k..[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles623818760 --dbfilename orange.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1067647322 --dbfilename orange.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1114,12 +1112,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1706838753 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2492669807 --dbfilename raspberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles1706838753\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles1706838753"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles1706838753"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles2492669807\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles2492669807"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles2492669807"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1131,15 +1129,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 18:46:15.599[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 18:46:15.600 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 18:59:40.962[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:59:40.962 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[stage-7] [0m[92mReceived "orange"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 18:46:15.702 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:59:41.065 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -21,11 +21,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc29e!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(19e8a5a7056130ab17f56efeb8777e4bc0a7b37f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd4\x7f݆\xdb\xd7C\""[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf2\xe7\xdf\x04\x8c\xca\u07fb"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -45,11 +45,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc29e!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(19e8a5a7056130ab17f56efeb8777e4bc0a7b37f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a\xcc\x12\x83\toDH"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1*\xb42\xb7c\xeb6"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -69,11 +69,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc29e!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(19e8a5a7056130ab17f56efeb8777e4bc0a7b37f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\x1e\xf1\x19\x95[*\xe8"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\x84S5\xd2\xd8e\x06"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -93,11 +93,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 19e8a5a7056130ab17f56efeb8777e4bc0a7b37f 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 8e70e081c222f69cf05a9ffe26c33581d5247e06 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc29e!h\xfa\bused-mem\u00a06\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(19e8a5a7056130ab17f56efeb8777e4bc0a7b37f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\ax]\xfc\xe2e\x1e\xfb"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\xceIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e70e081c222f69cf05a9ffe26c33581d5247e06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffC\xdc\xc49|V\xac\xe2"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -214,7 +214,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2099 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2089 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -240,11 +240,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2;e!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\xf6\xeeG_\xab\x8f\xfd"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9\x8e\xcd\xc3;\xbb\xa1V"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -264,11 +264,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2;e!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffQE!B\x8d\x13\x88\x97"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaaC\xa6\xf5\x00\x12\x95\xdb"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -288,11 +288,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<e!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffIxgTW~\xf5z"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffe\xedA\xf2e\xa9\x1b\xeb"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -312,11 +312,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<e!h\xfa\bused-mem\u00a06\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffQ\x1e˱ @\xc1i"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffH\xb5\xd6\xfe\xcb'\xd2\x0f"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 5[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: $ redis-cli PING[0m
@@ -336,11 +336,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-5: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-5: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<e!h\xfa\bused-mem\xc2\xf0?\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY<\xaf\x12\xf2U-g"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-5: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(\xfc\xa0\xd7Pf\x18\x06"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 6[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: $ redis-cli PING[0m
@@ -360,11 +360,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-6: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-6: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<e!h\xfa\bused-mem\xc20I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x116\n\xe0`\x14\xd9K"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-6: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmf\x02\xd5s\x0fb\x16"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 7[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: $ redis-cli PING[0m
@@ -384,11 +384,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-7: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-7: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 515c0cedf69f1c1610424910f740830be029dd23 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "+FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received RESP simple string: "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<e!h\xfa\bused-mem\u0080R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(515c0cedf69f1c1610424910f740830be029dd23\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff붖R\x89\xe3W\xb4"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-7: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\xceIh\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1ceb378f1f246b1d1c2ce2f1a700a7122dfe3559\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd6m\x8e4P\x9b\xe0\xfe"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -597,11 +597,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=e!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff6\xf5\xd2]+\xc8\xf9\""[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb9\xb4gb\xc5&\x88\xbc"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -621,11 +621,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2=e!h\xfa\bused-mem\xc2\x10i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf7\xe0y8\xf6©\xb4"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80H\xcd~\xc9\xc9\x0ev"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -645,11 +645,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 8cc33d9dfcafe83cb749cafa25c4f71509fc6f29 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>e!h\xfa\bused-mem\xc2`6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(04c9f7a2d2b3c6aaae0a649fc14040feaa5d7cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\xc3\x17DI\xf08\xee"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8cc33d9dfcafe83cb749cafa25c4f71509fc6f29\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffȯ_.ߵ\xa7D"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -734,11 +734,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 234e06b67e7b5e6345ffb0294dd4f8d4860e58bb 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 234e06b67e7b5e6345ffb0294dd4f8d4860e58bb 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 234e06b67e7b5e6345ffb0294dd4f8d4860e58bb 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC b4a986acb8ffb95769fc85547db94f6f3080a691 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>e!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(234e06b67e7b5e6345ffb0294dd4f8d4860e58bb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffC\xceXז\xbaO\xe0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4a986acb8ffb95769fc85547db94f6f3080a691\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,\xf9\x83\xbf\xa4\x06DZ"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -793,11 +793,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC c587823713edf81aa8fad05ef9d77398b0fb5082 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC c587823713edf81aa8fad05ef9d77398b0fb5082 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC c587823713edf81aa8fad05ef9d77398b0fb5082 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC e9f03f7ed366e7307dc2995b732088f9af385c80 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2>e!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c587823713edf81aa8fad05ef9d77398b0fb5082\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa95-_/\x17T\x15"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xceIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e9f03f7ed366e7307dc2995b732088f9af385c80\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc\xf0\xb8y٩\xdd\xf4"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -822,9 +822,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 0aab88863a0fdcba2a3a2e84ee614e160f97b4ac 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0aab88863a0fdcba2a3a2e84ee614e160f97b4ac 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 0aab88863a0fdcba2a3a2e84ee614e160f97b4ac 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 3663c9573dac016d1f71d5d23469afaa6be41556 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -923,10 +923,12 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:00a5a20c8ec6537756a9dff036abc11cbdf1e99e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:00a5a20c8ec6537756a9dff036abc11cbdf1e99e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:00a5a20c8ec6537756a9dff036abc11cbdf1e99e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cddce38c7118ca157e733fb456c9e858d55f380d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -949,9 +951,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ad94520bce4b1277b9a98d45a0dd42086adf4837\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ad94520bce4b1277b9a98d45a0dd42086adf4837\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ad94520bce4b1277b9a98d45a0dd42086adf4837\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:68104ffd1c154e5cf2272238b720eda627d68a29\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -980,7 +982,7 @@ Debug = true
 [33m[stage-13] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
 [33m[stage-13] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed 0a                   | ..BMI.;{..[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles2456554607 --dbfilename pear.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles932667743 --dbfilename pear.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
@@ -1015,7 +1017,7 @@ Debug = true
 [33m[stage-12] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 03 5d d3 a4 75 38 | blueberry..]..u8[0m
 [33m[stage-12] [0m[36m0080 | 83 47 0a                                        | .G.[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1411824206 --dbfilename mango.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4235584202 --dbfilename mango.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1059,12 +1061,12 @@ Debug = true
 [33m[stage-11] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
 [33m[stage-11] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d 0a                   | .:..r.,.=.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3155096687 --dbfilename grape.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3315367980 --dbfilename grape.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$5\r\napple\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["orange", "apple", "raspberry", "blueberry"][0m
-[33m[stage-11] [0m[92mReceived ["orange", "apple", "raspberry", "blueberry"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["blueberry", "raspberry", "orange", "apple"][0m
+[33m[stage-11] [0m[92mReceived ["blueberry", "raspberry", "orange", "apple"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
@@ -1080,7 +1082,7 @@ Debug = true
 [33m[stage-10] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
 [33m[stage-10] [0m[36m0040 | 72 79 ff 1c 00 77 32 d4 0b 28 5c 0a             | ry...w2..(\.[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles4043971343 --dbfilename strawberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1634753782 --dbfilename strawberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1101,7 +1103,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
 [33m[stage-9] [0m[36m0040 | 6b 9a 0a                                        | k..[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles920165907 --dbfilename orange.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles623818760 --dbfilename orange.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1112,12 +1114,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1483530113 --dbfilename raspberry.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1706838753 --dbfilename raspberry.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1483530113\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1483530113"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1483530113"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles1706838753\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles1706838753"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles1706838753"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1129,15 +1131,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 11:04:33.826[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 11:04:33.826 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 18:46:15.599[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:46:15.600 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[stage-7] [0m[92mReceived "orange"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 11:04:33.930 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:46:15.702 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -218,9 +218,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD apple * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749667589057-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749667589057-0"[0m
-[33m[stage-36] [0m[92mReceived "1749667589057-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749668427811-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749668427811-0"[0m
+[33m[stage-36] [0m[92mReceived "1749668427811-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xf3Nw\xa0\x7f\x05\xf7"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2c3036f666b19af55c88414b82e6e46454ba4ad2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0e\x8d\x99\x1c\xfe\x06><"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@>%A\x9b\xd61z"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2c3036f666b19af55c88414b82e6e46454ba4ad2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]@\xf2*ů\n\xb1"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8f\x90\xc2F\xfem\xbfJ"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2c3036f666b19af55c88414b82e6e46454ba4ad2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x92\xee\x15-\xa0\x14\x84\x81"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 2c3036f666b19af55c88414b82e6e46454ba4ad2 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\xc8UJP\xe3v\xae"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2L\xd2Ih\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2c3036f666b19af55c88414b82e6e46454ba4ad2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\xb6\x82!\x0e\x9aMe"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -528,7 +528,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2098 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2091 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -554,11 +554,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(Q\xe9\xb6\xfc\t|,"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f58eff66201e74205f4e189aa02da0abc63e405f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x94\x1f\x9aA\x8d.\b\xad"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -578,11 +578,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff{\x9c\x82\x80ǠH\xa1"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f58eff66201e74205f4e189aa02da0abc63e405f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc7\xd2\xf1w\xb6\x87< "[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -602,11 +602,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC f58eff66201e74205f4e189aa02da0abc63e405f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb42e\x87\xa2\x1bƑ"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f58eff66201e74205f4e189aa02da0abc63e405f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b|\x16p\xd3<\xb2\x10"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -810,11 +810,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\xda&\x93孙="[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(520109bbef380ef22896bf3465f3b38235d50c18\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x97\x1c\xb7\x13TsI\x19"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -834,11 +834,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd&\x8c\x8f\xe9B\x1f\xf7"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\xd2Ih\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(520109bbef380ef22896bf3465f3b38235d50c18\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae\xe0\x1d\x0fX\x9c\xcf\xd3"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -858,11 +858,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 520109bbef380ef22896bf3465f3b38235d50c18 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5\xc1\x1e\xdf\xff>\xb6\xc5"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\xd2Ih\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(520109bbef380ef22896bf3465f3b38235d50c18\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe6\a\x8f_N\xe0f\xe1"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -947,11 +947,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 1d9b8e73dc5af6ee3b4084eab2c0d6e9be63faf8 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 1d9b8e73dc5af6ee3b4084eab2c0d6e9be63faf8 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 1d9b8e73dc5af6ee3b4084eab2c0d6e9be63faf8 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1B\x80t\x04\xa8\xc8\xcc"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1d9b8e73dc5af6ee3b4084eab2c0d6e9be63faf8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\xa0\xe0\xcfk;\x1es"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1006,11 +1006,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC b2b2557b63517c1718f15f9ea307343548bf8c8b 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC b2b2557b63517c1718f15f9ea307343548bf8c8b 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC b2b2557b63517c1718f15f9ea307343548bf8c8b 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7\x9eSz@\x8f&\xdc"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Q\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b2b2557b63517c1718f15f9ea307343548bf8c8b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\r\xbfJ\tb\x91e\xc2"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1035,9 +1035,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC e41651c95efca9a06d9ca9f16dd7c94da5f6cb11 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC e41651c95efca9a06d9ca9f16dd7c94da5f6cb11 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC e41651c95efca9a06d9ca9f16dd7c94da5f6cb11 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1136,12 +1136,10 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:da1bbe28ad1dd96631222b46788f51b6e73f7481\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:da1bbe28ad1dd96631222b46788f51b6e73f7481\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:da1bbe28ad1dd96631222b46788f51b6e73f7481\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -1164,9 +1162,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c170cfc43766439638dca9ea0d5da95c1e9816d5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c170cfc43766439638dca9ea0d5da95c1e9816d5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c170cfc43766439638dca9ea0d5da95c1e9816d5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1196,7 +1194,7 @@ Debug = true
 [33m[stage-13] [0m[36m0080 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 05 61 | (.......orange.a[0m
 [33m[stage-13] [0m[36m0090 | 70 70 6c 65 ff 97 bc 36 ba ba f9 91 38 0a       | pple...6....8.[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2550350944 --dbfilename grape.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3756508235 --dbfilename grape.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -1235,7 +1233,7 @@ Debug = true
 [33m[stage-12] [0m[36m0060 | 61 72 05 6d 61 6e 67 6f ff ef 45 19 ae 1c 4e e1 | ar.mango..E...N.[0m
 [33m[stage-12] [0m[36m0070 | d1 0a                                           | ..[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1435182263 --dbfilename grape.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3136466339 --dbfilename grape.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1273,12 +1271,12 @@ Debug = true
 [33m[stage-11] [0m[36m0050 | 06 6f 72 61 6e 67 65 09 70 69 6e 65 61 70 70 6c | .orange.pineappl[0m
 [33m[stage-11] [0m[36m0060 | 65 ff 81 1c 15 76 40 d4 8d 69 0a                | e....v@..i.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1403295918 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles551797455 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\ngrape\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["raspberry", "orange", "grape"][0m
-[33m[stage-11] [0m[92mReceived ["raspberry", "orange", "grape"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\ngrape\r\n$6\r\norange\r\n$9\r\nraspberry\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["grape", "orange", "raspberry"][0m
+[33m[stage-11] [0m[92mReceived ["grape", "orange", "raspberry"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
@@ -1294,7 +1292,7 @@ Debug = true
 [33m[stage-10] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 05 67 72 61 70 65 ff | trawberry.grape.[0m
 [33m[stage-10] [0m[36m0040 | 32 44 77 42 d8 b7 2f a2 0a                      | 2DwB../..[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4106195785 --dbfilename raspberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2396007563 --dbfilename raspberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1315,7 +1313,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 61 6e 67 6f 05 61 70 70 6c 65 ff a0 d5 9e e7 44 | ango.apple.....D[0m
 [33m[stage-9] [0m[36m0040 | df 41 72 0a                                     | .Ar.[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles253758928 --dbfilename raspberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles635577388 --dbfilename raspberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -1326,12 +1324,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles505797869 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1703100055 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$22\r\n/tmp/rdbfiles505797869\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles505797869"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles505797869"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles1703100055\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles1703100055"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles1703100055"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1343,15 +1341,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 18:46:37.753[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 18:46:37.753 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 19:00:36.558[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 19:00:36.558 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "banana"[0m
 [33m[stage-7] [0m[92mReceived "banana"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 18:46:37.856 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 19:00:36.661 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -218,9 +218,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD apple * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1747019107575-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1747019107575-0"[0m
-[33m[stage-36] [0m[92mReceived "1747019107575-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749667589057-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749667589057-0"[0m
+[33m[stage-36] [0m[92mReceived "1749667589057-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2de!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(96e224ef3043e72a9598199f25696f33f11ff9f0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa6\x9dA\r\xbfY\xdd\x05"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xf3Nw\xa0\x7f\x05\xf7"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2de!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(96e224ef3043e72a9598199f25696f33f11ff9f0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh.\x8e\bm\xe1\xdao"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@>%A\x9b\xd61z"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2de!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(96e224ef3043e72a9598199f25696f33f11ff9f0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xfcm\x92\xf1մ\xcf"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8f\x90\xc2F\xfem\xbfJ"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 96e224ef3043e72a9598199f25696f33f11ff9f0 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC e53904c19ca4090fb31608f96f0d37eac97dd7b0 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2de!h\xfa\bused-mem\u00a06\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(96e224ef3043e72a9598199f25696f33f11ff9f0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffu\x9a\xc1w\x86\xeb\x80\xdc"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x05\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e53904c19ca4090fb31608f96f0d37eac97dd7b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\xc8UJP\xe3v\xae"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -528,7 +528,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2105 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2098 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -554,11 +554,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2fe!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8f0cbc56c08a8f79168c5837feaed149046cd750\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xecd\xa9y>\x1f/\x82"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(Q\xe9\xb6\xfc\t|,"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -578,11 +578,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ge!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8f0cbc56c08a8f79168c5837feaed149046cd750\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd7\">\x18\x17\x16~6"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff{\x9c\x82\x80ǠH\xa1"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -602,11 +602,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC 8f0cbc56c08a8f79168c5837feaed149046cd750 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a5a4b29cb36631843c25b6872b10151705faea11 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ge!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8f0cbc56c08a8f79168c5837feaed149046cd750\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd2\xf0݂\x8b\"\x10\x96"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\b\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5a4b29cb36631843c25b6872b10151705faea11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb42e\x87\xa2\x1bƑ"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -810,11 +810,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ie!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(033f6e47c3bd8ed305447ff07d66b6e36e9d70a3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffD=\x8b\t\xad1\x01\x9f"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\xda&\x93孙="[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -834,11 +834,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ie!h\xfa\bused-mem\xc2\x10i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(033f6e47c3bd8ed305447ff07d66b6e36e9d70a3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x85( lp;Q\t"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd&\x8c\x8f\xe9B\x1f\xf7"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -858,11 +858,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 033f6e47c3bd8ed305447ff07d66b6e36e9d70a3 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 4c27375198b18060b17617f43cbd0d182eb5448e 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ie!h\xfa\bused-mem\xc2`6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(033f6e47c3bd8ed305447ff07d66b6e36e9d70a3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg\x860\xe4\x91\xfdb\x1a"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4c27375198b18060b17617f43cbd0d182eb5448e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5\xc1\x1e\xdf\xff>\xb6\xc5"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -947,11 +947,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 08731945448826182ec9f0f7fbf0f61d32aa6a37 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 08731945448826182ec9f0f7fbf0f61d32aa6a37 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 08731945448826182ec9f0f7fbf0f61d32aa6a37 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ie!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(08731945448826182ec9f0f7fbf0f61d32aa6a37\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdd\t\x8c\x01-r\xb5\xe7"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6cfdb89d80a117d3d592d02c1e1ebfbf92631bfa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1B\x80t\x04\xa8\xc8\xcc"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1006,11 +1006,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 0b2d81bbaaef0c6dab7ff1cfe492649a0811fd3e 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0b2d81bbaaef0c6dab7ff1cfe492649a0811fd3e 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 0b2d81bbaaef0c6dab7ff1cfe492649a0811fd3e 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ie!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0b2d81bbaaef0c6dab7ff1cfe492649a0811fd3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA\xe1\x14\xd6\xe684\x93"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\n\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5748dcc161a953ae94c7a2a2f4bcb6ca2323d55a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7\x9eSz@\x8f&\xdc"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1035,9 +1035,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 79490f1ec0910efa775eb6c98060eb60d16905cc 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 79490f1ec0910efa775eb6c98060eb60d16905cc 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 79490f1ec0910efa775eb6c98060eb60d16905cc 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 2657a84eb306b7bfcb3ae20b24051f0685a84704 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1136,10 +1136,12 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e3e5e7d8ed7ef8786cdf984a2a10c7d16c0b9f3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e3e5e7d8ed7ef8786cdf984a2a10c7d16c0b9f3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9e3e5e7d8ed7ef8786cdf984a2a10c7d16c0b9f3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5326d0b33236fd67634e6a6adbcb4929ad937a77\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -1162,9 +1164,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e67c6e6dd490ae38d536e1a02066182e21154d2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e67c6e6dd490ae38d536e1a02066182e21154d2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e67c6e6dd490ae38d536e1a02066182e21154d2e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fafd316889c19fb2f01463a5e3c64f07c74ce886\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1194,7 +1196,7 @@ Debug = true
 [33m[stage-13] [0m[36m0080 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 05 61 | (.......orange.a[0m
 [33m[stage-13] [0m[36m0090 | 70 70 6c 65 ff 97 bc 36 ba ba f9 91 38 0a       | pple...6....8.[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3376506876 --dbfilename grape.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2550350944 --dbfilename grape.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -1224,16 +1226,16 @@ Debug = true
 [33m[stage-12] [0m[36mHexdump of RDB file contents: [0m
 [33m[stage-12] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-12] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[stage-12] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[stage-12] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 09 72 | er.7.2.0.......r[0m
+[33m[stage-12] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-12] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-12] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 72 | s-bits.@.......r[0m
 [33m[stage-12] [0m[36m0030 | 61 73 70 62 65 72 72 79 05 67 72 61 70 65 00 05 | aspberry.grape..[0m
 [33m[stage-12] [0m[36m0040 | 6d 61 6e 67 6f 06 6f 72 61 6e 67 65 00 09 62 6c | mango.orange..bl[0m
 [33m[stage-12] [0m[36m0050 | 75 65 62 65 72 72 79 04 70 65 61 72 00 04 70 65 | ueberry.pear..pe[0m
-[33m[stage-12] [0m[36m0060 | 61 72 05 6d 61 6e 67 6f ff 63 07 71 c6 31 93 25 | ar.mango.c.q.1.%[0m
-[33m[stage-12] [0m[36m0070 | 15 0a                                           | ..[0m
+[33m[stage-12] [0m[36m0060 | 61 72 05 6d 61 6e 67 6f ff ef 45 19 ae 1c 4e e1 | ar.mango..E...N.[0m
+[33m[stage-12] [0m[36m0070 | d1 0a                                           | ..[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3150470910 --dbfilename grape.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1435182263 --dbfilename grape.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1271,12 +1273,12 @@ Debug = true
 [33m[stage-11] [0m[36m0050 | 06 6f 72 61 6e 67 65 09 70 69 6e 65 61 70 70 6c | .orange.pineappl[0m
 [33m[stage-11] [0m[36m0060 | 65 ff 81 1c 15 76 40 d4 8d 69 0a                | e....v@..i.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles97231474 --dbfilename pear.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1403295918 --dbfilename pear.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\ngrape\r\n$6\r\norange\r\n$9\r\nraspberry\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["grape", "orange", "raspberry"][0m
-[33m[stage-11] [0m[92mReceived ["grape", "orange", "raspberry"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\ngrape\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["raspberry", "orange", "grape"][0m
+[33m[stage-11] [0m[92mReceived ["raspberry", "orange", "grape"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
@@ -1292,7 +1294,7 @@ Debug = true
 [33m[stage-10] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 05 67 72 61 70 65 ff | trawberry.grape.[0m
 [33m[stage-10] [0m[36m0040 | 32 44 77 42 d8 b7 2f a2 0a                      | 2DwB../..[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1282592670 --dbfilename raspberry.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles4106195785 --dbfilename raspberry.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1313,7 +1315,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 61 6e 67 6f 05 61 70 70 6c 65 ff a0 d5 9e e7 44 | ango.apple.....D[0m
 [33m[stage-9] [0m[36m0040 | df 41 72 0a                                     | .Ar.[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles4218455544 --dbfilename raspberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles253758928 --dbfilename raspberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -1324,12 +1326,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3141226087 --dbfilename banana.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles505797869 --dbfilename banana.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3141226087\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3141226087"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3141226087"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$22\r\n/tmp/rdbfiles505797869\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles505797869"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles505797869"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1341,15 +1343,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 11:05:17.383[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 11:05:17.383 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 18:46:37.753[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:46:37.753 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "banana"[0m
 [33m[stage-7] [0m[92mReceived "banana"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "mango" at 11:05:17.486 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "mango" at 18:46:37.856 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET mango[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -601,9 +601,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749667606539-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749667606539-0"[0m
-[33m[stage-36] [0m[92mReceived "1749667606539-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749668389782-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749668389782-0"[0m
+[33m[stage-36] [0m[92mReceived "1749668389782-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -720,11 +720,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\\\xd7u-wRa\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d5dfe89044ce9587cdab2efef276c2701b983fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7<&+%:\af"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -744,11 +744,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\x1a\x1e\x1bL\xfbU\x87"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d5dfe89044ce9587cdab2efef276c2701b983fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffd\xf1M\x1d\x1e\x933\xeb"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -768,11 +768,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0\xb4\xf9\x1c)@۷"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d5dfe89044ce9587cdab2efef276c2701b983fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab_\xaa\x1a{(\xbd\xdb"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -792,11 +792,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 0d5dfe89044ce9587cdab2efef276c2701b983fa 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xed\xecn\x10\x87\xce\x12S"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&\xd2Ih\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0d5dfe89044ce9587cdab2efef276c2701b983fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x86\a=\x16զt?"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -913,7 +913,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2089 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2091 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -939,11 +939,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,\xdfZ\xcc\xf7\xb3t$"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9bbb9223dca77e5904a362c5b7b38c2ebf3df85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\xe1\x11i\xcf\\\xdeT"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -963,11 +963,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\x121\xfa\xcc\x1a@\xa9"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xd2Ih\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9bbb9223dca77e5904a362c5b7b38c2ebf3df85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa5\xd9\";\x0fD\xbc\a"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -987,11 +987,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb0\xbc\xd6\xfd\xa9\xa1Ι"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xd2Ih\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9bbb9223dca77e5904a362c5b7b38c2ebf3df85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffjw\xc5<j\xff27"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -1011,11 +1011,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9bbb9223dca77e5904a362c5b7b38c2ebf3df85 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\xe4A\xf1\a/\a}"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2)\xd2Ih\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9bbb9223dca77e5904a362c5b7b38c2ebf3df85\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffG/R0\xc4q\xfb\xd3"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1224,11 +1224,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1b\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6w\xb4%\x80\xc6\xd4\x19"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fa956d2762b0a481fda47c076c364fa6b4a6467b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x10\xc0:\xb9fD\xac\xba"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -1248,11 +1248,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1b\xcfIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\x8b\x1e9\x8c)R\xd3"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xd2Ih\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fa956d2762b0a481fda47c076c364fa6b4a6467b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)<\x90\xa5j\xab*p"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -1272,11 +1272,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC fa956d2762b0a481fda47c076c364fa6b4a6467b 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaa\x83)\xe5\xdc\f\xe8\xac"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xd2Ih\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fa956d2762b0a481fda47c076c364fa6b4a6467b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\xdb\x02\xf5|׃B"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1361,11 +1361,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 45aa3fa34125ec13d9feca516228a81e35427928 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 45aa3fa34125ec13d9feca516228a81e35427928 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 45aa3fa34125ec13d9feca516228a81e35427928 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(68335e05fccc7fa822c642f26df224c33c94dc9f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҮcCv\xc0\xda7"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xd2Ih\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45aa3fa34125ec13d9feca516228a81e35427928\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9J\x18-\xa6\x99\xb3J"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1420,11 +1420,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 53d2bfd5124bfb2a675bd85dd42ab243432450c5 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 53d2bfd5124bfb2a675bd85dd42ab243432450c5 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 53d2bfd5124bfb2a675bd85dd42ab243432450c5 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2256285a3fc703d36ad7683e92c82d131bacaabd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x02ݭ\xfeM\x1b\xb6\xd4"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2+\xd2Ih\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53d2bfd5124bfb2a675bd85dd42ab243432450c5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfa\x9e\xe2\x82\x16#\xc7\xeb"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1449,9 +1449,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 84e744792a10bfcbbd8d24d3ce4b5368221d7ebe 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 84e744792a10bfcbbd8d24d3ce4b5368221d7ebe 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 84e744792a10bfcbbd8d24d3ce4b5368221d7ebe 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1550,12 +1550,10 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:02599c451fa403800088b5b698426fd840895ec3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:02599c451fa403800088b5b698426fd840895ec3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:02599c451fa403800088b5b698426fd840895ec3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
-[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -1578,9 +1576,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6d7369d10c7e19bb6fdef92106280b6104818fa3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6d7369d10c7e19bb6fdef92106280b6104818fa3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6d7369d10c7e19bb6fdef92106280b6104818fa3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1599,18 +1597,18 @@ Debug = true
 [33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
 [33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[stage-13] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[stage-13] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 04 fc 00 0c | er.7.2.0........[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
 [33m[stage-13] [0m[36m0030 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 70 69 | (.......apple.pi[0m
 [33m[stage-13] [0m[36m0040 | 6e 65 61 70 70 6c 65 fc 00 9c ef 12 7e 01 00 00 | neapple.....~...[0m
 [33m[stage-13] [0m[36m0050 | 00 04 70 65 61 72 05 61 70 70 6c 65 fc 00 0c 28 | ..pear.apple...([0m
 [33m[stage-13] [0m[36m0060 | 8a c7 01 00 00 00 0a 73 74 72 61 77 62 65 72 72 | .......strawberr[0m
 [33m[stage-13] [0m[36m0070 | 79 05 6d 61 6e 67 6f fc 00 0c 28 8a c7 01 00 00 | y.mango...(.....[0m
 [33m[stage-13] [0m[36m0080 | 00 09 62 6c 75 65 62 65 72 72 79 06 6f 72 61 6e | ..blueberry.oran[0m
-[33m[stage-13] [0m[36m0090 | 67 65 ff 75 88 2d 53 6e 59 ab 7c 0a             | ge.u.-SnY.|.[0m
+[33m[stage-13] [0m[36m0090 | 67 65 ff 35 d1 a0 9e ee 98 4d 0c 0a             | ge.5.....M..[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2745706490 --dbfilename orange.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1801591972 --dbfilename orange.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -1650,7 +1648,7 @@ Debug = true
 [33m[stage-12] [0m[36m0070 | 65 72 72 79 09 70 69 6e 65 61 70 70 6c 65 ff 69 | erry.pineapple.i[0m
 [33m[stage-12] [0m[36m0080 | 69 c5 86 2b 78 5e 70 0a                         | i..+x^p.[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1491131059 --dbfilename pineapple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles66500949 --dbfilename pineapple.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1693,12 +1691,12 @@ Debug = true
 [33m[stage-11] [0m[36m0050 | 05 6d 61 6e 67 6f 09 72 61 73 70 62 65 72 72 79 | .mango.raspberry[0m
 [33m[stage-11] [0m[36m0060 | ff 1e dd aa 7c b5 f2 cc 39 0a                   | ....|...9.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3472488213 --dbfilename strawberry.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2423253280 --dbfilename strawberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n"[0m
-[33m[stage-11] [0m[36mclient: Received RESP array: ["pineapple", "mango", "blueberry"][0m
-[33m[stage-11] [0m[92mReceived ["pineapple", "mango", "blueberry"][0m
+[33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
+[33m[stage-11] [0m[36mclient: Received RESP array: ["mango", "blueberry", "pineapple"][0m
+[33m[stage-11] [0m[92mReceived ["mango", "blueberry", "pineapple"][0m
 [33m[stage-11] [0m[92mTest passed.[0m
 [33m[stage-11] [0m[36mTerminating program[0m
 [33m[stage-11] [0m[36mProgram terminated successfully[0m
@@ -1714,7 +1712,7 @@ Debug = true
 [33m[stage-10] [0m[36m0030 | 72 61 6e 67 65 0a 73 74 72 61 77 62 65 72 72 79 | range.strawberry[0m
 [33m[stage-10] [0m[36m0040 | ff 9a 13 5a 02 8b 9b 2d 32 0a                   | ...Z...-2.[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles339828687 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3041020273 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -1735,7 +1733,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 61 6e 61 6e 61 04 70 65 61 72 ff 40 3f 59 e4 93 | anana.pear.@?Y..[0m
 [33m[stage-9] [0m[36m0040 | 6b d8 e9 0a                                     | k...[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3278453243 --dbfilename strawberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles316146118 --dbfilename strawberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\nbanana\r\n"[0m
@@ -1746,12 +1744,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3785533704 --dbfilename pear.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2466512044 --dbfilename pear.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles3785533704\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles3785533704"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles3785533704"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles2466512044\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles2466512044"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles2466512044"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1763,15 +1761,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 18:46:55.342[0m
-[33m[stage-7] [0m[94mFetching key "pineapple" at 18:46:55.342 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 18:59:58.617[0m
+[33m[stage-7] [0m[94mFetching key "pineapple" at 18:59:58.617 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET pineapple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "strawberry"[0m
 [33m[stage-7] [0m[92mReceived "strawberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "pineapple" at 18:46:55.445 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "pineapple" at 18:59:58.720 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET pineapple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -601,9 +601,9 @@ Debug = true
 [33m[stage-36] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-36] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[stage-36] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1747019083628-0\r\n"[0m
-[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1747019083628-0"[0m
-[33m[stage-36] [0m[92mReceived "1747019083628-0"[0m
+[33m[stage-36] [0m[36mclient: Received bytes: "$15\r\n1749667606539-0\r\n"[0m
+[33m[stage-36] [0m[36mclient: Received RESP bulk string: "1749667606539-0"[0m
+[33m[stage-36] [0m[92mReceived "1749667606539-0"[0m
 [33m[stage-36] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[stage-36] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[stage-36] [0m[92mTest passed.[0m
@@ -720,11 +720,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Le!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4696abddd423b9d4f7316a157a9f714caa24a20\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xa7\x94$\xf8t\xb1\xda"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\\\xd7u-wRa\n"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 2[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -744,11 +744,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Le!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4696abddd423b9d4f7316a157a9f714caa24a20\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\x14[!*̶\xb0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\x1a\x1e\x1bL\xfbU\x87"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 3[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -768,11 +768,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Le!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4696abddd423b9d4f7316a157a9f714caa24a20\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82Ƹ\xbb\xb6\xf8\xd8\x10"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0\xb4\xf9\x1c)@۷"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [0m[36mCreating replica: 4[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -792,11 +792,11 @@ Debug = true
 [33m[stage-31] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-31] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-31] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0\r\n"[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
-[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC b4696abddd423b9d4f7316a157a9f714caa24a20 0"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0\r\n"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
+[33m[stage-31] [handshake] [0m[92mReceived "FULLRESYNC 9a0f49bc6a3afb6792a129279d1b9b2ca8f34141 0"[0m
 [33m[stage-31] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Le!h\xfa\bused-mem\u00a06\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b4696abddd423b9d4f7316a157a9f714caa24a20\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\xa0\x14^\xc1\xc6\xec\x03"[0m
+[33m[stage-31] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a0f49bc6a3afb6792a129279d1b9b2ca8f34141\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xed\xecn\x10\x87\xce\x12S"[0m
 [33m[stage-31] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-31] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-31] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -913,7 +913,7 @@ Debug = true
 [33m[stage-31] [test] [0m[36mreplica-4: Not sending ACK to Master[0m
 [33m[stage-31] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[stage-31] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[stage-31] [test] [0m[94mWAIT command returned after 2109 ms[0m
+[33m[stage-31] [test] [0m[94mWAIT command returned after 2089 ms[0m
 [33m[stage-31] [0m[92mTest passed.[0m
 [33m[stage-31] [0m[36mTerminating program[0m
 [33m[stage-31] [0m[36mProgram terminated successfully[0m
@@ -939,11 +939,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Oe!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9f45594e0ca4c4a0720036283bacdf77c65aa21\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b^t\xb9#q\xfe\x0e"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,\xdfZ\xcc\xf7\xb3t$"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 2[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -963,11 +963,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Oe!h\xfa\bused-mem\xc2\x10$\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9f45594e0ca4c4a0720036283bacdf77c65aa21\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6\xed\xbb\xbc\xf1\xc9\xf9d"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\x121\xfa\xcc\x1a@\xa9"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 3[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -987,11 +987,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Oe!h\xfa\bused-mem\xc2P-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9f45594e0ca4c4a0720036283bacdf77c65aa21\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3?X&m\xfd\x97\xc4"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb0\xbc\xd6\xfd\xa9\xa1Ι"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [0m[36mCreating replica: 4[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: $ redis-cli PING[0m
@@ -1011,11 +1011,11 @@ Debug = true
 [33m[stage-30] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-30] [handshake] [0m[94mreplica-4: > PSYNC ? -1[0m
 [33m[stage-30] [handshake] [0m[36mreplica-4: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0\r\n"[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
-[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a9f45594e0ca4c4a0720036283bacdf77c65aa21 0"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "+FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0\r\n"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received RESP simple string: "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
+[33m[stage-30] [handshake] [0m[92mReceived "FULLRESYNC a99ebca38ec84700bb6e577a347b4d8d61003c1f 0"[0m
 [33m[stage-30] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Oe!h\xfa\bused-mem\u00a06\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a9f45594e0ca4c4a0720036283bacdf77c65aa21\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdbY\xf4\xc3\x1aã\xd7"[0m
+[33m[stage-30] [handshake] [0m[36mreplica-4: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x19\xcfIh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a99ebca38ec84700bb6e577a347b4d8d61003c1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\xe4A\xf1\a/\a}"[0m
 [33m[stage-30] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-30] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[stage-30] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1224,11 +1224,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-1: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-1: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qe!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d6bd41ae5acd71a99314270b0492cb749761d088\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\xbdd\r\xa4\xfa4\x1b"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-1: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1b\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6w\xb4%\x80\xc6\xd4\x19"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 2[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: $ redis-cli PING[0m
@@ -1248,11 +1248,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-2: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-2: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qe!h\xfa\bused-mem\xc2\x10i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d6bd41ae5acd71a99314270b0492cb749761d088\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x92\xa8\xcfhy\xf0d\x8d"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-2: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1b\xcfIh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\x8b\x1e9\x8c)R\xd3"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [0m[36mCreating replica: 3[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: $ redis-cli PING[0m
@@ -1272,11 +1272,11 @@ Debug = true
 [33m[stage-25] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-25] [handshake] [0m[94mreplica-3: > PSYNC ? -1[0m
 [33m[stage-25] [handshake] [0m[36mreplica-3: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0\r\n"[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
-[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC d6bd41ae5acd71a99314270b0492cb749761d088 0"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "+FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0\r\n"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received RESP simple string: "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
+[33m[stage-25] [handshake] [0m[92mReceived "FULLRESYNC 698c9754445c802e2aebaf7bdba3d2eba37901d7 0"[0m
 [33m[stage-25] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qe!h\xfa\bused-mem\xc2`6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d6bd41ae5acd71a99314270b0492cb749761d088\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffp\x06\xdf\xe0\x986W\x9e"[0m
+[33m[stage-25] [handshake] [0m[36mreplica-3: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(698c9754445c802e2aebaf7bdba3d2eba37901d7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaa\x83)\xe5\xdc\f\xe8\xac"[0m
 [33m[stage-25] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-25] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-25] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1361,11 +1361,11 @@ Debug = true
 [33m[stage-24] [handshake] [0m[92mReceived "OK"[0m
 [33m[stage-24] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[stage-24] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 2ae499dc98a9fe79b048f4f119977d7e0b202312 0\r\n"[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 2ae499dc98a9fe79b048f4f119977d7e0b202312 0"[0m
-[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 2ae499dc98a9fe79b048f4f119977d7e0b202312 0"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0\r\n"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0"[0m
+[33m[stage-24] [handshake] [0m[92mReceived "FULLRESYNC 68335e05fccc7fa822c642f26df224c33c94dc9f 0"[0m
 [33m[stage-24] [handshake] [0m[36mReading RDB file...[0m
-[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qe!h\xfa\bused-mem\xc2`\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2ae499dc98a9fe79b048f4f119977d7e0b202312\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\t\x86\xd2ct\x85\xab\xfc"[0m
+[33m[stage-24] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(68335e05fccc7fa822c642f26df224c33c94dc9f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҮcCv\xc0\xda7"[0m
 [33m[stage-24] [handshake] [0m[92mReceived RDB file[0m
 [33m[stage-24] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[stage-24] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1420,11 +1420,11 @@ Debug = true
 [33m[stage-23] [0m[92mReceived "OK"[0m
 [33m[stage-23] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-23] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC d9d2aa52670446f6ae0535ceae2ddfce09ddaf04 0\r\n"[0m
-[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC d9d2aa52670446f6ae0535ceae2ddfce09ddaf04 0"[0m
-[33m[stage-23] [0m[92mReceived "FULLRESYNC d9d2aa52670446f6ae0535ceae2ddfce09ddaf04 0"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "+FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0\r\n"[0m
+[33m[stage-23] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0"[0m
+[33m[stage-23] [0m[92mReceived "FULLRESYNC 2256285a3fc703d36ad7683e92c82d131bacaabd 0"[0m
 [33m[stage-23] [0m[36mReading RDB file...[0m
-[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Re!h\xfa\bused-mem\xc2@~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9d2aa52670446f6ae0535ceae2ddfce09ddaf04\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff3\xff\x00[\x84Ⱦ\n"[0m
+[33m[stage-23] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x1c\xcfIh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2256285a3fc703d36ad7683e92c82d131bacaabd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x02ݭ\xfeM\x1b\xb6\xd4"[0m
 [33m[stage-23] [0m[92mReceived RDB file[0m
 [33m[stage-23] [0m[92mTest passed.[0m
 [33m[stage-23] [0m[36mTerminating program[0m
@@ -1449,9 +1449,9 @@ Debug = true
 [33m[stage-22] [0m[92mReceived "OK"[0m
 [33m[stage-22] [0m[94mclient: > PSYNC ? -1[0m
 [33m[stage-22] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 32e3737b10f668039c075964374c05e072c1b989 0\r\n"[0m
-[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 32e3737b10f668039c075964374c05e072c1b989 0"[0m
-[33m[stage-22] [0m[92mReceived "FULLRESYNC 32e3737b10f668039c075964374c05e072c1b989 0"[0m
+[33m[stage-22] [0m[36mclient: Received bytes: "+FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0\r\n"[0m
+[33m[stage-22] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0"[0m
+[33m[stage-22] [0m[92mReceived "FULLRESYNC 2ebb6d9c8f0d5c248af1de24a62c892c02c363db 0"[0m
 [33m[stage-22] [0m[92mTest passed.[0m
 [33m[stage-22] [0m[36mTerminating program[0m
 [33m[stage-22] [0m[36mProgram terminated successfully[0m
@@ -1550,10 +1550,12 @@ Debug = true
 [33m[stage-17] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-17] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-17] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2a758d8ea7db912dab1060e95b217d32fe4feba4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2a758d8ea7db912dab1060e95b217d32fe4feba4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2a758d8ea7db912dab1060e95b217d32fe4feba4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-17] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-17] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ad3533b9a7c6b2b0665ba6edec8a77a4eca04ef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_replid:xxx in response.[0m
+[33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[stage-17] [0m[92mTest passed.[0m
 [33m[stage-17] [0m[36mTerminating program[0m
@@ -1576,9 +1578,9 @@ Debug = true
 [33m[stage-15] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[stage-15] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[stage-15] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d8ecc72799ed8c13bc0a2d6318302f5a69830b2b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d8ecc72799ed8c13bc0a2d6318302f5a69830b2b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d8ecc72799ed8c13bc0a2d6318302f5a69830b2b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[stage-15] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[stage-15] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ee0e391f03a672eabd2926c7631ec125752f4cc2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[stage-15] [0m[92mFound role:master in response.[0m
 [33m[stage-15] [0m[92mTest passed.[0m
 [33m[stage-15] [0m[36mTerminating program[0m
@@ -1597,18 +1599,18 @@ Debug = true
 [33m[stage-13] [0m[36mHexdump of RDB file contents: [0m
 [33m[stage-13] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-13] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[stage-13] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[stage-13] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
+[33m[stage-13] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[stage-13] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[stage-13] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 04 fc 00 0c | er.7.2.0........[0m
 [33m[stage-13] [0m[36m0030 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 70 69 | (.......apple.pi[0m
 [33m[stage-13] [0m[36m0040 | 6e 65 61 70 70 6c 65 fc 00 9c ef 12 7e 01 00 00 | neapple.....~...[0m
 [33m[stage-13] [0m[36m0050 | 00 04 70 65 61 72 05 61 70 70 6c 65 fc 00 0c 28 | ..pear.apple...([0m
 [33m[stage-13] [0m[36m0060 | 8a c7 01 00 00 00 0a 73 74 72 61 77 62 65 72 72 | .......strawberr[0m
 [33m[stage-13] [0m[36m0070 | 79 05 6d 61 6e 67 6f fc 00 0c 28 8a c7 01 00 00 | y.mango...(.....[0m
 [33m[stage-13] [0m[36m0080 | 00 09 62 6c 75 65 62 65 72 72 79 06 6f 72 61 6e | ..blueberry.oran[0m
-[33m[stage-13] [0m[36m0090 | 67 65 ff 35 d1 a0 9e ee 98 4d 0c 0a             | ge.5.....M..[0m
+[33m[stage-13] [0m[36m0090 | 67 65 ff 75 88 2d 53 6e 59 ab 7c 0a             | ge.u.-SnY.|.[0m
 [33m[stage-13] [0m[36m[0m
-[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles3195009256 --dbfilename orange.rdb[0m
+[33m[stage-13] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles2745706490 --dbfilename orange.rdb[0m
 [33m[stage-13] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[stage-13] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[stage-13] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -1648,7 +1650,7 @@ Debug = true
 [33m[stage-12] [0m[36m0070 | 65 72 72 79 09 70 69 6e 65 61 70 70 6c 65 ff 69 | erry.pineapple.i[0m
 [33m[stage-12] [0m[36m0080 | 69 c5 86 2b 78 5e 70 0a                         | i..+x^p.[0m
 [33m[stage-12] [0m[36m[0m
-[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles726036248 --dbfilename pineapple.rdb[0m
+[33m[stage-12] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles1491131059 --dbfilename pineapple.rdb[0m
 [33m[stage-12] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[stage-12] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[stage-12] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -1691,7 +1693,7 @@ Debug = true
 [33m[stage-11] [0m[36m0050 | 05 6d 61 6e 67 6f 09 72 61 73 70 62 65 72 72 79 | .mango.raspberry[0m
 [33m[stage-11] [0m[36m0060 | ff 1e dd aa 7c b5 f2 cc 39 0a                   | ....|...9.[0m
 [33m[stage-11] [0m[36m[0m
-[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles1766360006 --dbfilename strawberry.rdb[0m
+[33m[stage-11] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3472488213 --dbfilename strawberry.rdb[0m
 [33m[stage-11] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-11] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-11] [0m[36mclient: Received bytes: "*3\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n"[0m
@@ -1712,7 +1714,7 @@ Debug = true
 [33m[stage-10] [0m[36m0030 | 72 61 6e 67 65 0a 73 74 72 61 77 62 65 72 72 79 | range.strawberry[0m
 [33m[stage-10] [0m[36m0040 | ff 9a 13 5a 02 8b 9b 2d 32 0a                   | ...Z...-2.[0m
 [33m[stage-10] [0m[36m[0m
-[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles573914021 --dbfilename banana.rdb[0m
+[33m[stage-10] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles339828687 --dbfilename banana.rdb[0m
 [33m[stage-10] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[stage-10] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[stage-10] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -1733,7 +1735,7 @@ Debug = true
 [33m[stage-9] [0m[36m0030 | 61 6e 61 6e 61 04 70 65 61 72 ff 40 3f 59 e4 93 | anana.pear.@?Y..[0m
 [33m[stage-9] [0m[36m0040 | 6b d8 e9 0a                                     | k...[0m
 [33m[stage-9] [0m[36m[0m
-[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles2563734092 --dbfilename strawberry.rdb[0m
+[33m[stage-9] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3278453243 --dbfilename strawberry.rdb[0m
 [33m[stage-9] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[stage-9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[stage-9] [0m[36mclient: Received bytes: "*1\r\n$6\r\nbanana\r\n"[0m
@@ -1744,12 +1746,12 @@ Debug = true
 [33m[stage-9] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-8] [0m[94mRunning tests for Stage #8: zg5[0m
-[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles332935576 --dbfilename pear.rdb[0m
+[33m[stage-8] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdbfiles3785533704 --dbfilename pear.rdb[0m
 [33m[stage-8] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[stage-8] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles332935576\r\n"[0m
-[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles332935576"][0m
-[33m[stage-8] [0m[92mReceived ["dir", "/private/var/folders/nm/b5lzlxrs65vgxg9gg1x477zw0000gn/T/rdbfiles332935576"][0m
+[33m[stage-8] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$23\r\n/tmp/rdbfiles3785533704\r\n"[0m
+[33m[stage-8] [0m[36mclient: Received RESP array: ["dir", "/tmp/rdbfiles3785533704"][0m
+[33m[stage-8] [0m[92mReceived ["dir", "/tmp/rdbfiles3785533704"][0m
 [33m[stage-8] [0m[92mTest passed.[0m
 [33m[stage-8] [0m[36mTerminating program[0m
 [33m[stage-8] [0m[36mProgram terminated successfully[0m
@@ -1761,15 +1763,15 @@ Debug = true
 [33m[stage-7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[stage-7] [0m[92mReceived "OK"[0m
-[33m[stage-7] [0m[92mReceived OK at 11:04:53.495[0m
-[33m[stage-7] [0m[94mFetching key "pineapple" at 11:04:53.495 (should not be expired)[0m
+[33m[stage-7] [0m[92mReceived OK at 18:46:55.342[0m
+[33m[stage-7] [0m[94mFetching key "pineapple" at 18:46:55.342 (should not be expired)[0m
 [33m[stage-7] [0m[94m> GET pineapple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
 [33m[stage-7] [0m[36mReceived RESP bulk string: "strawberry"[0m
 [33m[stage-7] [0m[92mReceived "strawberry"[0m
 [33m[stage-7] [0m[36mSleeping for 101ms[0m
-[33m[stage-7] [0m[94mFetching key "pineapple" at 11:04:53.598 (should be expired)[0m
+[33m[stage-7] [0m[94mFetching key "pineapple" at 18:46:55.445 (should be expired)[0m
 [33m[stage-7] [0m[94m> GET pineapple[0m
 [33m[stage-7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[stage-7] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_repl_id.go
+++ b/internal/test_repl_id.go
@@ -50,11 +50,13 @@ func testReplReplicationID(stageHarness *test_case_harness.TestCaseHarness) erro
 
 	if regexp.MustCompile("master_replid:([a-zA-Z0-9]+)").Match([]byte(responseValue.String())) {
 		logger.Successf("Found master_replid:xxx in response.")
+		logger.Successf("Found master_replid:xxx in response.")
 	} else {
 		patternMatchError = fmt.Errorf("Expected master_replid:xxx to be present in response. Got: %q", responseValue.String())
 	}
 
 	if regexp.MustCompile("master_repl_offset:0").Match([]byte(responseValue.String())) {
+		logger.Successf("Found master_reploffset:0 in response.")
 		logger.Successf("Found master_reploffset:0 in response.")
 	} else {
 		patternMatchError = fmt.Errorf("Expected master_repl_offset:0 to be present in response. Got: %q", responseValue.String())

--- a/internal/test_repl_id.go
+++ b/internal/test_repl_id.go
@@ -50,13 +50,11 @@ func testReplReplicationID(stageHarness *test_case_harness.TestCaseHarness) erro
 
 	if regexp.MustCompile("master_replid:([a-zA-Z0-9]+)").Match([]byte(responseValue.String())) {
 		logger.Successf("Found master_replid:xxx in response.")
-		logger.Successf("Found master_replid:xxx in response.")
 	} else {
 		patternMatchError = fmt.Errorf("Expected master_replid:xxx to be present in response. Got: %q", responseValue.String())
 	}
 
 	if regexp.MustCompile("master_repl_offset:0").Match([]byte(responseValue.String())) {
-		logger.Successf("Found master_reploffset:0 in response.")
 		logger.Successf("Found master_reploffset:0 in response.")
 	} else {
 		patternMatchError = fmt.Errorf("Expected master_repl_offset:0 to be present in response. Got: %q", responseValue.String())


### PR DESCRIPTION
Introduce a workflow to regenerate fixtures on labeled pull requests and add a setup target in the Makefile for Redis tester prerequisites. Update test job name for improved clarity.