### PR TITLE
fix: correct mutex handling in SendCommandTestCase Run method

### DIFF
--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -42,9 +42,9 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		}
 
 		t.readMutex.Lock()
-		defer t.readMutex.Unlock()
-
 		value, err = client.ReadValue()
+		t.readMutex.Unlock()
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/sending-output-but-not-being-recognised-by-tester/12346