### PR TITLE
Refactor: Avoid random in naming and re-use `ReceiveValueTestCase`

### DIFF
--- a/internal/rdb_file_creator.go
+++ b/internal/rdb_file_creator.go
@@ -26,7 +26,7 @@ type RDBFileCreator struct {
 }
 
 func NewRDBFileCreator() (*RDBFileCreator, error) {
-	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles")
+	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles-")
 	if err != nil {
 		return &RDBFileCreator{}, err
 	}

--- a/internal/rdb_file_creator.go
+++ b/internal/rdb_file_creator.go
@@ -26,7 +26,7 @@ type RDBFileCreator struct {
 }
 
 func NewRDBFileCreator() (*RDBFileCreator, error) {
-	tmpDir, err := MkdirTemp("rdbfiles")
+	tmpDir, err := MkdirTemp("rdb")
 	if err != nil {
 		return &RDBFileCreator{}, err
 	}

--- a/internal/rdb_file_creator.go
+++ b/internal/rdb_file_creator.go
@@ -26,7 +26,7 @@ type RDBFileCreator struct {
 }
 
 func NewRDBFileCreator() (*RDBFileCreator, error) {
-	tmpDir, err := os.MkdirTemp("", "rdbfiles")
+	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles")
 	if err != nil {
 		return &RDBFileCreator{}, err
 	}

--- a/internal/rdb_file_creator.go
+++ b/internal/rdb_file_creator.go
@@ -26,19 +26,13 @@ type RDBFileCreator struct {
 }
 
 func NewRDBFileCreator() (*RDBFileCreator, error) {
-	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles-")
+	tmpDir, err := MkdirTemp("rdbfiles")
 	if err != nil {
 		return &RDBFileCreator{}, err
 	}
 
-	// On MacOS, the tmpDir is a symlink to a directory in /var/folders/...
-	realDir, err := filepath.EvalSymlinks(tmpDir)
-	if err != nil {
-		return &RDBFileCreator{}, fmt.Errorf("could not resolve symlink: %v", err)
-	}
-
 	return &RDBFileCreator{
-		Dir:      realDir,
+		Dir:      tmpDir,
 		Filename: fmt.Sprintf("%s.rdb", random.RandomWord()),
 	}, nil
 }

--- a/internal/rdb_file_creator_test.go
+++ b/internal/rdb_file_creator_test.go
@@ -18,10 +18,10 @@ func TestRDBFileCreator(t *testing.T) {
 		t.Fatalf("CodeCrafters Tester Error: %s", err)
 	}
 
-	randomKeyAndValue := random.RandomWords(2)
-	randomKey, randomValue := randomKeyAndValue[0], randomKeyAndValue[1]
+	keyAndValue := random.RandomWords(2)
+	key, value := keyAndValue[0], keyAndValue[1]
 
-	if err := RDBFileCreator.Write([]KeyValuePair{{key: randomKey, value: randomValue}}); err != nil {
+	if err := RDBFileCreator.Write([]KeyValuePair{{key: key, value: value}}); err != nil {
 		t.Fatalf("CodeCrafters Tester Error: %s", err)
 	}
 

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -112,7 +112,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 	replacements := map[string][]*regexp.Regexp{
 		"tcp_port":                {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
 		" tmp_dir ":               {regexp.MustCompile(` /private/tmp/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
-		"$length\\r\\ntmp_dir\\r": {regexp.MustCompile(`\$\d+\\r\\n/private/var/folders/[^ ]+\\r\\n`), regexp.MustCompile(`\$\d+\\r\\n/tmp/[^ ]+\\r\\n`)},
+		"$length\\r\\ntmp_dir\\r": {regexp.MustCompile(`\$\d+\\r\\n/private/tmp/[^ ]+\\r\\n`), regexp.MustCompile(`\$\d+\\r\\n/tmp/[^ ]+\\r\\n`)},
 		"\"tmp_dir\"":             {regexp.MustCompile(`"/private/tmp/[^"]+"`), regexp.MustCompile(`"/tmp/[^"]+"`)},
 		"timestamp":               {regexp.MustCompile(`\d{2}:\d{2}:\d{2}\.\d{3}`)},
 		"info_replication":        {regexp.MustCompile(`"# Replication\\r\\n[^"]+"`)},

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -110,8 +110,8 @@ func TestStages(t *testing.T) {
 
 func normalizeTesterOutput(testerOutput []byte) []byte {
 	replacements := map[string][]*regexp.Regexp{
-		"tcp_port":                {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
-		" tmp_dir ":               {regexp.MustCompile(` /private/var/folders/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
+		"tcp_port": {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
+		// " tmp_dir ":               {regexp.MustCompile(` /private/var/folders/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
 		"$length\\r\\ntmp_dir\\r": {regexp.MustCompile(`\$\d+\\r\\n/private/var/folders/[^ ]+\\r\\n`), regexp.MustCompile(`\$\d+\\r\\n/tmp/[^ ]+\\r\\n`)},
 		"\"tmp_dir\"":             {regexp.MustCompile(`"/private/var/folders/[^"]+"`), regexp.MustCompile(`"/tmp/[^"]+"`)},
 		"timestamp":               {regexp.MustCompile(`\d{2}:\d{2}:\d{2}\.\d{3}`)},

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -111,9 +111,9 @@ func TestStages(t *testing.T) {
 func normalizeTesterOutput(testerOutput []byte) []byte {
 	replacements := map[string][]*regexp.Regexp{
 		"tcp_port":                {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
-		" tmp_dir ":               {regexp.MustCompile(` /private/var/folders/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
+		" tmp_dir ":               {regexp.MustCompile(` /private/tmp/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
 		"$length\\r\\ntmp_dir\\r": {regexp.MustCompile(`\$\d+\\r\\n/private/var/folders/[^ ]+\\r\\n`), regexp.MustCompile(`\$\d+\\r\\n/tmp/[^ ]+\\r\\n`)},
-		"\"tmp_dir\"":             {regexp.MustCompile(`"/private/var/folders/[^"]+"`), regexp.MustCompile(`"/tmp/[^"]+"`)},
+		"\"tmp_dir\"":             {regexp.MustCompile(`"/private/tmp/[^"]+"`), regexp.MustCompile(`"/tmp/[^"]+"`)},
 		"timestamp":               {regexp.MustCompile(`\d{2}:\d{2}:\d{2}\.\d{3}`)},
 		"info_replication":        {regexp.MustCompile(`"# Replication\\r\\n[^"]+"`)},
 		"replication_id":          {regexp.MustCompile(`FULLRESYNC [A-Za-z0-9]+ 0`)},

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -110,8 +110,8 @@ func TestStages(t *testing.T) {
 
 func normalizeTesterOutput(testerOutput []byte) []byte {
 	replacements := map[string][]*regexp.Regexp{
-		"tcp_port": {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
-		// " tmp_dir ":               {regexp.MustCompile(` /private/var/folders/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
+		"tcp_port":                {regexp.MustCompile(`read tcp 127.0.0.1:\d+->127.0.0.1:6379: read: connection reset by peer`)},
+		" tmp_dir ":               {regexp.MustCompile(` /private/var/folders/[^ ]+ `), regexp.MustCompile(` /tmp/[^ ]+ `)},
 		"$length\\r\\ntmp_dir\\r": {regexp.MustCompile(`\$\d+\\r\\n/private/var/folders/[^ ]+\\r\\n`), regexp.MustCompile(`\$\d+\\r\\n/tmp/[^ ]+\\r\\n`)},
 		"\"tmp_dir\"":             {regexp.MustCompile(`"/private/var/folders/[^"]+"`), regexp.MustCompile(`"/tmp/[^"]+"`)},
 		"timestamp":               {regexp.MustCompile(`\d{2}:\d{2}:\d{2}\.\d{3}`)},

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -22,13 +22,12 @@ func (t *ReceiveValueTestCase) Run(client *resp_client.RespConnection, logger *l
 	if err != nil {
 		return err
 	}
-	return t.runAssertionAndCheck(client, logger, value)
+	t.ActualValue = value
+	return t.runAssertionAndCheck(client, logger)
 }
 
-func (t *ReceiveValueTestCase) runAssertionAndCheck(client *resp_client.RespConnection, logger *logger.Logger, value resp_value.Value) error {
-	t.ActualValue = value
-
-	if err := t.Assertion.Run(value); err != nil {
+func (t *ReceiveValueTestCase) runAssertionAndCheck(client *resp_client.RespConnection, logger *logger.Logger) error {
+	if err := t.Assertion.Run(t.ActualValue); err != nil {
 		return err
 	}
 
@@ -40,6 +39,6 @@ func (t *ReceiveValueTestCase) runAssertionAndCheck(client *resp_client.RespConn
 		}
 	}
 
-	logger.Successf("Received %s", value.FormattedString())
+	logger.Successf("Received %s", t.ActualValue.FormattedString())
 	return nil
 }

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -22,10 +22,13 @@ func (t *ReceiveValueTestCase) Run(client *resp_client.RespConnection, logger *l
 	if err != nil {
 		return err
 	}
+	return t.runAssertionAndCheck(client, logger, value)
+}
 
+func (t *ReceiveValueTestCase) runAssertionAndCheck(client *resp_client.RespConnection, logger *logger.Logger, value resp_value.Value) error {
 	t.ActualValue = value
 
-	if err = t.Assertion.Run(value); err != nil {
+	if err := t.Assertion.Run(value); err != nil {
 		return err
 	}
 

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -23,10 +23,10 @@ func (t *ReceiveValueTestCase) Run(client *resp_client.RespConnection, logger *l
 		return err
 	}
 	t.ActualValue = value
-	return t.runAssertionAndCheck(client, logger)
+	return t.AssertAndCheck(client, logger)
 }
 
-func (t *ReceiveValueTestCase) runAssertionAndCheck(client *resp_client.RespConnection, logger *logger.Logger) error {
+func (t *ReceiveValueTestCase) AssertAndCheck(client *resp_client.RespConnection, logger *logger.Logger) error {
 	if err := t.Assertion.Run(t.ActualValue); err != nil {
 		return err
 	}

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -23,10 +23,10 @@ func (t *ReceiveValueTestCase) Run(client *resp_client.RespConnection, logger *l
 		return err
 	}
 	t.ActualValue = value
-	return t.AssertAndCheck(client, logger)
+	return t.AssertAndCheckUnread(client, logger)
 }
 
-func (t *ReceiveValueTestCase) AssertAndCheck(client *resp_client.RespConnection, logger *logger.Logger) error {
+func (t *ReceiveValueTestCase) AssertAndCheckUnread(client *resp_client.RespConnection, logger *logger.Logger) error {
 	if err := t.Assertion.Run(t.ActualValue); err != nil {
 		return err
 	}

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -18,15 +18,23 @@ type ReceiveValueTestCase struct {
 }
 
 func (t *ReceiveValueTestCase) Run(client *resp_client.RespConnection, logger *logger.Logger) error {
+	err := t.RunWithoutAssert(client)
+	if err != nil {
+		return err
+	}
+	return t.Assert(client, logger)
+}
+
+func (t *ReceiveValueTestCase) RunWithoutAssert(client *resp_client.RespConnection) error {
 	value, err := client.ReadValue()
 	if err != nil {
 		return err
 	}
 	t.ActualValue = value
-	return t.AssertAndCheckUnread(client, logger)
+	return nil
 }
 
-func (t *ReceiveValueTestCase) AssertAndCheckUnread(client *resp_client.RespConnection, logger *logger.Logger) error {
+func (t *ReceiveValueTestCase) Assert(client *resp_client.RespConnection, logger *logger.Logger) error {
 	if err := t.Assertion.Run(t.ActualValue); err != nil {
 		return err
 	}

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -20,7 +20,8 @@ type SendCommandTestCase struct {
 	Retries                   int
 	ShouldRetryFunc           func(resp_value.Value) bool
 
-	receiveCommandTestCase *ReceiveValueTestCase
+	// ReceivedResponse is set after the test case is run
+	ReceivedResponse resp_value.Value
 
 	readMutex sync.Mutex
 }
@@ -64,12 +65,13 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		}
 	}
 
-	t.receiveCommandTestCase = &ReceiveValueTestCase{
+	t.ReceivedResponse = value
+	receiveCommandTestCase := ReceiveValueTestCase{
 		Assertion:                 t.Assertion,
 		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
 		ActualValue:               value,
 	}
-	return t.receiveCommandTestCase.runAssertionAndCheck(client, logger)
+	return receiveCommandTestCase.runAssertionAndCheck(client, logger)
 }
 
 func (t *SendCommandTestCase) PauseReadingResponse() {
@@ -78,11 +80,4 @@ func (t *SendCommandTestCase) PauseReadingResponse() {
 
 func (t *SendCommandTestCase) ResumeReadingResponse() {
 	t.readMutex.Unlock()
-}
-
-func (t *SendCommandTestCase) GetReceivedResponse() resp_value.Value {
-	if t.receiveCommandTestCase != nil {
-		return t.receiveCommandTestCase.ActualValue
-	}
-	return resp_value.Value{}
 }

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -71,7 +71,7 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
 		ActualValue:               value,
 	}
-	return receiveCommandTestCase.runAssertionAndCheck(client, logger)
+	return receiveCommandTestCase.AssertAndCheck(client, logger)
 }
 
 func (t *SendCommandTestCase) PauseReadingResponse() {

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -82,5 +82,8 @@ func (t *SendCommandTestCase) ResumeReadingResponse() {
 }
 
 func (t *SendCommandTestCase) GetReceivedResponse() resp_value.Value {
-	return t.receiveCommandTestCase.ActualValue
+	if t.receiveCommandTestCase != nil {
+		return t.receiveCommandTestCase.ActualValue
+	}
+	return resp_value.Value{}
 }

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -71,7 +71,7 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
 		ActualValue:               value,
 	}
-	return receiveCommandTestCase.AssertAndCheck(client, logger)
+	return receiveCommandTestCase.AssertAndCheckUnread(client, logger)
 }
 
 func (t *SendCommandTestCase) PauseReadingResponse() {

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -26,8 +26,6 @@ type SendCommandTestCase struct {
 }
 
 func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *logger.Logger) error {
-	// We initialize early to prevent nil dereference errors in GetReceivedResponse()
-	t.receiveCommandTestCase = &ReceiveValueTestCase{}
 	var value resp_value.Value
 	var err error
 

--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -67,8 +67,9 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 	t.receiveCommandTestCase = &ReceiveValueTestCase{
 		Assertion:                 t.Assertion,
 		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
+		ActualValue:               value,
 	}
-	return t.receiveCommandTestCase.runAssertionAndCheck(client, logger, value)
+	return t.receiveCommandTestCase.runAssertionAndCheck(client, logger)
 }
 
 func (t *SendCommandTestCase) PauseReadingResponse() {

--- a/internal/test_expiry.go
+++ b/internal/test_expiry.go
@@ -26,13 +26,13 @@ func testExpiry(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	randomWords := random.RandomWords(2)
-	randomKey := randomWords[0]
-	randomValue := randomWords[1]
+	keyAndValue := random.RandomWords(2)
+	key := keyAndValue[0]
+	value := keyAndValue[1]
 
 	setCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "set",
-		Args:      []string{randomKey, randomValue, "px", "100"},
+		Args:      []string{key, value, "px", "100"},
 		Assertion: resp_assertions.NewStringAssertion("OK"),
 	}
 
@@ -42,12 +42,12 @@ func testExpiry(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger.Successf("Received OK at %s", time.Now().Format("15:04:05.000"))
-	logger.Infof("Fetching key %q at %s (should not be expired)", randomKey, time.Now().Format("15:04:05.000"))
+	logger.Infof("Fetching key %q at %s (should not be expired)", key, time.Now().Format("15:04:05.000"))
 
 	getCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "get",
-		Args:      []string{randomKey},
-		Assertion: resp_assertions.NewStringAssertion(randomValue),
+		Args:      []string{key},
+		Assertion: resp_assertions.NewStringAssertion(value),
 	}
 
 	if err := getCommandTestCase.Run(client, logger); err != nil {
@@ -58,11 +58,11 @@ func testExpiry(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger.Debugf("Sleeping for 101ms")
 	time.Sleep(101 * time.Millisecond)
 
-	logger.Infof("Fetching key %q at %s (should be expired)", randomKey, time.Now().Format("15:04:05.000"))
+	logger.Infof("Fetching key %q at %s (should be expired)", key, time.Now().Format("15:04:05.000"))
 
 	getCommandTestCase = test_cases.SendCommandTestCase{
 		Command:   "get",
-		Args:      []string{randomKey},
+		Args:      []string{key},
 		Assertion: resp_assertions.NewNilAssertion(),
 	}
 

--- a/internal/test_get_set.go
+++ b/internal/test_get_set.go
@@ -24,15 +24,15 @@ func testGetSet(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	randomWords := random.RandomWords(2)
+	keyAndValue := random.RandomWords(2)
 
-	randomKey := randomWords[0]
-	randomValue := randomWords[1]
+	key := keyAndValue[0]
+	randovalueValue := keyAndValue[1]
 
-	logger.Debugf("Setting key %s to %s", randomKey, randomValue)
+	logger.Debugf("Setting key %s to %s", key, randovalueValue)
 	setCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "set",
-		Args:      []string{randomKey, randomValue},
+		Args:      []string{key, randovalueValue},
 		Assertion: resp_assertions.NewStringAssertion("OK"),
 	}
 
@@ -41,12 +41,12 @@ func testGetSet(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	logger.Debugf("Getting key %s", randomKey)
+	logger.Debugf("Getting key %s", key)
 
 	getCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "get",
-		Args:      []string{randomKey},
-		Assertion: resp_assertions.NewStringAssertion(randomValue),
+		Args:      []string{key},
+		Assertion: resp_assertions.NewStringAssertion(randovalueValue),
 	}
 
 	if err := getCommandTestCase.Run(client, logger); err != nil {

--- a/internal/test_get_set.go
+++ b/internal/test_get_set.go
@@ -27,12 +27,12 @@ func testGetSet(stageHarness *test_case_harness.TestCaseHarness) error {
 	keyAndValue := random.RandomWords(2)
 
 	key := keyAndValue[0]
-	randovalueValue := keyAndValue[1]
+	value := keyAndValue[1]
 
-	logger.Debugf("Setting key %s to %s", key, randovalueValue)
+	logger.Debugf("Setting key %s to %s", key, value)
 	setCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "set",
-		Args:      []string{key, randovalueValue},
+		Args:      []string{key, value},
 		Assertion: resp_assertions.NewStringAssertion("OK"),
 	}
 
@@ -46,7 +46,7 @@ func testGetSet(stageHarness *test_case_harness.TestCaseHarness) error {
 	getCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "get",
 		Args:      []string{key},
-		Assertion: resp_assertions.NewStringAssertion(randovalueValue),
+		Assertion: resp_assertions.NewStringAssertion(value),
 	}
 
 	if err := getCommandTestCase.Run(client, logger); err != nil {

--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -7,15 +7,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:12.417[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 17:28:12.417 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:34:55.476[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:34:55.477 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 17:28:12.520 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:34:55.580 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -7,15 +7,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 19:17:39.587[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 19:17:39.587 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:12.417[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 17:28:12.417 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 19:17:39.690 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 17:28:12.520 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876523951-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876523951-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751876523951-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946729976-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946729976-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751946729976-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1285,11 +1285,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\xfd\xea\f1*\xa1'"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\x9c\xc6k\x95\xe5\xfbc"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1309,11 +1309,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff =\xbd\",\xf6\xfb;"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\\\x91E\x889\xa1\x7f"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1333,11 +1333,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%\xef^\xb8\xb0\u0095\x9b"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;\x8er\xdf\x14\r\xcf\xdf"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1457,7 +1457,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2003 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2006 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1491,11 +1491,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81[\x1b\x7fh1\xec\xe9"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmz\f\x9c\x19\a\x01M"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1515,11 +1515,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\x9bLQu\xed\xb6\xf5"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҺ[\xb2\x04\xdb[Q"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1539,11 +1539,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;I\xaf\xcb\xe9\xd9\xd8U"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd7h\xb8(\x98\xef5\xf1"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1563,11 +1563,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffR\\\x9b\x05Q\x83\xb10"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbe}\x8c\xe6 \xb5\\\x94"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1587,11 +1587,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x843\x11\xb2\xdcN ("[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh\x12\x06Q\xadx͌"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -1611,11 +1611,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\xe1\xf2(@zN\x88"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xc0\xe5\xcb1L\xa3,"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8\xf4\xc6\xe6\xf8 '\xed"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x04\xd5\xd1\x05\x89\x16\xcaI"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1956,11 +1956,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf5\xb5\x8aw\xea\xbb\x04\x96"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7\xe0\xf6o+\x1d\x80\x18"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1980,11 +1980,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffEӹ9\xf8\xd5\tv"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\x86\xc5!9s\x8d\xf8"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -2004,11 +2004,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd6\x0e1\x9a\xd6wg\x13"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14[M\x82\x17\xd1\xe3\x9d"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2114,11 +2114,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fc527511d7c30418b8e806c540c01df6f49f5288\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb0\x15\x11\r\xfd膻"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2\x92j\xe8d\x15]8"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2180,11 +2180,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2edaca7e97c409f8bdeb4e6d606d82d84c95528c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9]\xf8\xb7\xedr\xe4\xbe"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b87f875117a557edb1eba1e578200fa10062e5c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffzڧ(BY\x96\xb7"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2209,9 +2209,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2374,9 +2374,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2400,9 +2400,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2431,7 +2431,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 1e 63 cd 24 aa 2f | ape.apple..c.$./[0m
 [33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3064972155106135341 --dbfilename pineapple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9439 --dbfilename pineapple.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET banana[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2465,7 +2465,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 79 00 05 67 72 61 70 65 06 62 61 6e 61 6e 61 ff | y..grape.banana.[0m
 [33m[tester::#DQ3] [0m[36m0070 | 22 42 53 9d 9d 75 69 c1                         | "BS..ui.[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2507285533399197960 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2904 --dbfilename raspberry.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
@@ -2505,24 +2505,24 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff 8b | ..grape.orange..[0m
 [33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-9089350173626074116 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9251 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n$4\r\npear\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [0m[36m  "grape",[0m
+[33m[tester::#JW4] [0m[36m  "pineapple",[0m
 [33m[tester::#JW4] [0m[36m  "pear",[0m
-[33m[tester::#JW4] [0m[36m  "banana"[0m
+[33m[tester::#JW4] [0m[36m  "grape"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [0m[92m  "grape",[0m
+[33m[tester::#JW4] [0m[92m  "pineapple",[0m
 [33m[tester::#JW4] [0m[92m  "pear",[0m
-[33m[tester::#JW4] [0m[92m  "banana"[0m
+[33m[tester::#JW4] [0m[92m  "grape"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2540,7 +2540,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 65 61 72 05 61 70 70 6c 65 ff 4e 07 75 77 a0 9f | ear.apple.N.uw..[0m
 [33m[tester::#GC6] [0m[36m0040 | 21 94                                           | !.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2148911027371760764 --dbfilename apple.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2337 --dbfilename apple.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
@@ -2561,7 +2561,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 73 70 62 65 72 72 79 05 61 70 70 6c 65 ff 55 | aspberry.apple.U[0m
 [33m[tester::#JZ6] [0m[36m0040 | 43 23 e0 5a 6e 28 62                            | C#.Zn(b[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2696214322140077102 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1316 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
@@ -2574,19 +2574,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2336529644416475508 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5701 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-2336529644416475508\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-2336529644416475508"[0m
-[33m[tester::#ZG5] [0m[36m][0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5701\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-5701"][0m
 [33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived [[0m
-[33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-2336529644416475508"[0m
-[33m[tester::#ZG5] [0m[92m][0m
+[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-5701"][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
@@ -2599,15 +2593,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:07:13.063[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:07:13.063 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:37:18.939[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:37:18.939 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:07:13.167 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:37:19.042 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540322135-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540322135-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751540322135-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751542976467-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751542976467-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751542976467-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1285,11 +1285,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\\沸\xe2\xb5v\xe6"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80\xc0\xed\xfe\x06$\x1e\xe5"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1309,11 +1309,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3&\xe5\x96\xffi,\xfa"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff?\x00\xba\xd0\x1b\xf8D\xf9"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1333,11 +1333,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe6\xf4\x06\fc]BZ"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff:\xd2YJ\x87\xcc*Y"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1457,7 +1457,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2109 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2006 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1491,11 +1491,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17\x10'l\x83]vo"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\U000f7ae1\x0f7\x13\xdb"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1515,11 +1515,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\xd0pB\x9e\x81,s"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffLw\xfc\x8f\x12\xebI\xc7"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1539,11 +1539,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\x02\x93\xd8\x02\xb5B\xd3"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xa5\x1f\x15\x8e\xdf'g"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1563,11 +1563,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\x17\xa7\x16\xba\xef+\xb6"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \xb0+\xdb6\x85N\x02"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1587,11 +1587,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12x-\xa17\"\xba\xae"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf6ߡl\xbbH\xdf\x1a"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -1611,11 +1611,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17\xaa\xce;\xab\x16\xd4\x0e"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4lfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xee\xe2\xe7za%\xa2\xf7"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~\xbf\xfa\xf5\x13L\xbdk"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4lfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\xf7Ӵ\xd9\x7f˒"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1956,11 +1956,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\x82\">\xf5\xcb\xf2i"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0/ٟ\x1d\xb2\xdcj"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1980,11 +1980,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1d\xe4\x11p\xe7\xa5\xff\x89"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffPI\xea\xd1\x0f\xdcъ"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -2004,11 +2004,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e9\x99\xd3\xc9\a\x91\xec"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffÔbr!~\xbf\xef"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2114,11 +2114,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffb\xcb\xe4\xb8\xe7DH\xe5"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc6lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b6422864e29fe1f34434c72afb4893d94ba18f9\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffk\xff2\x99\x8e\x04Z\xd2"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2180,11 +2180,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2hbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2bc692b38b0ee2b20783b71255b69d3379e105f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffd\x06S\xb6\xd5\xe2X8"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc6lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e8d51203aaacc1e7a3c3c378b8b1c083161e87d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc1\x00\x9b\x1d\xecJY\xdc"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2209,9 +2209,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2374,9 +2374,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2400,9 +2400,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2432,7 +2432,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 0c 28 8a c7 01 00 00 00 04 70 65 61 72 09 72 61 | .(.......pear.ra[0m
 [33m[tester::#SM4] [0m[36m0090 | 73 70 62 65 72 72 79 ff 22 e3 13 f5 84 4c bb fb | spberry."....L..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2728267965 --dbfilename blueberry.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles323591230 --dbfilename blueberry.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2470,7 +2470,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 72 72 79 00 04 70 65 61 72 09 62 6c 75 65 62 65 | rry..pear.bluebe[0m
 [33m[tester::#DQ3] [0m[36m0060 | 72 72 79 ff 76 fa 57 f1 4d f7 1d b7             | rry.v.W.M...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4003038860 --dbfilename grape.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2438193340 --dbfilename grape.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -2495,28 +2495,28 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 00 00 09 72 | er.7.2.0.......r[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 72 | s-bits.@.......r[0m
 [33m[tester::#JW4] [0m[36m0030 | 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 65 | aspberry.strawbe[0m
 [33m[tester::#JW4] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 05 6d | rry..blueberry.m[0m
 [33m[tester::#JW4] [0m[36m0050 | 61 6e 67 6f 00 06 62 61 6e 61 6e 61 05 67 72 61 | ango..banana.gra[0m
-[33m[tester::#JW4] [0m[36m0060 | 70 65 ff 68 59 42 f0 97 6c 48 db                | pe.hYB..lH.[0m
+[33m[tester::#JW4] [0m[36m0060 | 70 65 ff 9d 1f fa 6e 94 42 b7 e4                | pe....n.B..[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2588578971 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1524002636 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "banana"[0m
+[33m[tester::#JW4] [0m[36m  "raspberry"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "banana"[0m
+[33m[tester::#JW4] [0m[92m  "raspberry"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2534,7 +2534,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 ff 2d | pple.raspberry.-[0m
 [33m[tester::#GC6] [0m[36m0040 | 27 a2 3e fd 1b 1c c6                            | '.>....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles865624334 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles526666065 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -2555,7 +2555,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 05 61 70 70 6c 65 ff a0 d5 9e e7 44 | ango.apple.....D[0m
 [33m[tester::#JZ6] [0m[36m0040 | df 41 72                                        | .Ar[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles234762196 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3231572699 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -2568,18 +2568,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966 --dbfilename grape.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171 --dbfilename grape.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2593,15 +2593,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 16:43:51.313[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 16:43:51.313 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:05.468[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pear" at 17:28:05.468 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pear[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pineapple"[0m
 [33m[tester::#YZ1] [0m[92mReceived "pineapple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 16:43:51.416 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pear" at 17:28:05.571 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pear[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751516460696-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751516460696-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751516460696-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540322135-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540322135-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751540322135-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1285,11 +1285,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-\x05fh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6a22692a93e043955535d73190946c615fd77bc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff^\x14\xa7n\x0e\xe5\\\xc1"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\\沸\xe2\xb5v\xe6"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1309,11 +1309,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-\x05fh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6a22692a93e043955535d73190946c615fd77bc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe1\xd4\xf0@\x139\x06\xdd"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3&\xe5\x96\xffi,\xfa"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1333,11 +1333,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC f6a22692a93e043955535d73190946c615fd77bc 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 039319c5f084de438ba712d1c06934e437432174 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2-\x05fh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6a22692a93e043955535d73190946c615fd77bc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe4\x06\x13ڏ\rh}"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2bbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(039319c5f084de438ba712d1c06934e437432174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe6\xf4\x06\fc]BZ"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1457,7 +1457,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2010 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2109 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1491,11 +1491,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2/\x05fh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"Ȫ\xef\xaf\xef&\xc4"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17\x10'l\x83]vo"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1515,11 +1515,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2/\x05fh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\b\xfd\xc1\xb23|\xd8"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\xd0pB\x9e\x81,s"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1539,11 +1539,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x05fh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf3x`\xc59\xb0\xa4."[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\x02\x93\xd8\x02\xb5B\xd3"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1563,11 +1563,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x05fh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9amT\v\x81\xea\xcdK"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\x17\xa7\x16\xba\xef+\xb6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1587,11 +1587,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x05fh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\x02\u07bc\f'\\S"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12x-\xa17\"\xba\xae"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -1611,11 +1611,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x05fh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xd0=&\x90\x132\xf3"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17\xaa\xce;\xab\x16\xd4\x0e"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 6c32ee5d3d513886cfe8a78c057d36eba7b04389 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 53349184a2920ccf06513c0ac3a82fd9ae1f6b12 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc20\x05fh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c32ee5d3d513886cfe8a78c057d36eba7b04389\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \xc5\t\xe8(I[\x96"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ebfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(53349184a2920ccf06513c0ac3a82fd9ae1f6b12\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~\xbf\xfa\xf5\x13L\xbdk"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1956,11 +1956,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\x05fh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(850bea5db9850343f74127124a65ea6022bcc6ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83\\Bd\xfa\xe7\x99\xc5"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\x82\">\xf5\xcb\xf2i"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1980,11 +1980,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\x05fh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(850bea5db9850343f74127124a65ea6022bcc6ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff3:q*艔%"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1d\xe4\x11p\xe7\xa5\xff\x89"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -2004,11 +2004,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 850bea5db9850343f74127124a65ea6022bcc6ce 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 28a23ca451fb4a9a745dc1eb28daf13384c4282c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22\x05fh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(850bea5db9850343f74127124a65ea6022bcc6ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd4j\x87}\x98\xdfX\t"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28a23ca451fb4a9a745dc1eb28daf13384c4282c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e9\x99\xd3\xc9\a\x91\xec"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2114,11 +2114,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 0bc633e193e8d747f14a70fec1839d0b401b0184 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 0bc633e193e8d747f14a70fec1839d0b401b0184 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 0bc633e193e8d747f14a70fec1839d0b401b0184 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22\x05fh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0bc633e193e8d747f14a70fec1839d0b401b0184\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\xd6\x13#\xa1\x1f\xf2 "[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2gbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(508294b88dd9e1e7e1fe7dbdd3fbc6a4d4177530\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffb\xcb\xe4\xb8\xe7DH\xe5"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2180,11 +2180,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 9670b3878135ee609b463f4f9f6854c875e48b74 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 9670b3878135ee609b463f4f9f6854c875e48b74 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 9670b3878135ee609b463f4f9f6854c875e48b74 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2bc692b38b0ee2b20783b71255b69d3379e105f5 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc22\x05fh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9670b3878135ee609b463f4f9f6854c875e48b74\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]\x99\xb7\xac#\xed\xb0\xb3"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2hbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2bc692b38b0ee2b20783b71255b69d3379e105f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffd\x06S\xb6\xd5\xe2X8"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2209,9 +2209,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 06c80635bed6bda49719281ea3e50135976e5ae9 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 06c80635bed6bda49719281ea3e50135976e5ae9 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 06c80635bed6bda49719281ea3e50135976e5ae9 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC da3887b9a95120c1bcd21298f76ae23076fdaec7 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2374,9 +2374,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:60e362f97a7ff58b2a65624401a2283bc55aebf0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:60e362f97a7ff58b2a65624401a2283bc55aebf0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:60e362f97a7ff58b2a65624401a2283bc55aebf0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6f32a0197bbd30f471f479cdd9bc647c19d1fc49\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2400,9 +2400,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7f39504904feaf07b188b7adaf217539a1d61375\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7f39504904feaf07b188b7adaf217539a1d61375\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7f39504904feaf07b188b7adaf217539a1d61375\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d12022ffa2dace98bcc279deb50fe90053d42fa8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2432,7 +2432,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 0c 28 8a c7 01 00 00 00 04 70 65 61 72 09 72 61 | .(.......pear.ra[0m
 [33m[tester::#SM4] [0m[36m0090 | 73 70 62 65 72 72 79 ff 22 e3 13 f5 84 4c bb fb | spberry."....L..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles146955288 --dbfilename blueberry.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2728267965 --dbfilename blueberry.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2470,7 +2470,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 72 72 79 00 04 70 65 61 72 09 62 6c 75 65 62 65 | rry..pear.bluebe[0m
 [33m[tester::#DQ3] [0m[36m0060 | 72 72 79 ff 76 fa 57 f1 4d f7 1d b7             | rry.v.W.M...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1409536129 --dbfilename grape.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4003038860 --dbfilename grape.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -2495,28 +2495,28 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 72 | s-bits.@.......r[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 00 00 09 72 | er.7.2.0.......r[0m
 [33m[tester::#JW4] [0m[36m0030 | 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 65 | aspberry.strawbe[0m
 [33m[tester::#JW4] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 05 6d | rry..blueberry.m[0m
 [33m[tester::#JW4] [0m[36m0050 | 61 6e 67 6f 00 06 62 61 6e 61 6e 61 05 67 72 61 | ango..banana.gra[0m
-[33m[tester::#JW4] [0m[36m0060 | 70 65 ff 9d 1f fa 6e 94 42 b7 e4                | pe....n.B..[0m
+[33m[tester::#JW4] [0m[36m0060 | 70 65 ff 68 59 42 f0 97 6c 48 db                | pe.hYB..lH.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2266622856 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2588578971 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
+[33m[tester::#JW4] [0m[36m  "raspberry",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry"[0m
+[33m[tester::#JW4] [0m[36m  "banana"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
+[33m[tester::#JW4] [0m[92m  "raspberry",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry"[0m
+[33m[tester::#JW4] [0m[92m  "banana"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2534,7 +2534,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 ff 2d | pple.raspberry.-[0m
 [33m[tester::#GC6] [0m[36m0040 | 27 a2 3e fd 1b 1c c6                            | '.>....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2633843191 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles865624334 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -2555,7 +2555,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 05 61 70 70 6c 65 ff a0 d5 9e e7 44 | ango.apple.....D[0m
 [33m[tester::#JZ6] [0m[36m0040 | df 41 72                                        | .Ar[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles854098776 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles234762196 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -2568,18 +2568,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles621511671 --dbfilename grape.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966 --dbfilename grape.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles621511671\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles621511671"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles621511671"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4043121966"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2593,15 +2593,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 10:06:09.837[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 10:06:09.837 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 16:43:51.313[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pear" at 16:43:51.313 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pear[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pineapple"[0m
 [33m[tester::#YZ1] [0m[92mReceived "pineapple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 10:06:09.941 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pear" at 16:43:51.416 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pear[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -1162,9 +1162,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751542976467-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751542976467-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751542976467-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876523951-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876523951-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751876523951-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1285,11 +1285,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80\xc0\xed\xfe\x06$\x1e\xe5"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\xfd\xea\f1*\xa1'"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1309,11 +1309,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff?\x00\xba\xd0\x1b\xf8D\xf9"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff =\xbd\",\xf6\xfb;"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1333,11 +1333,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC b40ac207c783fc55548e04dc0e9bd375fa748e9e 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 7b0c0110cd6585899e328969aa72ea7a419027ce 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b40ac207c783fc55548e04dc0e9bd375fa748e9e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff:\xd2YJ\x87\xcc*Y"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0c0110cd6585899e328969aa72ea7a419027ce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%\xef^\xb8\xb0\u0095\x9b"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1457,7 +1457,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2006 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2003 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1491,11 +1491,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\U000f7ae1\x0f7\x13\xdb"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81[\x1b\x7fh1\xec\xe9"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1515,11 +1515,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffLw\xfc\x8f\x12\xebI\xc7"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\x9bLQu\xed\xb6\xf5"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1539,11 +1539,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffI\xa5\x1f\x15\x8e\xdf'g"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;I\xaf\xcb\xe9\xd9\xd8U"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1563,11 +1563,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \xb0+\xdb6\x85N\x02"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffR\\\x9b\x05Q\x83\xb10"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1587,11 +1587,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc3lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf6ߡl\xbbH\xdf\x1a"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x843\x11\xb2\xdcN ("[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -1611,11 +1611,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4lfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xee\xe2\xe7za%\xa2\xf7"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\xe1\xf2(@zN\x88"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 8b306d399448f021e914c429c2493aa07a30886e 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 5275e7c42b277e0b5936e9177ce6209c43a0924a 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc4lfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b306d399448f021e914c429c2493aa07a30886e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\xf7Ӵ\xd9\x7f˒"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\x83kh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5275e7c42b277e0b5936e9177ce6209c43a0924a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8\xf4\xc6\xe6\xf8 '\xed"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1956,11 +1956,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0/ٟ\x1d\xb2\xdcj"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf5\xb5\x8aw\xea\xbb\x04\x96"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1980,11 +1980,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffPI\xea\xd1\x0f\xdcъ"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffEӹ9\xf8\xd5\tv"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -2004,11 +2004,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC fba9ee16855ed9e2be221873e768b4cb87406a88 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc5lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fba9ee16855ed9e2be221873e768b4cb87406a88\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffÔbr!~\xbf\xef"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c1cdd6c12efb3544ccad6a1fa056cb1dcbf4d03\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd6\x0e1\x9a\xd6wg\x13"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2114,11 +2114,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 8b6422864e29fe1f34434c72afb4893d94ba18f9 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC fc527511d7c30418b8e806c540c01df6f49f5288 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc6lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8b6422864e29fe1f34434c72afb4893d94ba18f9\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffk\xff2\x99\x8e\x04Z\xd2"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fc527511d7c30418b8e806c540c01df6f49f5288\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb0\x15\x11\r\xfd膻"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2180,11 +2180,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2e8d51203aaacc1e7a3c3c378b8b1c083161e87d 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 2edaca7e97c409f8bdeb4e6d606d82d84c95528c 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc6lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2e8d51203aaacc1e7a3c3c378b8b1c083161e87d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc1\x00\x9b\x1d\xecJY\xdc"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime±\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2edaca7e97c409f8bdeb4e6d606d82d84c95528c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9]\xf8\xb7\xedr\xe4\xbe"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2209,9 +2209,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 8a1b1bff17d11bbebfb41bfde73607b785ff43ff 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 338e01a1dfa56748298e2d71217601e183e52b8a 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2374,9 +2374,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4f1b6b8ccd03a2d935d9a594e761b3522f7f10b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a6263fd9171a506b9949c1ab678a26bf3696702e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2400,9 +2400,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7717e56a5c1dc89faaff351ae648bda32871c8e8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:565fcf4b4ecc34e4081cfbd552c57901e4aa7fe1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2417,106 +2417,112 @@ Debug = true
 [33m[tester::#BW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SM4] [0m[94mRunning tests for Stage #SM4 (sm4)[0m
-[33m[tester::#SM4] [0m[94mCreated RDB file with 4 key-value pairs: {"strawberry": "strawberry", "apple": "orange", "mango": "blueberry", "pear": "raspberry"}[0m
+[33m[tester::#SM4] [0m[94mCreated RDB file with 3 key-value pairs: {"banana": "orange", "pineapple": "raspberry", "grape": "apple"}[0m
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 9c | s-bits.@........[0m
-[33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 0a 73 74 72 61 77 62 65 72 | ..~.....strawber[0m
-[33m[tester::#SM4] [0m[36m0040 | 72 79 0a 73 74 72 61 77 62 65 72 72 79 fc 00 0c | ry.strawberry...[0m
-[33m[tester::#SM4] [0m[36m0050 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 06 6f 72 | (.......apple.or[0m
-[33m[tester::#SM4] [0m[36m0060 | 61 6e 67 65 fc 00 0c 28 8a c7 01 00 00 00 05 6d | ange...(.......m[0m
-[33m[tester::#SM4] [0m[36m0070 | 61 6e 67 6f 09 62 6c 75 65 62 65 72 72 79 fc 00 | ango.blueberry..[0m
-[33m[tester::#SM4] [0m[36m0080 | 0c 28 8a c7 01 00 00 00 04 70 65 61 72 09 72 61 | .(.......pear.ra[0m
-[33m[tester::#SM4] [0m[36m0090 | 73 70 62 65 72 72 79 ff 22 e3 13 f5 84 4c bb fb | spberry."....L..[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 9c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 06 62 61 6e 61 6e 61 06 6f | ..~.....banana.o[0m
+[33m[tester::#SM4] [0m[36m0040 | 72 61 6e 67 65 fc 00 0c 28 8a c7 01 00 00 00 09 | range...(.......[0m
+[33m[tester::#SM4] [0m[36m0050 | 70 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 | pineapple.raspbe[0m
+[33m[tester::#SM4] [0m[36m0060 | 72 72 79 fc 00 0c 28 8a c7 01 00 00 00 05 67 72 | rry...(.......gr[0m
+[33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 1e 63 cd 24 aa 2f | ape.apple..c.$./[0m
+[33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles323591230 --dbfilename blueberry.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET strawberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3064972155106135341 --dbfilename pineapple.rdb[0m
+[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET banana[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET apple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#SM4] [0m[92mReceived "orange"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET mango[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "blueberry"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pear[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET pineapple[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
 [33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [0m[92mReceived "apple"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#DQ3] [0m[94mRunning tests for Stage #DQ3 (dq3)[0m
-[33m[tester::#DQ3] [0m[94mCreated RDB file with 3 key-value pairs: {"pineapple": "mango", "raspberry": "raspberry", "pear": "blueberry"}[0m
+[33m[tester::#DQ3] [0m[94mCreated RDB file with 4 key-value pairs: {"orange": "grape", "raspberry": "blueberry", "pear": "strawberry", "grape": "banana"}[0m
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 70 | s-bits.@.......p[0m
-[33m[tester::#DQ3] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 05 6d 61 6e 67 6f 00 09 | ineapple.mango..[0m
-[33m[tester::#DQ3] [0m[36m0040 | 72 61 73 70 62 65 72 72 79 09 72 61 73 70 62 65 | raspberry.raspbe[0m
-[33m[tester::#DQ3] [0m[36m0050 | 72 72 79 00 04 70 65 61 72 09 62 6c 75 65 62 65 | rry..pear.bluebe[0m
-[33m[tester::#DQ3] [0m[36m0060 | 72 72 79 ff 76 fa 57 f1 4d f7 1d b7             | rry.v.W.M...[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 06 6f | s-bits.@.......o[0m
+[33m[tester::#DQ3] [0m[36m0030 | 72 61 6e 67 65 05 67 72 61 70 65 00 09 72 61 73 | range.grape..ras[0m
+[33m[tester::#DQ3] [0m[36m0040 | 70 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 | pberry.blueberry[0m
+[33m[tester::#DQ3] [0m[36m0050 | 00 04 70 65 61 72 0a 73 74 72 61 77 62 65 72 72 | ..pear.strawberr[0m
+[33m[tester::#DQ3] [0m[36m0060 | 79 00 05 67 72 61 70 65 06 62 61 6e 61 6e 61 ff | y..grape.banana.[0m
+[33m[tester::#DQ3] [0m[36m0070 | 22 42 53 9d 9d 75 69 c1                         | "BS..ui.[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2438193340 --dbfilename grape.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2507285533399197960 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET orange[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
+[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
 [33m[tester::#DQ3] [0m[94mclient: > GET raspberry[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "raspberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
 [33m[tester::#DQ3] [0m[92mReceived "blueberry"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET grape[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[tester::#DQ3] [0m[92mReceived "banana"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JW4] [0m[94mRunning tests for Stage #JW4 (jw4)[0m
-[33m[tester::#JW4] [0m[94mCreated RDB file with 3 keys: ["raspberry", "blueberry", "banana"][0m
+[33m[tester::#JW4] [0m[94mCreated RDB file with 5 keys: ["pineapple", "banana", "pear", "raspberry", "grape"][0m
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 72 | s-bits.@.......r[0m
-[33m[tester::#JW4] [0m[36m0030 | 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 65 | aspberry.strawbe[0m
-[33m[tester::#JW4] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 05 6d | rry..blueberry.m[0m
-[33m[tester::#JW4] [0m[36m0050 | 61 6e 67 6f 00 06 62 61 6e 61 6e 61 05 67 72 61 | ango..banana.gra[0m
-[33m[tester::#JW4] [0m[36m0060 | 70 65 ff 9d 1f fa 6e 94 42 b7 e4                | pe....n.B..[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 09 70 | s-bits.@.......p[0m
+[33m[tester::#JW4] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 04 70 65 61 72 00 06 62 | ineapple.pear..b[0m
+[33m[tester::#JW4] [0m[36m0040 | 61 6e 61 6e 61 05 67 72 61 70 65 00 04 70 65 61 | anana.grape..pea[0m
+[33m[tester::#JW4] [0m[36m0050 | 72 09 72 61 73 70 62 65 72 72 79 00 09 72 61 73 | r.raspberry..ras[0m
+[33m[tester::#JW4] [0m[36m0060 | 70 62 65 72 72 79 09 70 69 6e 65 61 70 70 6c 65 | pberry.pineapple[0m
+[33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff 8b | ..grape.orange..[0m
+[33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1524002636 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-9089350173626074116 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n$4\r\npear\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry"[0m
+[33m[tester::#JW4] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [0m[36m  "grape",[0m
+[33m[tester::#JW4] [0m[36m  "pear",[0m
+[33m[tester::#JW4] [0m[36m  "banana"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry"[0m
+[33m[tester::#JW4] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [0m[92m  "grape",[0m
+[33m[tester::#JW4] [0m[92m  "pear",[0m
+[33m[tester::#JW4] [0m[92m  "banana"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2524,62 +2530,62 @@ Debug = true
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GC6] [0m[94mRunning tests for Stage #GC6 (gc6)[0m
-[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"apple": "raspberry"}[0m
+[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"pear": "apple"}[0m
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
-[33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 ff 2d | pple.raspberry.-[0m
-[33m[tester::#GC6] [0m[36m0040 | 27 a2 3e fd 1b 1c c6                            | '.>....[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#GC6] [0m[36m0030 | 65 61 72 05 61 70 70 6c 65 ff 4e 07 75 77 a0 9f | ear.apple.N.uw..[0m
+[33m[tester::#GC6] [0m[36m0040 | 21 94                                           | !.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles526666065 --dbfilename banana.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#GC6] [0m[92mReceived "raspberry"[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2148911027371760764 --dbfilename apple.rdb[0m
+[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#GC6] [0m[92mReceived "apple"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JZ6] [0m[94mRunning tests for Stage #JZ6 (jz6)[0m
-[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["mango"][0m
+[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["raspberry"][0m
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 6d | s-bits.@.......m[0m
-[33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 05 61 70 70 6c 65 ff a0 d5 9e e7 44 | ango.apple.....D[0m
-[33m[tester::#JZ6] [0m[36m0040 | df 41 72                                        | .Ar[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 72 | s-bits.@.......r[0m
+[33m[tester::#JZ6] [0m[36m0030 | 61 73 70 62 65 72 72 79 05 61 70 70 6c 65 ff 55 | aspberry.apple.U[0m
+[33m[tester::#JZ6] [0m[36m0040 | 43 23 e0 5a 6e 28 62                            | C#.Zn(b[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3231572699 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2696214322140077102 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["mango"][0m
+[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["raspberry"][0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["mango"][0m
+[33m[tester::#JZ6] [0m[92mReceived ["raspberry"][0m
 [33m[tester::#JZ6] [0m[92m[0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171 --dbfilename grape.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2336529644416475508 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-2336529644416475508\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-2336529644416475508"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-1955388171"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-2336529644416475508"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2588,22 +2594,22 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET pear pineapple px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\npineapple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [0m[94m$ redis-cli SET mango blueberry px 100[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:05.468[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 17:28:05.468 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET pear[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pineapple"[0m
-[33m[tester::#YZ1] [0m[92mReceived "pineapple"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 14:07:13.063[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:07:13.063 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET mango[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pear" at 17:28:05.571 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET pear[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:07:13.167 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET mango[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
@@ -2613,29 +2619,29 @@ Debug = true
 
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LA7] [0m[36mSetting key strawberry to pineapple[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET strawberry pineapple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [0m[36mSetting key mango to raspberry[0m
+[33m[tester::#LA7] [0m[94m$ redis-cli SET mango raspberry[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#LA7] [0m[92mReceived "OK"[0m
-[33m[tester::#LA7] [0m[36mGetting key strawberry[0m
-[33m[tester::#LA7] [0m[94m> GET strawberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
-[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
+[33m[tester::#LA7] [0m[36mGetting key mango[0m
+[33m[tester::#LA7] [0m[94m> GET mango[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#LA7] [0m[92mReceived "raspberry"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO mango[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "mango"[0m
-[33m[tester::#QQ0] [0m[92mReceived "mango"[0m
+[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO orange[0m
+[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#QQ0] [0m[92mReceived "orange"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -5,17 +5,17 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 03 fc 00 0c | er.7.2.0........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
 [33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 0a 73 | (.......orange.s[0m
 [33m[tester::#SM4] [0m[36m0040 | 74 72 61 77 62 65 72 72 79 fc 00 9c ef 12 7e 01 | trawberry.....~.[0m
 [33m[tester::#SM4] [0m[36m0050 | 00 00 00 05 6d 61 6e 67 6f 05 61 70 70 6c 65 fc | ....mango.apple.[0m
 [33m[tester::#SM4] [0m[36m0060 | 00 0c 28 8a c7 01 00 00 00 09 70 69 6e 65 61 70 | ..(.......pineap[0m
-[33m[tester::#SM4] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff a2 c6 | ple.blueberry...[0m
-[33m[tester::#SM4] [0m[36m0080 | 44 8d ef 3e 2c 29                               | D..>,)[0m
+[33m[tester::#SM4] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff 34 d0 | ple.blueberry.4.[0m
+[33m[tester::#SM4] [0m[36m0080 | 8c 58 51 4a 5d 62                               | .XQJ]b[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2059651345 --dbfilename pear.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1398531362 --dbfilename pear.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -40,17 +40,17 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 05 67 | er.7.2.0.......g[0m
 [33m[tester::#DQ3] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 00 05 | rape.pineapple..[0m
 [33m[tester::#DQ3] [0m[36m0040 | 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 00 | apple.raspberry.[0m
 [33m[tester::#DQ3] [0m[36m0050 | 06 62 61 6e 61 6e 61 05 61 70 70 6c 65 00 05 6d | .banana.apple..m[0m
 [33m[tester::#DQ3] [0m[36m0060 | 61 6e 67 6f 06 6f 72 61 6e 67 65 00 06 6f 72 61 | ango.orange..ora[0m
-[33m[tester::#DQ3] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff 33 20 d4 0d 23 b2 9b | nge.pear.3 ..#..[0m
-[33m[tester::#DQ3] [0m[36m0080 | af                                              | .[0m
+[33m[tester::#DQ3] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff db dd 70 78 d3 ab 98 | nge.pear...px...[0m
+[33m[tester::#DQ3] [0m[36m0080 | c3                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3868301261 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles85216460 --dbfilename raspberry.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -93,7 +93,7 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 00 09 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 | ..blueberry.pear[0m
 [33m[tester::#JW4] [0m[36m0060 | ff 5c f3 42 ee 46 08 a6 3f                      | .\.B.F..?[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles745317994 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1084641240 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
@@ -116,7 +116,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 ff 12 | rape.pineapple..[0m
 [33m[tester::#GC6] [0m[36m0040 | 7d 54 51 cd 7a 5c 8d                            | }TQ.z\.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1196484635 --dbfilename orange.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2360380044 --dbfilename orange.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -137,7 +137,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 ff 0c | ango.pineapple..[0m
 [33m[tester::#JZ6] [0m[36m0040 | 1b cb 91 b2 ed f6 19                            | .......[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3948750978 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles4010693826 --dbfilename pear.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -150,18 +150,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -175,15 +175,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:12.295[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 16:44:12.295 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:27:46.300[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 17:27:46.301 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pear"[0m
 [33m[tester::#YZ1] [0m[92mReceived "pear"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 16:44:12.398 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 17:27:46.404 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -1,78 +1,72 @@
 Debug = true
 
 [33m[tester::#SM4] [0m[94mRunning tests for Stage #SM4 (sm4)[0m
-[33m[tester::#SM4] [0m[94mCreated RDB file with 3 key-value pairs: {"orange": "strawberry", "mango": "apple", "pineapple": "blueberry"}[0m
+[33m[tester::#SM4] [0m[94mCreated RDB file with 4 key-value pairs: {"blueberry": "pear", "mango": "raspberry", "grape": "grape", "pear": "orange"}[0m
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
-[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 0a 73 | (.......orange.s[0m
-[33m[tester::#SM4] [0m[36m0040 | 74 72 61 77 62 65 72 72 79 fc 00 9c ef 12 7e 01 | trawberry.....~.[0m
-[33m[tester::#SM4] [0m[36m0050 | 00 00 00 05 6d 61 6e 67 6f 05 61 70 70 6c 65 fc | ....mango.apple.[0m
-[33m[tester::#SM4] [0m[36m0060 | 00 0c 28 8a c7 01 00 00 00 09 70 69 6e 65 61 70 | ..(.......pineap[0m
-[33m[tester::#SM4] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff 34 d0 | ple.blueberry.4.[0m
-[33m[tester::#SM4] [0m[36m0080 | 8c 58 51 4a 5d 62                               | .XQJ]b[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 | (.......blueberr[0m
+[33m[tester::#SM4] [0m[36m0040 | 79 04 70 65 61 72 fc 00 0c 28 8a c7 01 00 00 00 | y.pear...(......[0m
+[33m[tester::#SM4] [0m[36m0050 | 05 6d 61 6e 67 6f 09 72 61 73 70 62 65 72 72 79 | .mango.raspberry[0m
+[33m[tester::#SM4] [0m[36m0060 | fc 00 9c ef 12 7e 01 00 00 00 05 67 72 61 70 65 | .....~.....grape[0m
+[33m[tester::#SM4] [0m[36m0070 | 05 67 72 61 70 65 fc 00 0c 28 8a c7 01 00 00 00 | .grape...(......[0m
+[33m[tester::#SM4] [0m[36m0080 | 04 70 65 61 72 06 6f 72 61 6e 67 65 ff 9c 12 84 | .pear.orange....[0m
+[33m[tester::#SM4] [0m[36m0090 | bd e8 ad 48 6f                                  | ...Ho[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1398531362 --dbfilename pear.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET orange[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "strawberry"[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-762728739072168494 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pear"[0m
+[33m[tester::#SM4] [0m[92mReceived "pear"[0m
 [33m[tester::#SM4] [0m[94mclient: > GET mango[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pineapple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "blueberry"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET pear[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
+[33m[tester::#SM4] [0m[92mReceived "orange"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#DQ3] [0m[94mRunning tests for Stage #DQ3 (dq3)[0m
-[33m[tester::#DQ3] [0m[94mCreated RDB file with 5 key-value pairs: {"grape": "pineapple", "apple": "raspberry", "banana": "apple", "mango": "orange", "orange": "pear"}[0m
+[33m[tester::#DQ3] [0m[94mCreated RDB file with 3 key-value pairs: {"apple": "mango", "grape": "orange", "pineapple": "pear"}[0m
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 05 67 | er.7.2.0.......g[0m
-[33m[tester::#DQ3] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 00 05 | rape.pineapple..[0m
-[33m[tester::#DQ3] [0m[36m0040 | 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 00 | apple.raspberry.[0m
-[33m[tester::#DQ3] [0m[36m0050 | 06 62 61 6e 61 6e 61 05 61 70 70 6c 65 00 05 6d | .banana.apple..m[0m
-[33m[tester::#DQ3] [0m[36m0060 | 61 6e 67 6f 06 6f 72 61 6e 67 65 00 06 6f 72 61 | ango.orange..ora[0m
-[33m[tester::#DQ3] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff db dd 70 78 d3 ab 98 | nge.pear...px...[0m
-[33m[tester::#DQ3] [0m[36m0080 | c3                                              | .[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 05 61 | s-bits.@.......a[0m
+[33m[tester::#DQ3] [0m[36m0030 | 70 70 6c 65 05 6d 61 6e 67 6f 00 05 67 72 61 70 | pple.mango..grap[0m
+[33m[tester::#DQ3] [0m[36m0040 | 65 06 6f 72 61 6e 67 65 00 09 70 69 6e 65 61 70 | e.orange..pineap[0m
+[33m[tester::#DQ3] [0m[36m0050 | 70 6c 65 04 70 65 61 72 ff ec 0e 82 6d 87 2b 51 | ple.pear....m.+Q[0m
+[33m[tester::#DQ3] [0m[36m0060 | 91                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles85216460 --dbfilename raspberry.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pineapple"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-9041902677571988971 --dbfilename apple.rdb[0m
+[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "raspberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET banana[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#DQ3] [0m[92mReceived "apple"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET mango[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
+[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET grape[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "orange"[0m
 [33m[tester::#DQ3] [0m[92mReceived "orange"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET orange[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET pineapple[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
 [33m[tester::#DQ3] [0m[92mReceived "pear"[0m
@@ -81,44 +75,44 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JW4] [0m[94mRunning tests for Stage #JW4 (jw4)[0m
-[33m[tester::#JW4] [0m[94mCreated RDB file with 3 keys: ["banana", "apple", "blueberry"][0m
+[33m[tester::#JW4] [0m[94mCreated RDB file with 3 keys: ["blueberry", "apple", "mango"][0m
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 06 62 | s-bits.@.......b[0m
-[33m[tester::#JW4] [0m[36m0030 | 61 6e 61 6e 61 09 70 69 6e 65 61 70 70 6c 65 00 | anana.pineapple.[0m
-[33m[tester::#JW4] [0m[36m0040 | 05 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 | .apple.raspberry[0m
-[33m[tester::#JW4] [0m[36m0050 | 00 09 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 | ..blueberry.pear[0m
-[33m[tester::#JW4] [0m[36m0060 | ff 5c f3 42 ee 46 08 a6 3f                      | .\.B.F..?[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 62 | s-bits.@.......b[0m
+[33m[tester::#JW4] [0m[36m0030 | 6c 75 65 62 65 72 72 79 06 62 61 6e 61 6e 61 00 | lueberry.banana.[0m
+[33m[tester::#JW4] [0m[36m0040 | 05 61 70 70 6c 65 09 70 69 6e 65 61 70 70 6c 65 | .apple.pineapple[0m
+[33m[tester::#JW4] [0m[36m0050 | 00 05 6d 61 6e 67 6f 09 62 6c 75 65 62 65 72 72 | ..mango.blueberr[0m
+[33m[tester::#JW4] [0m[36m0060 | 79 ff 68 0f 5f 46 25 26 d0 08                   | y.h._F%&..[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1084641240 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6547838570342237478 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["apple", "blueberry", "banana"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["apple", "mango", "blueberry"][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["apple", "blueberry", "banana"][0m
+[33m[tester::#JW4] [0m[92mReceived ["apple", "mango", "blueberry"][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GC6] [0m[94mRunning tests for Stage #GC6 (gc6)[0m
-[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"grape": "pineapple"}[0m
+[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"raspberry": "pineapple"}[0m
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 ff 12 | rape.pineapple..[0m
-[33m[tester::#GC6] [0m[36m0040 | 7d 54 51 cd 7a 5c 8d                            | }TQ.z\.[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 72 | s-bits.@.......r[0m
+[33m[tester::#GC6] [0m[36m0030 | 61 73 70 62 65 72 72 79 09 70 69 6e 65 61 70 70 | aspberry.pineapp[0m
+[33m[tester::#GC6] [0m[36m0040 | 6c 65 ff 6c 09 59 cc 38 db e8 71                | le.l.Y.8..q[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2360380044 --dbfilename orange.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6438375023870740051 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
 [33m[tester::#GC6] [0m[92mReceived "pineapple"[0m
@@ -127,41 +121,41 @@ Debug = true
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JZ6] [0m[94mRunning tests for Stage #JZ6 (jz6)[0m
-[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["mango"][0m
+[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["banana"][0m
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 6d | s-bits.@.......m[0m
-[33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 ff 0c | ango.pineapple..[0m
-[33m[tester::#JZ6] [0m[36m0040 | 1b cb 91 b2 ed f6 19                            | .......[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 06 62 | s-bits.@.......b[0m
+[33m[tester::#JZ6] [0m[36m0030 | 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 79 ff | anana.raspberry.[0m
+[33m[tester::#JZ6] [0m[36m0040 | c5 21 ea c1 d2 83 0b 3f                         | .!.....?[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles4010693826 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-821201253856612956 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["mango"][0m
+[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["banana"][0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["mango"][0m
+[33m[tester::#JZ6] [0m[92mReceived ["banana"][0m
 [33m[tester::#JZ6] [0m[92m[0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8113002452566187660 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-8113002452566187660\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-8113002452566187660"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2573723905"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-8113002452566187660"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -170,22 +164,22 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET strawberry pear px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$4\r\npear\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [0m[94m$ redis-cli SET orange apple px 100[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:27:46.300[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 17:27:46.301 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET strawberry[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[tester::#YZ1] [0m[92mReceived "pear"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:25.347[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 14:06:25.347 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET orange[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#YZ1] [0m[92mReceived "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 17:27:46.404 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET strawberry[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 14:06:25.450 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET orange[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
@@ -195,29 +189,29 @@ Debug = true
 
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LA7] [0m[36mSetting key grape to raspberry[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET grape raspberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [0m[36mSetting key apple to grape[0m
+[33m[tester::#LA7] [0m[94m$ redis-cli SET apple grape[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#LA7] [0m[92mReceived "OK"[0m
-[33m[tester::#LA7] [0m[36mGetting key grape[0m
-[33m[tester::#LA7] [0m[94m> GET grape[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "raspberry"[0m
-[33m[tester::#LA7] [0m[92mReceived "raspberry"[0m
+[33m[tester::#LA7] [0m[36mGetting key apple[0m
+[33m[tester::#LA7] [0m[94m> GET apple[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#LA7] [0m[92mReceived "grape"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO mango[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "mango"[0m
-[33m[tester::#QQ0] [0m[92mReceived "mango"[0m
+[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO orange[0m
+[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#QQ0] [0m[92mReceived "orange"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -5,17 +5,17 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 03 fc 00 0c | er.7.2.0........[0m
 [33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 06 6f 72 61 6e 67 65 0a 73 | (.......orange.s[0m
 [33m[tester::#SM4] [0m[36m0040 | 74 72 61 77 62 65 72 72 79 fc 00 9c ef 12 7e 01 | trawberry.....~.[0m
 [33m[tester::#SM4] [0m[36m0050 | 00 00 00 05 6d 61 6e 67 6f 05 61 70 70 6c 65 fc | ....mango.apple.[0m
 [33m[tester::#SM4] [0m[36m0060 | 00 0c 28 8a c7 01 00 00 00 09 70 69 6e 65 61 70 | ..(.......pineap[0m
-[33m[tester::#SM4] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff 34 d0 | ple.blueberry.4.[0m
-[33m[tester::#SM4] [0m[36m0080 | 8c 58 51 4a 5d 62                               | .XQJ]b[0m
+[33m[tester::#SM4] [0m[36m0070 | 70 6c 65 09 62 6c 75 65 62 65 72 72 79 ff a2 c6 | ple.blueberry...[0m
+[33m[tester::#SM4] [0m[36m0080 | 44 8d ef 3e 2c 29                               | D..>,)[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles10756708 --dbfilename pear.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2059651345 --dbfilename pear.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET orange[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
@@ -40,17 +40,17 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 05 67 | er.7.2.0.......g[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 05 67 | s-bits.@.......g[0m
 [33m[tester::#DQ3] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 00 05 | rape.pineapple..[0m
 [33m[tester::#DQ3] [0m[36m0040 | 61 70 70 6c 65 09 72 61 73 70 62 65 72 72 79 00 | apple.raspberry.[0m
 [33m[tester::#DQ3] [0m[36m0050 | 06 62 61 6e 61 6e 61 05 61 70 70 6c 65 00 05 6d | .banana.apple..m[0m
 [33m[tester::#DQ3] [0m[36m0060 | 61 6e 67 6f 06 6f 72 61 6e 67 65 00 06 6f 72 61 | ango.orange..ora[0m
-[33m[tester::#DQ3] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff db dd 70 78 d3 ab 98 | nge.pear...px...[0m
-[33m[tester::#DQ3] [0m[36m0080 | c3                                              | .[0m
+[33m[tester::#DQ3] [0m[36m0070 | 6e 67 65 04 70 65 61 72 ff 33 20 d4 0d 23 b2 9b | nge.pear.3 ..#..[0m
+[33m[tester::#DQ3] [0m[36m0080 | af                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3517128500 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3868301261 --dbfilename raspberry.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -93,13 +93,13 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 00 09 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 | ..blueberry.pear[0m
 [33m[tester::#JW4] [0m[36m0060 | ff 5c f3 42 ee 46 08 a6 3f                      | .\.B.F..?[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2920519323 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles745317994 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["banana", "blueberry", "apple"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["apple", "blueberry", "banana"][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["banana", "blueberry", "apple"][0m
+[33m[tester::#JW4] [0m[92mReceived ["apple", "blueberry", "banana"][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -116,7 +116,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 09 70 69 6e 65 61 70 70 6c 65 ff 12 | rape.pineapple..[0m
 [33m[tester::#GC6] [0m[36m0040 | 7d 54 51 cd 7a 5c 8d                            | }TQ.z\.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4182401604 --dbfilename orange.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1196484635 --dbfilename orange.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -137,7 +137,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 ff 0c | ango.pineapple..[0m
 [33m[tester::#JZ6] [0m[36m0040 | 1b cb 91 b2 ed f6 19                            | .......[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1418308436 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3948750978 --dbfilename pear.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\nmango\r\n"[0m
@@ -150,18 +150,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2946443413 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2946443413\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2946443413"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2946443413"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3551765659"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -175,15 +175,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 13:03:59.916[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 13:03:59.916 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:12.295[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 16:44:12.295 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "pear"[0m
 [33m[tester::#YZ1] [0m[92mReceived "pear"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 13:04:00.019 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 16:44:12.398 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -16,7 +16,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 04 70 65 61 72 06 6f 72 61 6e 67 65 ff 9c 12 84 | .pear.orange....[0m
 [33m[tester::#SM4] [0m[36m0090 | bd e8 ad 48 6f                                  | ...Ho[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-762728739072168494 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6623 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
@@ -54,7 +54,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 70 6c 65 04 70 65 61 72 ff ec 0e 82 6d 87 2b 51 | ple.pear....m.+Q[0m
 [33m[tester::#DQ3] [0m[36m0060 | 91                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-9041902677571988971 --dbfilename apple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2020 --dbfilename apple.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -87,13 +87,13 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 00 05 6d 61 6e 67 6f 09 62 6c 75 65 62 65 72 72 | ..mango.blueberr[0m
 [33m[tester::#JW4] [0m[36m0060 | 79 ff 68 0f 5f 46 25 26 d0 08                   | y.h._F%&..[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6547838570342237478 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-7468 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$5\r\napple\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["apple", "mango", "blueberry"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["blueberry", "mango", "apple"][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["apple", "mango", "blueberry"][0m
+[33m[tester::#JW4] [0m[92mReceived ["blueberry", "mango", "apple"][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -110,7 +110,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 61 73 70 62 65 72 72 79 09 70 69 6e 65 61 70 70 | aspberry.pineapp[0m
 [33m[tester::#GC6] [0m[36m0040 | 6c 65 ff 6c 09 59 cc 38 db e8 71                | le.l.Y.8..q[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6438375023870740051 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1000 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -131,7 +131,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 79 ff | anana.raspberry.[0m
 [33m[tester::#JZ6] [0m[36m0040 | c5 21 ea c1 d2 83 0b 3f                         | .!.....?[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-821201253856612956 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-816 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$6\r\nbanana\r\n"[0m
@@ -144,19 +144,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8113002452566187660 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5582 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-8113002452566187660\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-8113002452566187660"[0m
-[33m[tester::#ZG5] [0m[36m][0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5582\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-5582"][0m
 [33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived [[0m
-[33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-8113002452566187660"[0m
-[33m[tester::#ZG5] [0m[92m][0m
+[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-5582"][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
@@ -169,15 +163,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:25.347[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 14:06:25.347 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:09.464[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 09:36:09.464 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET orange[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "apple"[0m
 [33m[tester::#YZ1] [0m[92mReceived "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 14:06:25.450 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 09:36:09.568 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET orange[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -26,11 +26,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\x9e\xebe@\xc8\xcd\x11"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \x02\xd0*\aM\x82E"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -50,11 +50,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe6^\xbcK]\x14\x97\r"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\u0087\x04\x1a\x91\xd8Y"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -74,11 +74,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\x8c_\xd1\xc1 \xf9\xad"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x10d\x9e\x86\xa5\xb6\xf9"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -98,11 +98,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8a\x99k\x1fyz\x90\xc8"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf3\x05PP>\xffߜ"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -255,7 +255,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2011 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2108 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -289,11 +289,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\x136\xe9\xf9\xbb\xd3Z"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1\xc2S6gV\x91v"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -313,11 +313,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\xd3a\xc7\xe4g\x89F"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\x02\x04\x18z\x8a\xcbj"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;\x01\x82]xS\xe7\xe6"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\xd0\xe7\x82澥\xca"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffR\x14\xb6\x93\xc0\t\x8e\x83"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2\xc5\xd3L^\xe4̯"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x84{<$M\xc4\x1f\x9b"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4\xaaY\xfb\xd3)]\xb7"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\xa9߾\xd1\xf0q;"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1x\xbaaO\x1d3\x17"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -433,11 +433,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8\xbc\xebpi\xaa\x18^"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffXm\x8e\xaf\xf7GZr"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -754,11 +754,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffo\x1d\aT\xa2\xc0bQ"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9Y\xff>\xae\x95\bq"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -778,11 +778,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdf{4\x1a\xb0\xaeo\xb1"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89?\xccp\xbc\xfb\x05\x91"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -802,11 +802,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\xa6\xbc\xb9\x9e\f\x01\xd4"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a\xe2DӒYk\xf4"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -912,11 +912,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(775024b1c2185689afdd5c7588dbb02c65642013\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\x036\x86R\xfcUB"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dffd9c05e41513290d86a5ea561da0176aa5bb74\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\xfd\xb6a\xec\x83MZ"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -978,11 +978,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a4debc350a382d87b5ac975821f21ace65b80a18\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffϚ0\xefJ\x94\x85\xd1"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"J\xc7ZjΥW"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1007,9 +1007,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1172,9 +1172,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1198,9 +1198,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1229,7 +1229,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
 [33m[tester::#SM4] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed                      | ..BMI.;{.[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles144342483 --dbfilename pear.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles839052465 --dbfilename pear.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
@@ -1264,7 +1264,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 03 5d d3 a4 75 38 | blueberry..]..u8[0m
 [33m[tester::#DQ3] [0m[36m0080 | 83 47                                           | .G[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2985550513 --dbfilename mango.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles958131242 --dbfilename mango.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1308,22 +1308,22 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
 [33m[tester::#JW4] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d                      | .:..r.,.=[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3418496042 --dbfilename grape.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles228935216 --dbfilename grape.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "apple",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
 [33m[tester::#JW4] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [0m[36m  "orange"[0m
+[33m[tester::#JW4] [0m[36m  "orange",[0m
+[33m[tester::#JW4] [0m[36m  "apple"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "apple",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
 [33m[tester::#JW4] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [0m[92m  "orange"[0m
+[33m[tester::#JW4] [0m[92m  "orange",[0m
+[33m[tester::#JW4] [0m[92m  "apple"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -1341,7 +1341,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
 [33m[tester::#GC6] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7                | ry..2h(,.&.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3925916096 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3297699935 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1362,7 +1362,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
 [33m[tester::#JZ6] [0m[36m0040 | 6b 9a                                           | k.[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1428879244 --dbfilename orange.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3136548219 --dbfilename orange.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1375,18 +1375,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991 --dbfilename raspberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615 --dbfilename raspberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1400,15 +1400,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:45.924[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 16:44:45.924 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:22.963[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 17:28:22.963 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[tester::#YZ1] [0m[92mReceived "orange"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 16:44:46.027 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 17:28:23.067 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -26,11 +26,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xact\xffx7#\x05\xfe"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc8\xf3\xee\xf0\n\xe0\xe0\xd3"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -50,11 +50,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xb4\xa8V*\xff_\xe2"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw3\xb9\xde\x17<\xba\xcf"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -74,11 +74,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16fK̶\xcb1B"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\xe1ZD\x8b\b\xd4o"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -98,11 +98,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7fs\x7f\x02\x0e\x91X'"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1b\xf4n\x8a3R\xbd\n"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -255,7 +255,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2092 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2012 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -289,11 +289,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\a\x00\x1a|^\xdfD"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\b\xad\xb5\xf3\x8d\xff\xc0"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -313,11 +313,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@\xc7W4a\x82\x85X"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\xc8\xfa\x9b\xeeQ\xa5\xdc"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1\x98\xcaZ\xa3BI\xb1"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xce\x1a\x19\x01re\xcb|"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffX\x8d\xfe\x94\x1b\x18 \xd4"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh$>\xb2\xbc<\xd2]"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\xe2t#\x96ձ\xcc"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbeK\xb4\x051\xf1CE"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b0\x97\xb9\n\xe1\xdfl"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbb\x99W\x9f\xad\xc5-\xe5"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -433,11 +433,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2%\xa3w\xb2\xbb\xb6\t"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҌcQ\x15\x9fD\x80"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -754,11 +754,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff}6\x8aUo\x15\xf5o"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ɕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffν\x1d\x99\x82i\x81I"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -778,11 +778,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcdP\xb9\x1b}{\xf8\x8f"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ɕlh\xfa\bused-mem\xc2 \xf1\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffq\x8f\x83?\xc8\xf1\xf0\xcb"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -802,11 +802,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffCb\x944\x15\x80\x85\xa7"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x99\x8b\u0600\xe0Q@\x85"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -912,11 +912,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a3aea9d9301c4b364a6018a816775f620b64662d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\xa4{\vlN[\x88"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffM\n\x9cZ\a\xc9\x13\xda"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -978,11 +978,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3d58529690b7789ccde0d2945da9b5e95b76e737\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2\xb5W7\x14\x81\x88\x14"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50bbc8eb5afc0ea40021b4f912d3e2496beba3b2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17Hd\x8dX\xe64r"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1007,9 +1007,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1172,9 +1172,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1198,9 +1198,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1230,7 +1230,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 79 05 | ......blueberry.[0m
 [33m[tester::#SM4] [0m[36m0090 | 61 70 70 6c 65 ff 92 f1 de f7 06 f6 06 ae       | apple.........[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-656545637400819176 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3943 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -1268,7 +1268,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
 [33m[tester::#DQ3] [0m[36m0060 | ff d2 b9 68 6d 79 81 2e 5d                      | ...hmy..][0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3028599034268840109 --dbfilename pear.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-662 --dbfilename pear.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
@@ -1302,20 +1302,20 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 69 6e 65 61 70 70 6c 65 0a 73 74 72 61 77 62 65 | ineapple.strawbe[0m
 [33m[tester::#JW4] [0m[36m0070 | 72 72 79 ff 1e 60 ef 0f 40 01 3a b1             | rry..`..@.:.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-4518155907013922221 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5147 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "grape",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
+[33m[tester::#JW4] [0m[36m  "grape",[0m
 [33m[tester::#JW4] [0m[36m  "orange",[0m
 [33m[tester::#JW4] [0m[36m  "pineapple"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "grape",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
+[33m[tester::#JW4] [0m[92m  "grape",[0m
 [33m[tester::#JW4] [0m[92m  "orange",[0m
 [33m[tester::#JW4] [0m[92m  "pineapple"[0m
 [33m[tester::#JW4] [0m[92m][0m
@@ -1335,7 +1335,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
 [33m[tester::#GC6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3283895374913131601 --dbfilename raspberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1473 --dbfilename raspberry.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
@@ -1356,7 +1356,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 6f 72 61 6e 67 65 ff 02 51 6c 32 | pple.orange..Ql2[0m
 [33m[tester::#JZ6] [0m[36m0040 | 97 93 08 f8                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-7282332576237470778 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-181 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
@@ -1369,19 +1369,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-997559609239412828 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2445 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$40\r\n/private/tmp/rdbfiles-997559609239412828\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-997559609239412828"[0m
-[33m[tester::#ZG5] [0m[36m][0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-2445\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-2445"][0m
 [33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived [[0m
-[33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-997559609239412828"[0m
-[33m[tester::#ZG5] [0m[92m][0m
+[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-2445"][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
@@ -1394,15 +1388,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:35.775[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:35.775 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:41.721[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:41.721 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:35.879 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:41.824 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -26,11 +26,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \x02\xd0*\aM\x82E"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xact\xffx7#\x05\xfe"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -50,11 +50,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9f\u0087\x04\x1a\x91\xd8Y"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xb4\xa8V*\xff_\xe2"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -74,11 +74,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x10d\x9e\x86\xa5\xb6\xf9"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16fK̶\xcb1B"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -98,11 +98,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 74279fd55aae999a15f978e30dff891207901916 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 93e7eea03ec3d15347d69ab907bc8a408b7ab371 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd2lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(74279fd55aae999a15f978e30dff891207901916\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf3\x05PP>\xffߜ"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(93e7eea03ec3d15347d69ab907bc8a408b7ab371\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7fs\x7f\x02\x0e\x91X'"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -255,7 +255,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2108 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2092 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -289,11 +289,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1\xc2S6gV\x91v"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\a\x00\x1a|^\xdfD"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -313,11 +313,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\x02\x04\x18z\x8a\xcbj"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@\xc7W4a\x82\x85X"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\xd0\xe7\x82澥\xca"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1\x98\xcaZ\xa3BI\xb1"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2\xc5\xd3L^\xe4̯"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffX\x8d\xfe\x94\x1b\x18 \xd4"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4\xaaY\xfb\xd3)]\xb7"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8e\xe2t#\x96ձ\xcc"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1x\xbaaO\x1d3\x17"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b0\x97\xb9\n\xe1\xdfl"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -433,11 +433,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC a64b158d60c000d6f7aa056bc1948686b827bd6c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd5lfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a64b158d60c000d6f7aa056bc1948686b827bd6c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffXm\x8e\xaf\xf7GZr"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\x83kh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d55fb3ee698d130c85f5781ad24bc39fdeeb1b5d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2%\xa3w\xb2\xbb\xb6\t"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -754,11 +754,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9Y\xff>\xae\x95\bq"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff}6\x8aUo\x15\xf5o"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -778,11 +778,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89?\xccp\xbc\xfb\x05\x91"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcdP\xb9\x1b}{\xf8\x8f"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -802,11 +802,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 197803d469e26f9b1c7af34ea57c0670ef4b59f8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC c396444e8b31f479f6fe325bd9e2f81cdc051c34 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(197803d469e26f9b1c7af34ea57c0670ef4b59f8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a\xe2DӒYk\xf4"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c396444e8b31f479f6fe325bd9e2f81cdc051c34\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffCb\x944\x15\x80\x85\xa7"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -912,11 +912,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC dffd9c05e41513290d86a5ea561da0176aa5bb74 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC a3aea9d9301c4b364a6018a816775f620b64662d 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dffd9c05e41513290d86a5ea561da0176aa5bb74\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\xfd\xb6a\xec\x83MZ"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a3aea9d9301c4b364a6018a816775f620b64662d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\xa4{\vlN[\x88"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -978,11 +978,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 3d58529690b7789ccde0d2945da9b5e95b76e737 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xd7lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8acc3b81eef4f90c65f24702fbd9d9ab73d32ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"J\xc7ZjΥW"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3d58529690b7789ccde0d2945da9b5e95b76e737\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2\xb5W7\x14\x81\x88\x14"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1007,9 +1007,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC dfcf31fcefc474bbcd5ecfb358ad79db67f3b8d2 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC a09d7b9909fca7920729da761c6faaf94d969fb5 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1172,9 +1172,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a95b4ea4e5c3eed95db051abeccee25c1c8f8968\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a01edba7a83ab83080168eb7bb612aaaa1dfa24a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1198,9 +1198,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7545cc0d3cde1ccd5b0d27b45f5c2611d20e5d96\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a9a441b5dee5b16fa1262981d59592965be3dda6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1215,115 +1215,109 @@ Debug = true
 [33m[tester::#BW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SM4] [0m[94mRunning tests for Stage #SM4 (sm4)[0m
-[33m[tester::#SM4] [0m[94mCreated RDB file with 3 key-value pairs: {"blueberry": "blueberry", "raspberry": "mango", "pineapple": "banana"}[0m
+[33m[tester::#SM4] [0m[94mCreated RDB file with 4 key-value pairs: {"pineapple": "pineapple", "grape": "orange", "pear": "raspberry", "blueberry": "apple"}[0m
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
-[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 | (.......blueberr[0m
-[33m[tester::#SM4] [0m[36m0040 | 79 09 62 6c 75 65 62 65 72 72 79 fc 00 9c ef 12 | y.blueberry.....[0m
-[33m[tester::#SM4] [0m[36m0050 | 7e 01 00 00 00 09 72 61 73 70 62 65 72 72 79 05 | ~.....raspberry.[0m
-[33m[tester::#SM4] [0m[36m0060 | 6d 61 6e 67 6f fc 00 0c 28 8a c7 01 00 00 00 09 | mango...(.......[0m
-[33m[tester::#SM4] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
-[33m[tester::#SM4] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed                      | ..BMI.;{.[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 09 70 69 6e 65 61 70 70 6c | (.......pineappl[0m
+[33m[tester::#SM4] [0m[36m0040 | 65 09 70 69 6e 65 61 70 70 6c 65 fc 00 0c 28 8a | e.pineapple...(.[0m
+[33m[tester::#SM4] [0m[36m0050 | c7 01 00 00 00 05 67 72 61 70 65 06 6f 72 61 6e | ......grape.oran[0m
+[33m[tester::#SM4] [0m[36m0060 | 67 65 fc 00 9c ef 12 7e 01 00 00 00 04 70 65 61 | ge.....~.....pea[0m
+[33m[tester::#SM4] [0m[36m0070 | 72 09 72 61 73 70 62 65 72 72 79 fc 00 0c 28 8a | r.raspberry...(.[0m
+[33m[tester::#SM4] [0m[36m0080 | c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 79 05 | ......blueberry.[0m
+[33m[tester::#SM4] [0m[36m0090 | 61 70 70 6c 65 ff 92 f1 de f7 06 f6 06 ae       | apple.........[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles839052465 --dbfilename pear.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "blueberry"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-656545637400819176 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
+[33m[tester::#SM4] [0m[92mReceived "pineapple"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
+[33m[tester::#SM4] [0m[92mReceived "orange"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET pear[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pineapple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#SM4] [0m[92mReceived "banana"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET blueberry[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [0m[92mReceived "apple"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#DQ3] [0m[94mRunning tests for Stage #DQ3 (dq3)[0m
-[33m[tester::#DQ3] [0m[94mCreated RDB file with 5 key-value pairs: {"grape": "mango", "orange": "banana", "blueberry": "orange", "pear": "grape", "banana": "blueberry"}[0m
+[33m[tester::#DQ3] [0m[94mCreated RDB file with 3 key-value pairs: {"pineapple": "pear", "raspberry": "apple", "apple": "strawberry"}[0m
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#DQ3] [0m[36m0030 | 72 61 70 65 05 6d 61 6e 67 6f 00 06 6f 72 61 6e | rape.mango..oran[0m
-[33m[tester::#DQ3] [0m[36m0040 | 67 65 06 62 61 6e 61 6e 61 00 09 62 6c 75 65 62 | ge.banana..blueb[0m
-[33m[tester::#DQ3] [0m[36m0050 | 65 72 72 79 06 6f 72 61 6e 67 65 00 04 70 65 61 | erry.orange..pea[0m
-[33m[tester::#DQ3] [0m[36m0060 | 72 05 67 72 61 70 65 00 06 62 61 6e 61 6e 61 09 | r.grape..banana.[0m
-[33m[tester::#DQ3] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 03 5d d3 a4 75 38 | blueberry..]..u8[0m
-[33m[tester::#DQ3] [0m[36m0080 | 83 47                                           | .G[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 09 70 | s-bits.@.......p[0m
+[33m[tester::#DQ3] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 04 70 65 61 72 00 09 72 | ineapple.pear..r[0m
+[33m[tester::#DQ3] [0m[36m0040 | 61 73 70 62 65 72 72 79 05 61 70 70 6c 65 00 05 | aspberry.apple..[0m
+[33m[tester::#DQ3] [0m[36m0050 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
+[33m[tester::#DQ3] [0m[36m0060 | ff d2 b9 68 6d 79 81 2e 5d                      | ...hmy..][0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles958131242 --dbfilename mango.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET orange[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#DQ3] [0m[92mReceived "banana"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET blueberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#DQ3] [0m[92mReceived "orange"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
-[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET banana[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "blueberry"[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3028599034268840109 --dbfilename pear.rdb[0m
+[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
+[33m[tester::#DQ3] [0m[92mReceived "pear"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET raspberry[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#DQ3] [0m[92mReceived "apple"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JW4] [0m[94mRunning tests for Stage #JW4 (jw4)[0m
-[33m[tester::#JW4] [0m[94mCreated RDB file with 4 keys: ["raspberry", "blueberry", "apple", "orange"][0m
+[33m[tester::#JW4] [0m[94mCreated RDB file with 4 keys: ["orange", "blueberry", "grape", "pineapple"][0m
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 72 | s-bits.@.......r[0m
-[33m[tester::#JW4] [0m[36m0030 | 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 65 | aspberry.strawbe[0m
-[33m[tester::#JW4] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 06 6f | rry..blueberry.o[0m
-[33m[tester::#JW4] [0m[36m0050 | 72 61 6e 67 65 00 05 61 70 70 6c 65 05 6d 61 6e | range..apple.man[0m
-[33m[tester::#JW4] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
-[33m[tester::#JW4] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d                      | .:..r.,.=[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 06 6f | s-bits.@.......o[0m
+[33m[tester::#JW4] [0m[36m0030 | 72 61 6e 67 65 05 67 72 61 70 65 00 09 62 6c 75 | range.grape..blu[0m
+[33m[tester::#JW4] [0m[36m0040 | 65 62 65 72 72 79 09 70 69 6e 65 61 70 70 6c 65 | eberry.pineapple[0m
+[33m[tester::#JW4] [0m[36m0050 | 00 05 67 72 61 70 65 05 6d 61 6e 67 6f 00 09 70 | ..grape.mango..p[0m
+[33m[tester::#JW4] [0m[36m0060 | 69 6e 65 61 70 70 6c 65 0a 73 74 72 61 77 62 65 | ineapple.strawbe[0m
+[33m[tester::#JW4] [0m[36m0070 | 72 72 79 ff 1e 60 ef 0f 40 01 3a b1             | rry..`..@.:.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles228935216 --dbfilename grape.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-4518155907013922221 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
+[33m[tester::#JW4] [0m[36m  "grape",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry",[0m
 [33m[tester::#JW4] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [0m[36m  "apple"[0m
+[33m[tester::#JW4] [0m[36m  "pineapple"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
+[33m[tester::#JW4] [0m[92m  "grape",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry",[0m
 [33m[tester::#JW4] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [0m[92m  "apple"[0m
+[33m[tester::#JW4] [0m[92m  "pineapple"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -1331,62 +1325,62 @@ Debug = true
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GC6] [0m[94mRunning tests for Stage #GC6 (gc6)[0m
-[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"blueberry": "raspberry"}[0m
+[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"apple": "banana"}[0m
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 62 | s-bits.@.......b[0m
-[33m[tester::#GC6] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
-[33m[tester::#GC6] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7                | ry..2h(,.&.[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
+[33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
+[33m[tester::#GC6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3297699935 --dbfilename strawberry.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET blueberry[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#GC6] [0m[92mReceived "raspberry"[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3283895374913131601 --dbfilename raspberry.rdb[0m
+[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
+[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[tester::#GC6] [0m[92mReceived "banana"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JZ6] [0m[94mRunning tests for Stage #JZ6 (jz6)[0m
-[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["grape"][0m
+[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["apple"][0m
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
-[33m[tester::#JZ6] [0m[36m0040 | 6b 9a                                           | k.[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
+[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 6f 72 61 6e 67 65 ff 02 51 6c 32 | pple.orange..Ql2[0m
+[33m[tester::#JZ6] [0m[36m0040 | 97 93 08 f8                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3136548219 --dbfilename orange.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-7282332576237470778 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["grape"][0m
+[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["apple"][0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["grape"][0m
+[33m[tester::#JZ6] [0m[92mReceived ["apple"][0m
 [33m[tester::#JZ6] [0m[92m[0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615 --dbfilename raspberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-997559609239412828 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$40\r\n/private/tmp/rdbfiles-997559609239412828\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-997559609239412828"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3180128615"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-997559609239412828"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1395,22 +1389,22 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET mango orange px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$6\r\norange\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [0m[94m$ redis-cli SET apple blueberry px 100[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:22.963[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 17:28:22.963 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET mango[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "orange"[0m
-[33m[tester::#YZ1] [0m[92mReceived "orange"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:35.775[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:35.775 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 17:28:23.067 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET mango[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:35.879 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
@@ -1420,18 +1414,18 @@ Debug = true
 
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LA7] [0m[36mSetting key banana to raspberry[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET banana raspberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [0m[36mSetting key orange to pineapple[0m
+[33m[tester::#LA7] [0m[94m$ redis-cli SET orange pineapple[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#LA7] [0m[92mReceived "OK"[0m
-[33m[tester::#LA7] [0m[36mGetting key banana[0m
-[33m[tester::#LA7] [0m[94m> GET banana[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "raspberry"[0m
-[33m[tester::#LA7] [0m[92mReceived "raspberry"[0m
+[33m[tester::#LA7] [0m[36mGetting key orange[0m
+[33m[tester::#LA7] [0m[94m> GET orange[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -26,11 +26,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0bfcd6a7276e15648083d61e7749ab9455e0b03d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbed\xf4N\xb8\xfa&\xca"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\x9e\xebe@\xc8\xcd\x11"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -50,11 +50,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\xbc\\h\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0bfcd6a7276e15648083d61e7749ab9455e0b03d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01\xa4\xa3`\xa5&|\xd6"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe6^\xbcK]\x14\x97\r"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -74,11 +74,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\xbc\\h\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0bfcd6a7276e15648083d61e7749ab9455e0b03d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x04v@\xfa9\x12\x12v"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\x8c_\xd1\xc1 \xf9\xad"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -98,11 +98,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 0bfcd6a7276e15648083d61e7749ab9455e0b03d 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d53b302933400c568301fb837d5cfd51fb634f7c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\xbc\\h\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0bfcd6a7276e15648083d61e7749ab9455e0b03d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmct4\x81H{\x13"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099bfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d53b302933400c568301fb837d5cfd51fb634f7c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8a\x99k\x1fyz\x90\xc8"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -255,7 +255,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2006 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2011 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -289,11 +289,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)I?\x87\v?N\xce"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\x136\xe9\xf9\xbb\xd3Z"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -313,11 +313,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x96\x89h\xa9\x16\xe3\x14\xd2"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\xd3a\xc7\xe4g\x89F"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -337,11 +337,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x93[\x8b3\x8a\xd7zr"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;\x01\x82]xS\xe7\xe6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -361,11 +361,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfaN\xbf\xfd2\x8d\x13\x17"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffR\x14\xb6\x93\xc0\t\x8e\x83"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -385,11 +385,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,!5J\xbf@\x82\x0f"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x84{<$M\xc4\x1f\x9b"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
@@ -409,11 +409,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)\xf3\xd6\xd0#t\xec\xaf"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\xa9߾\xd1\xf0q;"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
@@ -433,11 +433,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 06fe412977e625d86f1b4c1ce230d02cfa768ec4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4fcb0aa846fef12affe005ca75ab2a1b4d3fb512 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\xbc\\h\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(06fe412977e625d86f1b4c1ce230d02cfa768ec4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@\xe6\xe2\x1e\x9b.\x85\xca"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009cbfh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4fcb0aa846fef12affe005ca75ab2a1b4d3fb512\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8\xbc\xebpi\xaa\x18^"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -754,11 +754,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xbc\\h\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d332996fa15799fb2700d2b4e10714a0149cdcee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdc\xf1\xaa#\xc4<\\\x9f"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffo\x1d\aT\xa2\xc0bQ"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -778,11 +778,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xbc\\h\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d332996fa15799fb2700d2b4e10714a0149cdcee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffl\x97\x99m\xd6RQ\x7f"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdf{4\x1a\xb0\xaeo\xb1"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -802,11 +802,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d332996fa15799fb2700d2b4e10714a0149cdcee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xbc\\h\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d332996fa15799fb2700d2b4e10714a0149cdcee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xffJ\x11\xce\xf8\xf0?\x1a"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52b78fcdd295befdbdbb9a57fd0c3d3e8cf0ec55\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\xa6\xbc\xb9\x9e\f\x01\xd4"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -912,11 +912,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC ae520d636dbc4f3693b99c0d84b8c411150c9d40 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC ae520d636dbc4f3693b99c0d84b8c411150c9d40 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC ae520d636dbc4f3693b99c0d84b8c411150c9d40 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 775024b1c2185689afdd5c7588dbb02c65642013 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xbc\\h\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae520d636dbc4f3693b99c0d84b8c411150c9d40\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83\x12t\xc6\xc0\x9d\x9b\xee"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(775024b1c2185689afdd5c7588dbb02c65642013\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\x036\x86R\xfcUB"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -978,11 +978,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC d4efb77fe6563e531aed2ebbc319031a87b48bc4 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC d4efb77fe6563e531aed2ebbc319031a87b48bc4 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC d4efb77fe6563e531aed2ebbc319031a87b48bc4 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC a4debc350a382d87b5ac975821f21ace65b80a18 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4efb77fe6563e531aed2ebbc319031a87b48bc4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc2k!`\xa0}\xa4a"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009ebfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a4debc350a382d87b5ac975821f21ace65b80a18\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffϚ0\xefJ\x94\x85\xd1"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1007,9 +1007,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 0f48112219a581fe8d07b21e15bc5255aaff5de8 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0f48112219a581fe8d07b21e15bc5255aaff5de8 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 0f48112219a581fe8d07b21e15bc5255aaff5de8 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 33a00c165dc0e4af77027c715758ee19c7199f21 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1172,9 +1172,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:57c458d130108a4bb4de7f65b7c7988dc5cf1a01\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:57c458d130108a4bb4de7f65b7c7988dc5cf1a01\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:57c458d130108a4bb4de7f65b7c7988dc5cf1a01\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0ad7c16651e703039e540a8ab5d123ff76d3df5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1198,9 +1198,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1e43abecbdefb30b924b329e8893b215a263a0de\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1e43abecbdefb30b924b329e8893b215a263a0de\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1e43abecbdefb30b924b329e8893b215a263a0de\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:412486e98944480ded3f8619dc619fb3cd23fc8c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1227,9 +1227,9 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0050 | 7e 01 00 00 00 09 72 61 73 70 62 65 72 72 79 05 | ~.....raspberry.[0m
 [33m[tester::#SM4] [0m[36m0060 | 6d 61 6e 67 6f fc 00 0c 28 8a c7 01 00 00 00 09 | mango...(.......[0m
 [33m[tester::#SM4] [0m[36m0070 | 70 69 6e 65 61 70 70 6c 65 06 62 61 6e 61 6e 61 | pineapple.banana[0m
-[33m[tester::#SM4] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed 0a                   | ..BMI.;{..[0m
+[33m[tester::#SM4] [0m[36m0080 | ff 98 42 4d 49 d1 3b 7b ed                      | ..BMI.;{.[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1812181568 --dbfilename pear.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles144342483 --dbfilename pear.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
@@ -1262,9 +1262,9 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 65 72 72 79 06 6f 72 61 6e 67 65 00 04 70 65 61 | erry.orange..pea[0m
 [33m[tester::#DQ3] [0m[36m0060 | 72 05 67 72 61 70 65 00 06 62 61 6e 61 6e 61 09 | r.grape..banana.[0m
 [33m[tester::#DQ3] [0m[36m0070 | 62 6c 75 65 62 65 72 72 79 ff 03 5d d3 a4 75 38 | blueberry..]..u8[0m
-[33m[tester::#DQ3] [0m[36m0080 | 83 47 0a                                        | .G.[0m
+[33m[tester::#DQ3] [0m[36m0080 | 83 47                                           | .G[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2079095432 --dbfilename mango.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2985550513 --dbfilename mango.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1306,24 +1306,24 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0040 | 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 06 6f | rry..blueberry.o[0m
 [33m[tester::#JW4] [0m[36m0050 | 72 61 6e 67 65 00 05 61 70 70 6c 65 05 6d 61 6e | range..apple.man[0m
 [33m[tester::#JW4] [0m[36m0060 | 67 6f 00 06 6f 72 61 6e 67 65 05 61 70 70 6c 65 | go..orange.apple[0m
-[33m[tester::#JW4] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d 0a                   | .:..r.,.=.[0m
+[33m[tester::#JW4] [0m[36m0070 | ff 3a b9 90 72 de 2c a4 3d                      | .:..r.,.=[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1668220885 --dbfilename grape.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3418496042 --dbfilename grape.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nraspberry\r\n$6\r\norange\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#JW4] [0m[36m  "apple",[0m
+[33m[tester::#JW4] [0m[36m  "blueberry",[0m
 [33m[tester::#JW4] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [0m[36m  "blueberry"[0m
+[33m[tester::#JW4] [0m[36m  "orange"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
 [33m[tester::#JW4] [0m[92m  "apple",[0m
+[33m[tester::#JW4] [0m[92m  "blueberry",[0m
 [33m[tester::#JW4] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [0m[92m  "blueberry"[0m
+[33m[tester::#JW4] [0m[92m  "orange"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -1339,9 +1339,9 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
 [33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 62 | s-bits.@.......b[0m
 [33m[tester::#GC6] [0m[36m0030 | 6c 75 65 62 65 72 72 79 09 72 61 73 70 62 65 72 | lueberry.raspber[0m
-[33m[tester::#GC6] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7 0a             | ry..2h(,.&..[0m
+[33m[tester::#GC6] [0m[36m0040 | 72 79 ff e7 32 68 28 2c c5 26 d7                | ry..2h(,.&.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2106853685 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3925916096 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET blueberry[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1356,13 +1356,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 05 67 | er.7.2.0.......g[0m
-[33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff f8 12 5e 91 93 5d | rape.pear...^..][0m
-[33m[tester::#JZ6] [0m[36m0040 | a5 2e 0a                                        | ...[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
+[33m[tester::#JZ6] [0m[36m0040 | 6b 9a                                           | k.[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles558392868 --dbfilename orange.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1428879244 --dbfilename orange.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -1375,18 +1375,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2514889758 --dbfilename raspberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991 --dbfilename raspberry.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2514889758\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2514889758"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2514889758"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4057057991"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1400,15 +1400,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:03:51.103[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:03:51.103 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:45.924[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 16:44:45.924 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "orange"[0m
 [33m[tester::#YZ1] [0m[92mReceived "orange"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:03:51.206 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 16:44:46.027 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -378,9 +378,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1750907937964-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1750907937964-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1750907937964-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540359128-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540359128-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751540359128-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -502,11 +502,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\"\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a732ec9e462207e0c92c0031b5bd25645cae2c98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffwj\xc6\xf4\xa1\xedh5"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14\xb3\xa5Z\xa8\xd3\xe0\xdb"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -526,11 +526,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\"\xbc\\h\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a732ec9e462207e0c92c0031b5bd25645cae2c98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffȪ\x91ڼ12)"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabs\xf2t\xb5\x0f\xba\xc7"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -550,11 +550,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\"\xbc\\h\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a732ec9e462207e0c92c0031b5bd25645cae2c98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcdxr@ \x05\\\x89"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae\xa1\x11\xee);\xd4g"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -574,11 +574,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC a732ec9e462207e0c92c0031b5bd25645cae2c98 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\"\xbc\\h\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a732ec9e462207e0c92c0031b5bd25645cae2c98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4mF\x8e\x98_5\xec"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0088bfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b\x9f6]\xe7b\xcdF"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -731,7 +731,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2101 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2107 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2%\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4dd9691f11cdad33b4af12be4dafef0f3438fddf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89UOTR\x97\xb0\x03"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3\x13\xcc  \xf0\x96\t"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -785,11 +785,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2%\xbc\\h\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4dd9691f11cdad33b4af12be4dafef0f3438fddf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff6\x95\x18zOK\xea\x1f"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff|ӛ\x0e=,\xcc\x15"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -809,11 +809,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 4dd9691f11cdad33b4af12be4dafef0f3438fddf 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2%\xbc\\h\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4dd9691f11cdad33b4af12be4dafef0f3438fddf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff3G\xfb\xe0\xd3\x7f\x84\xbf"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffy\x01x\x94\xa1\x18\xa2\xb5"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1125,11 +1125,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2'\xbc\\h\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1e1f9c8abef84882356646dcf659cc64345cdfcf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%\xca\x06\x17\xa9`\xfe\x8f"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88\xfa\x98\x95\xfd\x1en\xc7"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1149,11 +1149,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2'\xbc\\h\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1e1f9c8abef84882356646dcf659cc64345cdfcf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x95\xac5Y\xbb\x0e\xf3o"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\x9c\xab\xdb\xefpc'"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1173,11 +1173,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 1e1f9c8abef84882356646dcf659cc64345cdfcf 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2'\xbc\\h\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1e1f9c8abef84882356646dcf659cc64345cdfcf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06q\xbd\xfa\x95\xac\x9d\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabA#x\xc1\xd2\rB"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1283,11 +1283,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC eecad344f0c2c1ba3b69a39595bf605dde7a1805 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC eecad344f0c2c1ba3b69a39595bf605dde7a1805 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC eecad344f0c2c1ba3b69a39595bf605dde7a1805 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2'\xbc\\h\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eecad344f0c2c1ba3b69a39595bf605dde7a1805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff/\x11mDJ\xe7l*"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008dbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x94(\xf3Pk\xa8~\xda"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1349,11 +1349,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 13018ecd2012897878c8aa5dd6c1296b04d2c541 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 13018ecd2012897878c8aa5dd6c1296b04d2c541 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 13018ecd2012897878c8aa5dd6c1296b04d2c541 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(\xbc\\h\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(13018ecd2012897878c8aa5dd6c1296b04d2c541\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffrF;\x02\x96P\xe6&"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008dbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(817b22bc22451d612603e18ccddae9a11467c7a2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16J\xc22\x9b\x17\v\xde"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1378,9 +1378,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 712ccd376d1820677440c43c585c41bf5d3c6431 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 712ccd376d1820677440c43c585c41bf5d3c6431 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 712ccd376d1820677440c43c585c41bf5d3c6431 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1543,9 +1543,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8df39f35ec759e95f0124511d083ffc25df26df7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8df39f35ec759e95f0124511d083ffc25df26df7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8df39f35ec759e95f0124511d083ffc25df26df7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1569,9 +1569,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a4688f79aa8e7b3b101f839316b0f69f0d0742c3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a4688f79aa8e7b3b101f839316b0f69f0d0742c3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a4688f79aa8e7b3b101f839316b0f69f0d0742c3\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1599,9 +1599,9 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0060 | 00 00 00 05 67 72 61 70 65 04 70 65 61 72 fc 00 | ....grape.pear..[0m
 [33m[tester::#SM4] [0m[36m0070 | 0c 28 8a c7 01 00 00 00 0a 73 74 72 61 77 62 65 | .(.......strawbe[0m
 [33m[tester::#SM4] [0m[36m0080 | 72 72 79 09 62 6c 75 65 62 65 72 72 79 ff 76 5f | rry.blueberry.v_[0m
-[33m[tester::#SM4] [0m[36m0090 | 64 e4 1a 6e 1a 3a 0a                            | d..n.:.[0m
+[33m[tester::#SM4] [0m[36m0090 | 64 e4 1a 6e 1a 3a                               | d..n.:[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles650220062 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3418644323 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1631,15 +1631,15 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 04 70 | er.7.2.0.......p[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 04 70 | s-bits.@.......p[0m
 [33m[tester::#DQ3] [0m[36m0030 | 65 61 72 06 6f 72 61 6e 67 65 00 06 6f 72 61 6e | ear.orange..oran[0m
 [33m[tester::#DQ3] [0m[36m0040 | 67 65 06 62 61 6e 61 6e 61 00 05 67 72 61 70 65 | ge.banana..grape[0m
 [33m[tester::#DQ3] [0m[36m0050 | 05 67 72 61 70 65 00 05 61 70 70 6c 65 04 70 65 | .grape..apple.pe[0m
-[33m[tester::#DQ3] [0m[36m0060 | 61 72 ff 57 a8 dd 14 c7 de 2d 57 0a             | ar.W.....-W.[0m
+[33m[tester::#DQ3] [0m[36m0060 | 61 72 ff a2 ee 65 8a c4 f0 d2 68                | ar...e....h[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4248915410 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1769262268 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
@@ -1675,15 +1675,15 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 06 62 61 6e 61 6e 61 00 06 6f 72 61 | rape.banana..ora[0m
 [33m[tester::#JW4] [0m[36m0040 | 6e 67 65 09 62 6c 75 65 62 65 72 72 79 00 06 62 | nge.blueberry..b[0m
 [33m[tester::#JW4] [0m[36m0050 | 61 6e 61 6e 61 05 61 70 70 6c 65 ff 33 4c d7 b6 | anana.apple.3L..[0m
-[33m[tester::#JW4] [0m[36m0060 | e5 63 43 09 0a                                  | .cC..[0m
+[33m[tester::#JW4] [0m[36m0060 | e5 63 43 09                                     | .cC.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3546809956 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles30226998 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$6\r\norange\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["banana", "orange", "grape"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["banana", "grape", "orange"][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["banana", "orange", "grape"][0m
+[33m[tester::#JW4] [0m[92mReceived ["banana", "grape", "orange"][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -1694,13 +1694,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 70 | s-bits.@.......p[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 70 | er.7.2.0.......p[0m
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 06 6f 72 61 6e 67 65 ff | ineapple.orange.[0m
-[33m[tester::#GC6] [0m[36m0040 | a2 22 f4 2e ac 2b 91 9d 0a                      | ."...+...[0m
+[33m[tester::#GC6] [0m[36m0040 | 80 58 a4 21 1e 4b 84 9b                         | .X.!.K..[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3402206299 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1348771406 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
@@ -1715,13 +1715,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 05 61 | er.7.2.0.......a[0m
-[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff aa ee 3c b0 | pple.banana...<.[0m
-[33m[tester::#JZ6] [0m[36m0040 | 09 01 4d 51 0a                                  | ..MQ.[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
+[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
+[33m[tester::#JZ6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles851786180 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3649333340 --dbfilename pear.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
@@ -1734,18 +1734,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4277684109 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4277684109\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4277684109"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles4277684109"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1759,15 +1759,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:04:07.340[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 09:04:07.340 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:28.500[0m
+[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 16:44:28.500 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET raspberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[tester::#YZ1] [0m[92mReceived "mango"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 09:04:07.444 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 16:44:28.604 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET raspberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -378,9 +378,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540359128-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540359128-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751540359128-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751543009807-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751543009807-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751543009807-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -502,11 +502,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14\xb3\xa5Z\xa8\xd3\xe0\xdb"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16\xee\xe1\x90\xd3~\x90y"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -526,11 +526,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabs\xf2t\xb5\x0f\xba\xc7"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9.\xb6\xbe\u03a2\xcae"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -550,11 +550,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087bfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae\xa1\x11\xee);\xd4g"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xac\xfcU$R\x96\xa4\xc5"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -574,11 +574,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 50ddfd62638bb41b6419a7b3823c497825bd4343 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0088bfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50ddfd62638bb41b6419a7b3823c497825bd4343\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b\x9f6]\xe7b\xcdF"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5\xe9a\xea\xea\xcc͠"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -731,7 +731,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2107 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2103 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3\x13\xcc  \xf0\x96\t"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfb5a\x9c\xf1\x83\x91\x1a"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -785,11 +785,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff|ӛ\x0e=,\xcc\x15"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffD\xf56\xb2\xec_\xcb\x06"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -809,11 +809,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 716d17bfbcc1fd16e204f1359624362416d5a76c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008abfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(716d17bfbcc1fd16e204f1359624362416d5a76c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffy\x01x\x94\xa1\x18\xa2\xb5"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA'\xd5(pk\xa5\xa6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1125,11 +1125,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88\xfa\x98\x95\xfd\x1en\xc7"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1d\xb7\x06\xca\xf9\xd1u\xc4"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1149,11 +1149,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\x9c\xab\xdb\xefpc'"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\xd15\x84\xeb\xbfx$"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1173,11 +1173,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8c73b7cad8b1c5fed991a65b225aead943b04305 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008cbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8c73b7cad8b1c5fed991a65b225aead943b04305\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabA#x\xc1\xd2\rB"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\f\xbd'\xc5\x1d\x16A"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1283,11 +1283,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008dbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4bc42a7e3bf7b62c9bd9ccf3fa79229ccc230bd2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x94(\xf3Pk\xa8~\xda"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1\xed\x02ί\xf3\xdet"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1349,11 +1349,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 817b22bc22451d612603e18ccddae9a11467c7a2 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008dbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(817b22bc22451d612603e18ccddae9a11467c7a2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16J\xc22\x9b\x17\v\xde"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(91e758724307a239612a99ab863053a88d4bab47\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdb=\x0f\xba\xd0:\xfb\x1e"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1378,9 +1378,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 6b571bd2c258fb4ab7f8a264f04544e29dd5ce75 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1543,9 +1543,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb41f4b68deb4de3f6780557f5c798f944577ef1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1569,9 +1569,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d736487e36b0f349fac7aceca8cb4547d07cbb60\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1601,7 +1601,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 72 72 79 09 62 6c 75 65 62 65 72 72 79 ff 76 5f | rry.blueberry.v_[0m
 [33m[tester::#SM4] [0m[36m0090 | 64 e4 1a 6e 1a 3a                               | d..n.:[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3418644323 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles159075472 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -1639,7 +1639,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 05 67 72 61 70 65 00 05 61 70 70 6c 65 04 70 65 | .grape..apple.pe[0m
 [33m[tester::#DQ3] [0m[36m0060 | 61 72 ff a2 ee 65 8a c4 f0 d2 68                | ar...e....h[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1769262268 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles667876130 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
@@ -1677,13 +1677,13 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 61 6e 61 6e 61 05 61 70 70 6c 65 ff 33 4c d7 b6 | anana.apple.3L..[0m
 [33m[tester::#JW4] [0m[36m0060 | e5 63 43 09                                     | .cC.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles30226998 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3189486215 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\nbanana\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["banana", "grape", "orange"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\norange\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["orange", "grape", "banana"][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["banana", "grape", "orange"][0m
+[33m[tester::#JW4] [0m[92mReceived ["orange", "grape", "banana"][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -1694,13 +1694,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 70 | er.7.2.0.......p[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 70 | s-bits.@.......p[0m
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 06 6f 72 61 6e 67 65 ff | ineapple.orange.[0m
-[33m[tester::#GC6] [0m[36m0040 | 80 58 a4 21 1e 4b 84 9b                         | .X.!.K..[0m
+[33m[tester::#GC6] [0m[36m0040 | a2 22 f4 2e ac 2b 91 9d                         | ."...+..[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1348771406 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1558621045 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
@@ -1721,7 +1721,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
 [33m[tester::#JZ6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3649333340 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1538102780 --dbfilename pear.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
@@ -1734,18 +1734,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3335113871"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1759,15 +1759,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 16:44:28.500[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 16:44:28.500 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:39.120[0m
+[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 17:28:39.120 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET raspberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[tester::#YZ1] [0m[92mReceived "mango"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 16:44:28.604 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 17:28:39.223 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET raspberry[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -378,9 +378,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876546514-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876546514-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751876546514-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946676291-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946676291-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751946676291-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -502,11 +502,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\xc9\"\x94\x12\x04\xf0P"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime´\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4\x8b\x83\xa3\xa47+\xec"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -526,11 +526,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\tu\xba\x0fتL"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\uef8c\xe9BZ'."[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -550,11 +550,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbaۖ \x93\xec\xc4\xec"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeblos\xdenI\x8e"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -574,11 +574,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd3\u03a2\xee+\xb6\xad\x89"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82y[\xbdf4 \xeb"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -731,7 +731,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2007 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc6\xe4\xea\x1b\xa7\xa8\xe2"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9f\xbb\xe6\xb2q\xf3\xe7"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -785,11 +785,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\xf6\xb3\xc4\x06{\xf2\xfe"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffF\xa6\xecȯ\xad\xa9\xfb"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -809,11 +809,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06$P^\x9aO\x9c^"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffCt\x0fR3\x99\xc7["[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1125,11 +1125,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ǃkh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(s\x8a\xc7\x02\x96\x19\xfa"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab\xe1X\xa4j\x1f\xe2\r"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1149,11 +1149,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffW>\xaa\xf4f\xfbd^"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1b\x87k\xeaxq\xef\xed"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1173,11 +1173,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\xe3\"WHY\n;"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88Z\xe3IVӁ\x88"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1283,11 +1283,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10bc606d491edebfe47f86d1ff2cb7b9d9337c26\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffɷ\x9e\x82\xc00\xe9\x91"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeº\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50f4faf7255f08cff8ada2f200426b29daf6168d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3<\xcb\xdb>\xfb\x83\n"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1349,11 +1349,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83r\xd2\xea\x17\x90\x0f("[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeº\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\xe8\xf3ߌU\xb7\x1f"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1378,9 +1378,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1543,9 +1543,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1569,9 +1569,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1600,7 +1600,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0070 | 6e 67 6f 06 6f 72 61 6e 67 65 ff 58 9d c8 3c e9 | ngo.orange.X..<.[0m
 [33m[tester::#SM4] [0m[36m0080 | bc 46 59                                        | .FY[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3626548408914545615 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1600 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET raspberry[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
@@ -1625,15 +1625,15 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 06 62 | s-bits.@.......b[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 00 00 06 62 | er.7.2.0.......b[0m
 [33m[tester::#DQ3] [0m[36m0030 | 61 6e 61 6e 61 05 61 70 70 6c 65 00 04 70 65 61 | anana.apple..pea[0m
 [33m[tester::#DQ3] [0m[36m0040 | 72 0a 73 74 72 61 77 62 65 72 72 79 00 09 62 6c | r.strawberry..bl[0m
 [33m[tester::#DQ3] [0m[36m0050 | 75 65 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 | ueberry.blueberr[0m
-[33m[tester::#DQ3] [0m[36m0060 | 79 ff 8d bc a5 75 40 e0 5f 22                   | y....u@._"[0m
+[33m[tester::#DQ3] [0m[36m0060 | 79 ff 6e 1a 43 ca 49 58 57 72                   | y.n.C.IXWr[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6112981457280301140 --dbfilename strawberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9407 --dbfilename strawberry.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET banana[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
@@ -1669,24 +1669,24 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0080 | 72 79 09 70 69 6e 65 61 70 70 6c 65 ff 6f da 7a | ry.pineapple.o.z[0m
 [33m[tester::#JW4] [0m[36m0090 | 6e 99 43 a8 45                                  | n.C.E[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-205137900962264348 --dbfilename pineapple.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2389 --dbfilename pineapple.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [0m[36m  "pineapple",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry"[0m
+[33m[tester::#JW4] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [0m[36m  "blueberry"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [0m[92m  "pineapple",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry"[0m
+[33m[tester::#JW4] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [0m[92m  "blueberry"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -1698,13 +1698,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 70 | er.7.2.0.......p[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 70 | s-bits.@.......p[0m
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 72 | ineapple.raspber[0m
-[33m[tester::#GC6] [0m[36m0040 | 72 79 ff 0a 19 c4 51 32 9f 06 5e                | ry....Q2..^[0m
+[33m[tester::#GC6] [0m[36m0040 | 72 79 ff f1 2b db 4b ca 51 08 d5                | ry..+.K.Q..[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8213092160634621402 --dbfilename orange.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -1719,13 +1719,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
-[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff ac | ear.strawberry..[0m
-[33m[tester::#JZ6] [0m[36m0040 | 16 e9 97 c8 3c d1 28                            | ....<.([0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 04 70 | er.7.2.0.......p[0m
+[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff d6 | ear.strawberry..[0m
+[33m[tester::#JZ6] [0m[36m0040 | 5f e2 14 2c 5b 67 c6                            | _..,[g.[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2259769932689477459 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3687 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
@@ -1738,19 +1738,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3109004153974137912 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-3109004153974137912\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-3109004153974137912"[0m
-[33m[tester::#ZG5] [0m[36m][0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-1438\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-1438"][0m
 [33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived [[0m
-[33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-3109004153974137912"[0m
-[33m[tester::#ZG5] [0m[92m][0m
+[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-1438"][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
@@ -1763,15 +1757,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:07:35.843[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:07:35.843 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:25.653[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:36:25.653 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "raspberry"[0m
 [33m[tester::#YZ1] [0m[92mReceived "raspberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:07:35.947 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:36:25.756 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -378,9 +378,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751543009807-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751543009807-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751543009807-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876546514-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876546514-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751876546514-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -502,11 +502,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16\xee\xe1\x90\xd3~\x90y"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\xc9\"\x94\x12\x04\xf0P"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -526,11 +526,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9.\xb6\xbe\u03a2\xcae"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\tu\xba\x0fتL"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -550,11 +550,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xac\xfcU$R\x96\xa4\xc5"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbaۖ \x93\xec\xc4\xec"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -574,11 +574,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e8572cb674ed1c64b7e51d13b70c7d17392c2a27 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e8572cb674ed1c64b7e51d13b70c7d17392c2a27\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5\xe9a\xea\xea\xcc͠"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ãkh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3fd79fd4b5f54fd9e7ef1b013a802a01cfe55eae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd3\u03a2\xee+\xb6\xad\x89"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -731,7 +731,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2103 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2007 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfb5a\x9c\xf1\x83\x91\x1a"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc6\xe4\xea\x1b\xa7\xa8\xe2"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -785,11 +785,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffD\xf56\xb2\xec_\xcb\x06"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\xf6\xb3\xc4\x06{\xf2\xfe"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -809,11 +809,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b8e9df2b2cce8187a8412595988491acab2b78c4 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 3e5dfc60140861a68fb6150901c6165a3965a391 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8e9df2b2cce8187a8412595988491acab2b78c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA'\xd5(pk\xa5\xa6"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ńkh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3e5dfc60140861a68fb6150901c6165a3965a391\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06$P^\x9aO\x9c^"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1125,11 +1125,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1d\xb7\x06\xca\xf9\xd1u\xc4"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ǃkh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(s\x8a\xc7\x02\x96\x19\xfa"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1149,11 +1149,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\xd15\x84\xeb\xbfx$"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffW>\xaa\xf4f\xfbd^"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1173,11 +1173,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 942ea449a2172cb2e193ad1889c04116bd3705b0 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ae2a977a0c43938ad8e6372793462d4b36d82601 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(942ea449a2172cb2e193ad1889c04116bd3705b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\f\xbd'\xc5\x1d\x16A"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae2a977a0c43938ad8e6372793462d4b36d82601\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc4\xe3\"WHY\n;"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1283,11 +1283,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 10bc606d491edebfe47f86d1ff2cb7b9d9337c26 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b8725a62f1d5828360a1e68b4563f1ae3c0bf8ec\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1\xed\x02ί\xf3\xdet"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10bc606d491edebfe47f86d1ff2cb7b9d9337c26\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffɷ\x9e\x82\xc00\xe9\x91"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1349,11 +1349,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 91e758724307a239612a99ab863053a88d4bab47 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(91e758724307a239612a99ab863053a88d4bab47\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdb=\x0f\xba\xd0:\xfb\x1e"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȃkh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(daaa6ef51d3e911a9cd5cfb1dffd3c5a50623354\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83r\xd2\xea\x17\x90\x0f("[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1378,9 +1378,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC b4bb13af5c57b627b5f43500ea4864ea10c58afb 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC d6d76ac1632e7b9aeb468ae24fabe69479c0b45c 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1543,9 +1543,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:0051abc52f2244004f3354d68c5b9d240a98dec1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:140745b7f7a4abaf7156713fd8a05b8b00a2af1a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1569,9 +1569,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96496dbee61192171aa92835fdb5805837d44ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:e7405272161c011be6706f550ed82895aec76c44\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1586,166 +1586,170 @@ Debug = true
 [33m[tester::#BW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SM4] [0m[94mRunning tests for Stage #SM4 (sm4)[0m
-[33m[tester::#SM4] [0m[94mCreated RDB file with 4 key-value pairs: {"pear": "mango", "mango": "orange", "grape": "pear", "strawberry": "blueberry"}[0m
+[33m[tester::#SM4] [0m[94mCreated RDB file with 3 key-value pairs: {"raspberry": "banana", "orange": "pineapple", "mango": "orange"}[0m
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
-[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 04 70 65 61 72 05 6d 61 6e | (.......pear.man[0m
-[33m[tester::#SM4] [0m[36m0040 | 67 6f fc 00 0c 28 8a c7 01 00 00 00 05 6d 61 6e | go...(.......man[0m
-[33m[tester::#SM4] [0m[36m0050 | 67 6f 06 6f 72 61 6e 67 65 fc 00 9c ef 12 7e 01 | go.orange.....~.[0m
-[33m[tester::#SM4] [0m[36m0060 | 00 00 00 05 67 72 61 70 65 04 70 65 61 72 fc 00 | ....grape.pear..[0m
-[33m[tester::#SM4] [0m[36m0070 | 0c 28 8a c7 01 00 00 00 0a 73 74 72 61 77 62 65 | .(.......strawbe[0m
-[33m[tester::#SM4] [0m[36m0080 | 72 72 79 09 62 6c 75 65 62 65 72 72 79 ff 76 5f | rry.blueberry.v_[0m
-[33m[tester::#SM4] [0m[36m0090 | 64 e4 1a 6e 1a 3a                               | d..n.:[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 0c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 09 72 61 73 70 62 65 72 72 | (.......raspberr[0m
+[33m[tester::#SM4] [0m[36m0040 | 79 06 62 61 6e 61 6e 61 fc 00 9c ef 12 7e 01 00 | y.banana.....~..[0m
+[33m[tester::#SM4] [0m[36m0050 | 00 00 06 6f 72 61 6e 67 65 09 70 69 6e 65 61 70 | ...orange.pineap[0m
+[33m[tester::#SM4] [0m[36m0060 | 70 6c 65 fc 00 0c 28 8a c7 01 00 00 00 05 6d 61 | ple...(.......ma[0m
+[33m[tester::#SM4] [0m[36m0070 | 6e 67 6f 06 6f 72 61 6e 67 65 ff 58 9d c8 3c e9 | ngo.orange.X..<.[0m
+[33m[tester::#SM4] [0m[36m0080 | bc 46 59                                        | .FY[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles159075472 --dbfilename apple.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#SM4] [0m[92mReceived "mango"[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3626548408914545615 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET raspberry[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "banana"[0m
+[33m[tester::#SM4] [0m[92mReceived "banana"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET orange[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[94mclient: > GET mango[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
 [33m[tester::#SM4] [0m[92mReceived "orange"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET strawberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "blueberry"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#DQ3] [0m[94mRunning tests for Stage #DQ3 (dq3)[0m
-[33m[tester::#DQ3] [0m[94mCreated RDB file with 4 key-value pairs: {"pear": "orange", "orange": "banana", "grape": "grape", "apple": "pear"}[0m
+[33m[tester::#DQ3] [0m[94mCreated RDB file with 3 key-value pairs: {"banana": "apple", "pear": "strawberry", "blueberry": "blueberry"}[0m
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 04 70 | s-bits.@.......p[0m
-[33m[tester::#DQ3] [0m[36m0030 | 65 61 72 06 6f 72 61 6e 67 65 00 06 6f 72 61 6e | ear.orange..oran[0m
-[33m[tester::#DQ3] [0m[36m0040 | 67 65 06 62 61 6e 61 6e 61 00 05 67 72 61 70 65 | ge.banana..grape[0m
-[33m[tester::#DQ3] [0m[36m0050 | 05 67 72 61 70 65 00 05 61 70 70 6c 65 04 70 65 | .grape..apple.pe[0m
-[33m[tester::#DQ3] [0m[36m0060 | 61 72 ff a2 ee 65 8a c4 f0 d2 68                | ar...e....h[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 06 62 | s-bits.@.......b[0m
+[33m[tester::#DQ3] [0m[36m0030 | 61 6e 61 6e 61 05 61 70 70 6c 65 00 04 70 65 61 | anana.apple..pea[0m
+[33m[tester::#DQ3] [0m[36m0040 | 72 0a 73 74 72 61 77 62 65 72 72 79 00 09 62 6c | r.strawberry..bl[0m
+[33m[tester::#DQ3] [0m[36m0050 | 75 65 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 | ueberry.blueberr[0m
+[33m[tester::#DQ3] [0m[36m0060 | 79 ff 8d bc a5 75 40 e0 5f 22                   | y....u@._"[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles667876130 --dbfilename pineapple.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-6112981457280301140 --dbfilename strawberry.rdb[0m
+[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET banana[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#DQ3] [0m[92mReceived "apple"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#DQ3] [0m[92mReceived "orange"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET orange[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#DQ3] [0m[92mReceived "banana"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET grape[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
-[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pear"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET blueberry[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "blueberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JW4] [0m[94mRunning tests for Stage #JW4 (jw4)[0m
-[33m[tester::#JW4] [0m[94mCreated RDB file with 3 keys: ["grape", "orange", "banana"][0m
+[33m[tester::#JW4] [0m[94mCreated RDB file with 5 keys: ["banana", "pineapple", "blueberry", "raspberry", "strawberry"][0m
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 06 62 61 6e 61 6e 61 00 06 6f 72 61 | rape.banana..ora[0m
-[33m[tester::#JW4] [0m[36m0040 | 6e 67 65 09 62 6c 75 65 62 65 72 72 79 00 06 62 | nge.blueberry..b[0m
-[33m[tester::#JW4] [0m[36m0050 | 61 6e 61 6e 61 05 61 70 70 6c 65 ff 33 4c d7 b6 | anana.apple.3L..[0m
-[33m[tester::#JW4] [0m[36m0060 | e5 63 43 09                                     | .cC.[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 06 62 | s-bits.@.......b[0m
+[33m[tester::#JW4] [0m[36m0030 | 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 79 00 | anana.raspberry.[0m
+[33m[tester::#JW4] [0m[36m0040 | 09 70 69 6e 65 61 70 70 6c 65 09 62 6c 75 65 62 | .pineapple.blueb[0m
+[33m[tester::#JW4] [0m[36m0050 | 65 72 72 79 00 09 62 6c 75 65 62 65 72 72 79 06 | erry..blueberry.[0m
+[33m[tester::#JW4] [0m[36m0060 | 62 61 6e 61 6e 61 00 09 72 61 73 70 62 65 72 72 | banana..raspberr[0m
+[33m[tester::#JW4] [0m[36m0070 | 79 04 70 65 61 72 00 0a 73 74 72 61 77 62 65 72 | y.pear..strawber[0m
+[33m[tester::#JW4] [0m[36m0080 | 72 79 09 70 69 6e 65 61 70 70 6c 65 ff 6f da 7a | ry.pineapple.o.z[0m
+[33m[tester::#JW4] [0m[36m0090 | 6e 99 43 a8 45                                  | n.C.E[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3189486215 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-205137900962264348 --dbfilename pineapple.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$6\r\norange\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["orange", "grape", "banana"][0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\nblueberry\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
+[33m[tester::#JW4] [0m[36m  "blueberry",[0m
+[33m[tester::#JW4] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [0m[36m  "raspberry"[0m
+[33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["orange", "grape", "banana"][0m
+[33m[tester::#JW4] [0m[92mReceived [[0m
+[33m[tester::#JW4] [0m[92m  "blueberry",[0m
+[33m[tester::#JW4] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [0m[92m  "raspberry"[0m
+[33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GC6] [0m[94mRunning tests for Stage #GC6 (gc6)[0m
-[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"pineapple": "orange"}[0m
+[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"pineapple": "raspberry"}[0m
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 70 | s-bits.@.......p[0m
-[33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 06 6f 72 61 6e 67 65 ff | ineapple.orange.[0m
-[33m[tester::#GC6] [0m[36m0040 | a2 22 f4 2e ac 2b 91 9d                         | ."...+..[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 70 | er.7.2.0.......p[0m
+[33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 72 | ineapple.raspber[0m
+[33m[tester::#GC6] [0m[36m0040 | 72 79 ff 0a 19 c4 51 32 9f 06 5e                | ry....Q2..^[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1558621045 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8213092160634621402 --dbfilename orange.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#GC6] [0m[92mReceived "orange"[0m
+[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[tester::#GC6] [0m[92mReceived "raspberry"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JZ6] [0m[94mRunning tests for Stage #JZ6 (jz6)[0m
-[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["apple"][0m
+[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["pear"][0m
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
-[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
-[33m[tester::#JZ6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff ac | ear.strawberry..[0m
+[33m[tester::#JZ6] [0m[36m0040 | 16 e9 97 c8 3c d1 28                            | ....<.([0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1538102780 --dbfilename pear.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-2259769932689477459 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["apple"][0m
+[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
+[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["pear"][0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["apple"][0m
+[33m[tester::#JZ6] [0m[92mReceived ["pear"][0m
 [33m[tester::#JZ6] [0m[92m[0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3109004153974137912 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-3109004153974137912\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-3109004153974137912"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-3925664214"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-3109004153974137912"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -1754,22 +1758,22 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET raspberry mango px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [0m[94m$ redis-cli SET banana raspberry px 100[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:39.120[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 17:28:39.120 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET raspberry[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
-[33m[tester::#YZ1] [0m[92mReceived "mango"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 14:07:35.843[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:07:35.843 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET banana[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#YZ1] [0m[92mReceived "raspberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "raspberry" at 17:28:39.223 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET raspberry[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:07:35.947 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET banana[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
@@ -1779,15 +1783,15 @@ Debug = true
 
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LA7] [0m[36mSetting key blueberry to pineapple[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET blueberry pineapple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [0m[36mSetting key orange to pineapple[0m
+[33m[tester::#LA7] [0m[94m$ redis-cli SET orange pineapple[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#LA7] [0m[92mReceived "OK"[0m
-[33m[tester::#LA7] [0m[36mGetting key blueberry[0m
-[33m[tester::#LA7] [0m[94m> GET blueberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#LA7] [0m[36mGetting key orange[0m
+[33m[tester::#LA7] [0m[94m> GET orange[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
 [33m[tester::#LA7] [0m[92mReceived "pineapple"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -774,9 +774,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751441496345-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751441496345-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751441496345-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540302324-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540302324-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751540302324-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -898,11 +898,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Y\xe0dh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621340ee07bebe819625d4e897f643c08d14ae42\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a\x12P\xc9\xc1\x9b\xec0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\x85\xab\xb4B\x1c\xbe\xe2"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -922,11 +922,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Y\xe0dh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621340ee07bebe819625d4e897f643c08d14ae42\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa5\xd2\a\xe7\xdcG\xb6,"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbfE\xfc\x9a_\xc0\xe4\xfe"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -946,11 +946,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Y\xe0dh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621340ee07bebe819625d4e897f643c08d14ae42\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa0\x00\xe4}@s،"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xba\x97\x1f\x00\xc3\xf4\x8a^"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -970,11 +970,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 621340ee07bebe819625d4e897f643c08d14ae42 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Y\xe0dh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(621340ee07bebe819625d4e897f643c08d14ae42\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc9\x15г\xf8)\xb1\xe9"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffӂ+\xce{\xae\xe3;"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1127,7 +1127,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2107 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2109 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1159,11 +1159,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2[\xe0dh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(734c32e788e3b6e1ac4d6d504ce7df1761f3bab5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x91\x9fi\x7ft\x06\xd4\xf7"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\x14\xe2\x93ٔR\xc2"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1183,11 +1183,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2[\xe0dh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(734c32e788e3b6e1ac4d6d504ce7df1761f3bab5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff._>Qiڎ\xeb"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9dԵ\xbd\xc4H\b\xde"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1207,11 +1207,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2[\xe0dh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(734c32e788e3b6e1ac4d6d504ce7df1761f3bab5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff+\x8d\xdd\xcb\xf5\xee\xe0K"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98\x06V'X|f~"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1231,11 +1231,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2[\xe0dh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(734c32e788e3b6e1ac4d6d504ce7df1761f3bab5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffB\x98\xe9\x05M\xb4\x89."[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf1\x13b\xe9\xe0&\x0f\x1b"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1255,11 +1255,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 734c32e788e3b6e1ac4d6d504ce7df1761f3bab5 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\\\xe0dh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(734c32e788e3b6e1ac4d6d504ce7df1761f3bab5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89\x18\xc6>\x86 \v{"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Rbfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\xf1\x96\xaa3\x1f<J"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1581,11 +1581,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^\xe0dh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(824e264a4a1f7ad7fdbe752cc8a015df897b9192\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\x93\x1c\x9d\xa5\x8f\xd4\xfb"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Sbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde_w\xf4Ԅ\xed\xe9"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1605,11 +1605,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^\xe0dh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(824e264a4a1f7ad7fdbe752cc8a015df897b9192\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbf\xf5/ӷ\xe1\xd9\x1b"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffs\xd6\xe16\x80\xb3\xf3D"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1629,11 +1629,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 824e264a4a1f7ad7fdbe752cc8a015df897b9192 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^\xe0dh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(824e264a4a1f7ad7fdbe752cc8a015df897b9192\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,(\xa7p\x99C\xb7~"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\vi\x95\xae\x11\x9d!"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1739,11 +1739,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 7a1e7f899083c83e2f7014d98f03146eef487637 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 7a1e7f899083c83e2f7014d98f03146eef487637 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 7a1e7f899083c83e2f7014d98f03146eef487637 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^\xe0dh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7a1e7f899083c83e2f7014d98f03146eef487637\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x05\xb9\xd6W'6`\x12"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fa845bad3d5699a97c139d166dd0003a60511ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff$\xac\xcf[\xbc\x13\xa5X"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1805,11 +1805,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC ce3cb4f7ab97bfdaa9ce7375d16cb57732b5b275 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC ce3cb4f7ab97bfdaa9ce7375d16cb57732b5b275 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC ce3cb4f7ab97bfdaa9ce7375d16cb57732b5b275 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^\xe0dh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ce3cb4f7ab97bfdaa9ce7375d16cb57732b5b275\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffs\x11\xe8c\xc8\xfa\x88\x97"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8acb568d7a12e33b0435f6f4f781c3f142f2a346\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x02\xf3\x10c\x06J\x1dT"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1834,9 +1834,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 6dc5fbf9ae3f4838c90f8ab654d5ce80bb5c21b5 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 6dc5fbf9ae3f4838c90f8ab654d5ce80bb5c21b5 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 6dc5fbf9ae3f4838c90f8ab654d5ce80bb5c21b5 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1999,9 +1999,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6d315c9fdf26949383197a48f6e2a8449651b2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6d315c9fdf26949383197a48f6e2a8449651b2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f6d315c9fdf26949383197a48f6e2a8449651b2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2025,9 +2025,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fdb8f13a17beae8d0c96f5bab8db432c22c2ac3e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fdb8f13a17beae8d0c96f5bab8db432c22c2ac3e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fdb8f13a17beae8d0c96f5bab8db432c22c2ac3e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2057,7 +2057,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 8a c7 01 00 00 00 05 61 70 70 6c 65 05 6d 61 6e | .......apple.man[0m
 [33m[tester::#SM4] [0m[36m0090 | 67 6f ff f7 60 56 50 63 52 61 7a                | go..`VPcRaz[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3527334376 --dbfilename grape.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2358980242 --dbfilename grape.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2087,16 +2087,16 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 09 70 | er.7.2.0.......p[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 70 | s-bits.@.......p[0m
 [33m[tester::#DQ3] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 70 69 6e 65 61 70 70 | ineapple.pineapp[0m
 [33m[tester::#DQ3] [0m[36m0040 | 6c 65 00 04 70 65 61 72 06 6f 72 61 6e 67 65 00 | le..pear.orange.[0m
 [33m[tester::#DQ3] [0m[36m0050 | 05 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 00 0a 73 | .mango.banana..s[0m
-[33m[tester::#DQ3] [0m[36m0060 | 74 72 61 77 62 65 72 72 79 04 70 65 61 72 ff 16 | trawberry.pear..[0m
-[33m[tester::#DQ3] [0m[36m0070 | d7 b4 83 8d 2d f2 30                            | ....-.0[0m
+[33m[tester::#DQ3] [0m[36m0060 | 74 72 61 77 62 65 72 72 79 04 70 65 61 72 ff 33 | trawberry.pear.3[0m
+[33m[tester::#DQ3] [0m[36m0070 | a8 09 ab 30 37 3e 50                            | ...07>P[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles986796517 --dbfilename mango.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3590744088 --dbfilename mango.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -2135,22 +2135,22 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 ff a8 e2 2b | mango.banana...+[0m
 [33m[tester::#JW4] [0m[36m0070 | 91 7f d7 c8 a1                                  | .....[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1063862788 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1010970056 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$4\r\npear\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "pear",[0m
 [33m[tester::#JW4] [0m[36m  "mango",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "grape"[0m
+[33m[tester::#JW4] [0m[36m  "grape",[0m
+[33m[tester::#JW4] [0m[36m  "pear"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "pear",[0m
 [33m[tester::#JW4] [0m[92m  "mango",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "grape"[0m
+[33m[tester::#JW4] [0m[92m  "grape",[0m
+[33m[tester::#JW4] [0m[92m  "pear"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2162,13 +2162,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 04 70 | er.7.2.0.......p[0m
-[33m[tester::#GC6] [0m[36m0030 | 65 61 72 09 72 61 73 70 62 65 72 72 79 ff fe 60 | ear.raspberry..`[0m
-[33m[tester::#GC6] [0m[36m0040 | b6 dc f1 02 f9 e2                               | ......[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#GC6] [0m[36m0030 | 65 61 72 09 72 61 73 70 62 65 72 72 79 ff 14 45 | ear.raspberry..E[0m
+[33m[tester::#GC6] [0m[36m0040 | 28 f1 bd 21 24 0b                               | (..!$.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1945156866 --dbfilename mango.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles179399245 --dbfilename mango.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -2189,7 +2189,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 09 70 69 6e 65 61 70 | trawberry.pineap[0m
 [33m[tester::#JZ6] [0m[36m0040 | 70 6c 65 ff 6f 06 7d d6 39 72 31 77             | ple.o.}.9r1w[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles41341269 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3049096669 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$10\r\nstrawberry\r\n"[0m
@@ -2202,18 +2202,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1880030867 --dbfilename orange.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235 --dbfilename orange.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$75\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1880030867\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1880030867"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1880030867"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2227,15 +2227,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 13:16:45.949[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 13:16:45.949 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 16:43:31.911[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 16:43:31.911 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pineapple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[tester::#YZ1] [0m[92mReceived "mango"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 13:16:46.052 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 16:43:32.015 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pineapple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -774,9 +774,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751540302324-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751540302324-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751540302324-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751543027483-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751543027483-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751543027483-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -898,11 +898,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\x85\xab\xb4B\x1c\xbe\xe2"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc\xf7\"\x99\x05i\xfa\xb5"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -922,11 +922,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbfE\xfc\x9a_\xc0\xe4\xfe"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x037u\xb7\x18\xb5\xa0\xa9"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -946,11 +946,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xba\x97\x1f\x00\xc3\xf4\x8a^"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06\xe5\x96-\x84\x81\xce\t"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -970,11 +970,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3253d3e6356ab051dccabe3cdfcc355e886dc805 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Obfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3253d3e6356ab051dccabe3cdfcc355e886dc805\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffӂ+\xce{\xae\xe3;"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffo\xf0\xa2\xe3<ۧl"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1127,7 +1127,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2109 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1159,11 +1159,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\x14\xe2\x93ٔR\xc2"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xdf\xfd\x83RPy\xd1"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1183,11 +1183,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9dԵ\xbd\xc4H\b\xde"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98\x1f\xaa\xadO\x8c#\xcd"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1207,11 +1207,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98\x06V'X|f~"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\xcdI7ӸMm"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1231,11 +1231,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Qbfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf1\x13b\xe9\xe0&\x0f\x1b"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01-%\x9d\x90Sr\xd6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1255,11 +1255,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC e61c38e8626c75a4bbda085df952f44d6238fe0c 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Rbfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e61c38e8626c75a4bbda085df952f44d6238fe0c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\xf1\x96\xaa3\x1f<J"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd7B\xaf*\x1d\x9e\xe3\xce"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1581,11 +1581,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Sbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde_w\xf4Ԅ\xed\xe9"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~-\x06\xeb\xf1\xcd\xc8\xe4"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1605,11 +1605,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffs\xd6\xe16\x80\xb3\xf3D"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xceK5\xa5\xe3\xa3\xc5\x04"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1629,11 +1629,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC bb977b82f442bd01f522797bfac5f61e977effc7 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bb977b82f442bd01f522797bfac5f61e977effc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\vi\x95\xae\x11\x9d!"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]\x96\xbd\x06\xcd\x01\xaba"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1739,11 +1739,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC fa845bad3d5699a97c139d166dd0003a60511ffe 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fa845bad3d5699a97c139d166dd0003a60511ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff$\xac\xcf[\xbc\x13\xa5X"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c1a23a9166ef6f769238d8c7bd9941accbe2a2f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\xf8\xe7Is\x0e\x8e\xe0"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1805,11 +1805,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 8acb568d7a12e33b0435f6f4f781c3f142f2a346 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tbfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8acb568d7a12e33b0435f6f4f781c3f142f2a346\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x02\xf3\x10c\x06J\x1dT"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\x1c\xaeH\x04\x1cq\x8b"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1834,9 +1834,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC fb5bd2c94a35da312bb61addeb7a3cd7917e56e3 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1999,9 +1999,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d0b0af41cbd2f92f8ff8031b7d12ac61d543f165\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2025,9 +2025,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:82c34f899cdc359c8470c129e8a0915eb2acf504\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2057,7 +2057,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 8a c7 01 00 00 00 05 61 70 70 6c 65 05 6d 61 6e | .......apple.man[0m
 [33m[tester::#SM4] [0m[36m0090 | 67 6f ff f7 60 56 50 63 52 61 7a                | go..`VPcRaz[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles2358980242 --dbfilename grape.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles360805460 --dbfilename grape.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2096,7 +2096,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 74 72 61 77 62 65 72 72 79 04 70 65 61 72 ff 33 | trawberry.pear.3[0m
 [33m[tester::#DQ3] [0m[36m0070 | a8 09 ab 30 37 3e 50                            | ...07>P[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3590744088 --dbfilename mango.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1933302041 --dbfilename mango.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
@@ -2126,31 +2126,31 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 05 67 | er.7.2.0.......g[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 05 67 | s-bits.@.......g[0m
 [33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 00 04 70 65 61 72 09 | rape.pear..pear.[0m
 [33m[tester::#JW4] [0m[36m0040 | 72 61 73 70 62 65 72 72 79 00 09 62 6c 75 65 62 | raspberry..blueb[0m
 [33m[tester::#JW4] [0m[36m0050 | 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 00 05 | erry.blueberry..[0m
-[33m[tester::#JW4] [0m[36m0060 | 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 ff a8 e2 2b | mango.banana...+[0m
-[33m[tester::#JW4] [0m[36m0070 | 91 7f d7 c8 a1                                  | .....[0m
+[33m[tester::#JW4] [0m[36m0060 | 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 ff ca ff a9 | mango.banana....[0m
+[33m[tester::#JW4] [0m[36m0070 | 4c e9 69 09 12                                  | L.i..[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles1010970056 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2342692206 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#JW4] [0m[36m  "mango",[0m
 [33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [0m[36m  "pear"[0m
+[33m[tester::#JW4] [0m[36m  "pear",[0m
+[33m[tester::#JW4] [0m[36m  "grape"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
 [33m[tester::#JW4] [0m[92m  "mango",[0m
 [33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [0m[92m  "pear"[0m
+[33m[tester::#JW4] [0m[92m  "pear",[0m
+[33m[tester::#JW4] [0m[92m  "grape"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2168,7 +2168,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 65 61 72 09 72 61 73 70 62 65 72 72 79 ff 14 45 | ear.raspberry..E[0m
 [33m[tester::#GC6] [0m[36m0040 | 28 f1 bd 21 24 0b                               | (..!$.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles179399245 --dbfilename mango.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3202548307 --dbfilename mango.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
@@ -2183,13 +2183,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 0a 73 | s-bits.@.......s[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 0a 73 | er.7.2.0.......s[0m
 [33m[tester::#JZ6] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 09 70 69 6e 65 61 70 | trawberry.pineap[0m
-[33m[tester::#JZ6] [0m[36m0040 | 70 6c 65 ff 6f 06 7d d6 39 72 31 77             | ple.o.}.9r1w[0m
+[33m[tester::#JZ6] [0m[36m0040 | 70 6c 65 ff fa 28 ca 59 c3 49 35 9e             | ple..(.Y.I5.[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles3049096669 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles211464190 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$10\r\nstrawberry\r\n"[0m
@@ -2202,18 +2202,18 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235 --dbfilename orange.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072 --dbfilename orange.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$74\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/rdbfiles811361235"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2227,15 +2227,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 16:43:31.911[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 16:43:31.911 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:56.915[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 17:28:56.915 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pineapple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
 [33m[tester::#YZ1] [0m[92mReceived "mango"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 16:43:32.015 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 17:28:57.018 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET pineapple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -774,9 +774,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876504214-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876504214-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751876504214-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946710193-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946710193-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751946710193-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -898,11 +898,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0098\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf8\xac\x82\xa2\xf5;\x13>"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2֕lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7͏\x00\xe91\xe0H"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -922,11 +922,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0098\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffGlՌ\xe8\xe7I\""[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2֕lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88\r\xd8.\xf4\xed\xbaT"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -946,11 +946,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7Knr\x8fbq\\"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2וlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx*cГh\x82*"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -970,11 +970,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde^Z\xbc78\x189"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2וlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x11?W\x1e+2\xebO"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1127,7 +1127,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2094 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2108 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1159,11 +1159,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb9\x00\xa16\x97c\xfc\xd6"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16Y(TLt\xaaK"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1183,11 +1183,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06\xc0\xf6\x18\x8a\xbf\xa6\xca"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9\x99\x7fzQ\xa8\xf0W"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1207,11 +1207,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\x12\x15\x82\x16\x8b\xc8j"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xacK\x9c\xe0͜\x9e\xf7"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1231,11 +1231,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffj\a!L\xaeѡ\x0f"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5^\xa8.u\xc6\xf7\x92"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1255,11 +1255,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbch\xab\xfb#\x1c0\x17"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x131\"\x99\xf8\vf\x8a"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1581,11 +1581,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009d\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw}\x8e\xde\xee\x13\t\x84"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ەlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc$\f\xe0\xa8]yf"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1605,11 +1605,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009d\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc7\x1b\xbd\x90\xfc}\x04d"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ەlh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\fB?\xae\xba3t\x86"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1629,11 +1629,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff KKǌ+\xc8H"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82p\x12\x81\xd2\xc8\t\xae"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1739,11 +1739,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e70a713769423b8c4d11915662dfa9af7208de79\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc9/\xf2\xacc\xd8\xd0h"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83\xf2}\xa0k\b@3"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1805,11 +1805,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e534d6386dc9b60fbb59a6ecbff034d46d84a8f9\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xa8\xba[\x9b\x96\xa8\xca"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(762cbb51f0e34b6b0b2787bd82e4c506ae84113a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw4M\x0f\aP\x1ca"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1834,9 +1834,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1999,9 +1999,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2025,9 +2025,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2058,7 +2058,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0090 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 72 61 | (.......apple.ra[0m
 [33m[tester::#SM4] [0m[36m00a0 | 73 70 62 65 72 72 79 ff 10 f6 99 42 96 77 a1 8d | spberry....B.w..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8213092160634621402 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
@@ -2102,7 +2102,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
 [33m[tester::#DQ3] [0m[36m0070 | ff 97 22 dd 30 46 ee 83 03                      | ..".0F...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3109004153974137912 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET strawberry[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
@@ -2141,22 +2141,22 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 79 00 05 6d 61 6e 67 6f 05 67 72 61 70 65 ff ba | y..mango.grape..[0m
 [33m[tester::#JW4] [0m[36m0070 | fb 6e db 72 08 1e 1b                            | .n.r...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-800552107268830371 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3062 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n$6\r\norange\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [0m[36m  "mango",[0m
+[33m[tester::#JW4] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [0m[36m  "strawberry",[0m
-[33m[tester::#JW4] [0m[36m  "banana"[0m
+[33m[tester::#JW4] [0m[36m  "mango",[0m
+[33m[tester::#JW4] [0m[36m  "orange"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [0m[92m  "mango",[0m
+[33m[tester::#JW4] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [0m[92m  "strawberry",[0m
-[33m[tester::#JW4] [0m[92m  "banana"[0m
+[33m[tester::#JW4] [0m[92m  "mango",[0m
+[33m[tester::#JW4] [0m[92m  "orange"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2174,7 +2174,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 ff df 76 69 ad | rape.orange..vi.[0m
 [33m[tester::#GC6] [0m[36m0040 | c7 19 1a 7f                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-4510245391833696574 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3337 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
 [33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
@@ -2195,7 +2195,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 65 61 72 09 70 69 6e 65 61 70 70 6c 65 ff a1 e2 | ear.pineapple...[0m
 [33m[tester::#JZ6] [0m[36m0040 | 16 a7 2d 81 76 2a                               | ..-.v*[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-5218263486714055450 --dbfilename grape.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1646 --dbfilename grape.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
@@ -2208,19 +2208,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-7768033789438484985 --dbfilename apple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6307 --dbfilename apple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-7768033789438484985\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-7768033789438484985"[0m
-[33m[tester::#ZG5] [0m[36m][0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-6307\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-6307"][0m
 [33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived [[0m
-[33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-7768033789438484985"[0m
-[33m[tester::#ZG5] [0m[92m][0m
+[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-6307"][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
@@ -2233,15 +2227,15 @@ Debug = true
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:53.790[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:53.790 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:59.774[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:59.774 (should not be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:53.894 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:59.877 (should be expired)[0m
 [33m[tester::#YZ1] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -774,9 +774,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751543027483-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751543027483-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751543027483-0"[0m
+[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751876504214-0\r\n"[0m
+[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751876504214-0"[0m
+[33m[tester::#XU6] [0m[92mReceived "1751876504214-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -898,11 +898,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc\xf7\"\x99\x05i\xfa\xb5"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0098\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf8\xac\x82\xa2\xf5;\x13>"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -922,11 +922,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x037u\xb7\x18\xb5\xa0\xa9"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0098\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffGlՌ\xe8\xe7I\""[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -946,11 +946,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06\xe5\x96-\x84\x81\xce\t"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7Knr\x8fbq\\"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -970,11 +970,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e48b70ff2ae77629848785b13d7677a8a9a1a3e7 0"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
+[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e4bc7d380511a2225753588bda960665ac5b9976 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e48b70ff2ae77629848785b13d7677a8a9a1a3e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffo\xf0\xa2\xe3<ۧl"[0m
+[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0099\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e4bc7d380511a2225753588bda960665ac5b9976\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde^Z\xbc78\x189"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1127,7 +1127,7 @@ Debug = true
 [33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2094 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1159,11 +1159,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xdf\xfd\x83RPy\xd1"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb9\x00\xa16\x97c\xfc\xd6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1183,11 +1183,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x98\x1f\xaa\xadO\x8c#\xcd"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06\xc0\xf6\x18\x8a\xbf\xa6\xca"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1207,11 +1207,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf6lfh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9d\xcdI7ӸMm"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\x12\x15\x82\x16\x8b\xc8j"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
@@ -1231,11 +1231,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7lfh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01-%\x9d\x90Sr\xd6"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffj\a!L\xaeѡ\x0f"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
@@ -1255,11 +1255,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 1800bf1b8203aef30364fca47c988a3a7a0bfdde 0"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
+[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC ad83a1c573555213943dd5b61770af06a4e073bd 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7lfh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1800bf1b8203aef30364fca47c988a3a7a0bfdde\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd7B\xaf*\x1d\x9e\xe3\xce"[0m
+[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009b\x83kh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ad83a1c573555213943dd5b61770af06a4e073bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbch\xab\xfb#\x1c0\x17"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1581,11 +1581,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~-\x06\xeb\xf1\xcd\xc8\xe4"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009d\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw}\x8e\xde\xee\x13\t\x84"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
@@ -1605,11 +1605,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xceK5\xa5\xe3\xa3\xc5\x04"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009d\x83kh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc7\x1b\xbd\x90\xfc}\x04d"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
@@ -1629,11 +1629,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ba5a6a008e5eb293d13272b0a75e3e668ca86ac8 0"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
+[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ba5a6a008e5eb293d13272b0a75e3e668ca86ac8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]\x96\xbd\x06\xcd\x01\xaba"[0m
+[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbb8f6450e5c8dba10fea7e903e3ad0ff4257d1f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff KKǌ+\xc8H"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1739,11 +1739,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC c1a23a9166ef6f769238d8c7bd9941accbe2a2f5 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0"[0m
+[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC e70a713769423b8c4d11915662dfa9af7208de79 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c1a23a9166ef6f769238d8c7bd9941accbe2a2f5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\xf8\xe7Is\x0e\x8e\xe0"[0m
+[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e70a713769423b8c4d11915662dfa9af7208de79\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc9/\xf2\xacc\xd8\xd0h"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1805,11 +1805,11 @@ Debug = true
 [33m[tester::#CF8] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc 0"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0\r\n"[0m
+[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0"[0m
+[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC e534d6386dc9b60fbb59a6ecbff034d46d84a8f9 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9lfh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(47d58e47ba8583bbd2e0a0f35c825b8fdbbfe5fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\x1c\xaeH\x04\x1cq\x8b"[0m
+[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\x83kh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e534d6386dc9b60fbb59a6ecbff034d46d84a8f9\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xa8\xba[\x9b\x96\xa8\xca"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1834,9 +1834,9 @@ Debug = true
 [33m[tester::#VM3] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
 [33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC bd6fe9859305c107b7c1c6ea45398a5630be90a1 0"[0m
+[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0\r\n"[0m
+[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0"[0m
+[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC cd1d3c01a06c807edaa39d275890dfe5a2839b22 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1999,9 +1999,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cab41a1eb2f489bdc45882640e655c58dc492e27\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a106eaccea3a8c538e5c79166bbd003b01a86496\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2025,9 +2025,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
 [33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fabe62d8b80d4a5a3cf5552215b2b2c0f876c877\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84330b3466ff9f5e1602493c8a75c14c2f47a0a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2042,115 +2042,121 @@ Debug = true
 [33m[tester::#BW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SM4] [0m[94mRunning tests for Stage #SM4 (sm4)[0m
-[33m[tester::#SM4] [0m[94mCreated RDB file with 4 key-value pairs: {"pineapple": "pineapple", "raspberry": "banana", "orange": "pear", "apple": "mango"}[0m
+[33m[tester::#SM4] [0m[94mCreated RDB file with 5 key-value pairs: {"pear": "grape", "strawberry": "pineapple", "orange": "apple", "grape": "pear", "apple": "raspberry"}[0m
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 9c | s-bits.@........[0m
-[33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 09 70 69 6e 65 61 70 70 6c | ..~.....pineappl[0m
-[33m[tester::#SM4] [0m[36m0040 | 65 09 70 69 6e 65 61 70 70 6c 65 fc 00 0c 28 8a | e.pineapple...(.[0m
-[33m[tester::#SM4] [0m[36m0050 | c7 01 00 00 00 09 72 61 73 70 62 65 72 72 79 06 | ......raspberry.[0m
-[33m[tester::#SM4] [0m[36m0060 | 62 61 6e 61 6e 61 fc 00 0c 28 8a c7 01 00 00 00 | banana...(......[0m
-[33m[tester::#SM4] [0m[36m0070 | 06 6f 72 61 6e 67 65 04 70 65 61 72 fc 00 0c 28 | .orange.pear...([0m
-[33m[tester::#SM4] [0m[36m0080 | 8a c7 01 00 00 00 05 61 70 70 6c 65 05 6d 61 6e | .......apple.man[0m
-[33m[tester::#SM4] [0m[36m0090 | 67 6f ff f7 60 56 50 63 52 61 7a                | go..`VPcRaz[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 05 fc 00 9c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 04 70 65 61 72 05 67 72 61 | ..~.....pear.gra[0m
+[33m[tester::#SM4] [0m[36m0040 | 70 65 fc 00 0c 28 8a c7 01 00 00 00 0a 73 74 72 | pe...(.......str[0m
+[33m[tester::#SM4] [0m[36m0050 | 61 77 62 65 72 72 79 09 70 69 6e 65 61 70 70 6c | awberry.pineappl[0m
+[33m[tester::#SM4] [0m[36m0060 | 65 fc 00 0c 28 8a c7 01 00 00 00 06 6f 72 61 6e | e...(.......oran[0m
+[33m[tester::#SM4] [0m[36m0070 | 67 65 05 61 70 70 6c 65 fc 00 0c 28 8a c7 01 00 | ge.apple...(....[0m
+[33m[tester::#SM4] [0m[36m0080 | 00 00 05 67 72 61 70 65 04 70 65 61 72 fc 00 0c | ...grape.pear...[0m
+[33m[tester::#SM4] [0m[36m0090 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 72 61 | (.......apple.ra[0m
+[33m[tester::#SM4] [0m[36m00a0 | 73 70 62 65 72 72 79 ff 10 f6 99 42 96 77 a1 8d | spberry....B.w..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles360805460 --dbfilename grape.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-8213092160634621402 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#SM4] [0m[92mReceived "banana"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET strawberry[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
+[33m[tester::#SM4] [0m[92mReceived "pineapple"[0m
 [33m[tester::#SM4] [0m[94mclient: > GET orange[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [0m[92mReceived "apple"[0m
+[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
+[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pear"[0m
 [33m[tester::#SM4] [0m[92mReceived "pear"[0m
 [33m[tester::#SM4] [0m[94mclient: > GET apple[0m
 [33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#SM4] [0m[92mReceived "mango"[0m
+[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#DQ3] [0m[94mRunning tests for Stage #DQ3 (dq3)[0m
-[33m[tester::#DQ3] [0m[94mCreated RDB file with 4 key-value pairs: {"pineapple": "pineapple", "pear": "orange", "mango": "banana", "strawberry": "pear"}[0m
+[33m[tester::#DQ3] [0m[94mCreated RDB file with 4 key-value pairs: {"strawberry": "mango", "mango": "raspberry", "banana": "grape", "apple": "strawberry"}[0m
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 09 70 | s-bits.@.......p[0m
-[33m[tester::#DQ3] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 70 69 6e 65 61 70 70 | ineapple.pineapp[0m
-[33m[tester::#DQ3] [0m[36m0040 | 6c 65 00 04 70 65 61 72 06 6f 72 61 6e 67 65 00 | le..pear.orange.[0m
-[33m[tester::#DQ3] [0m[36m0050 | 05 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 00 0a 73 | .mango.banana..s[0m
-[33m[tester::#DQ3] [0m[36m0060 | 74 72 61 77 62 65 72 72 79 04 70 65 61 72 ff 33 | trawberry.pear.3[0m
-[33m[tester::#DQ3] [0m[36m0070 | a8 09 ab 30 37 3e 50                            | ...07>P[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 0a 73 | s-bits.@.......s[0m
+[33m[tester::#DQ3] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 05 6d 61 6e 67 6f 00 | trawberry.mango.[0m
+[33m[tester::#DQ3] [0m[36m0040 | 05 6d 61 6e 67 6f 09 72 61 73 70 62 65 72 72 79 | .mango.raspberry[0m
+[33m[tester::#DQ3] [0m[36m0050 | 00 06 62 61 6e 61 6e 61 05 67 72 61 70 65 00 05 | ..banana.grape..[0m
+[33m[tester::#DQ3] [0m[36m0060 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
+[33m[tester::#DQ3] [0m[36m0070 | ff 97 22 dd 30 46 ee 83 03                      | ..".0F...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles1933302041 --dbfilename mango.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pineapple"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#DQ3] [0m[92mReceived "orange"[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-3109004153974137912 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET strawberry[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
+[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
 [33m[tester::#DQ3] [0m[94mclient: > GET mango[0m
 [33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#DQ3] [0m[92mReceived "banana"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET strawberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pear"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "raspberry"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET banana[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
+[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
+[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
+[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JW4] [0m[94mRunning tests for Stage #JW4 (jw4)[0m
-[33m[tester::#JW4] [0m[94mCreated RDB file with 4 keys: ["grape", "pear", "blueberry", "mango"][0m
+[33m[tester::#JW4] [0m[94mCreated RDB file with 4 keys: ["strawberry", "orange", "banana", "mango"][0m
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 00 04 70 65 61 72 09 | rape.pear..pear.[0m
-[33m[tester::#JW4] [0m[36m0040 | 72 61 73 70 62 65 72 72 79 00 09 62 6c 75 65 62 | raspberry..blueb[0m
-[33m[tester::#JW4] [0m[36m0050 | 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 00 05 | erry.blueberry..[0m
-[33m[tester::#JW4] [0m[36m0060 | 6d 61 6e 67 6f 06 62 61 6e 61 6e 61 ff ca ff a9 | mango.banana....[0m
-[33m[tester::#JW4] [0m[36m0070 | 4c e9 69 09 12                                  | L.i..[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 0a 73 | s-bits.@.......s[0m
+[33m[tester::#JW4] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 06 6f 72 61 6e 67 65 | trawberry.orange[0m
+[33m[tester::#JW4] [0m[36m0040 | 00 06 6f 72 61 6e 67 65 06 62 61 6e 61 6e 61 00 | ..orange.banana.[0m
+[33m[tester::#JW4] [0m[36m0050 | 06 62 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 | .banana.raspberr[0m
+[33m[tester::#JW4] [0m[36m0060 | 79 00 05 6d 61 6e 67 6f 05 67 72 61 70 65 ff ba | y..mango.grape..[0m
+[33m[tester::#JW4] [0m[36m0070 | fb 6e db 72 08 1e 1b                            | .n.r...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles2342692206 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-800552107268830371 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
+[33m[tester::#JW4] [0m[36m  "orange",[0m
 [33m[tester::#JW4] [0m[36m  "mango",[0m
-[33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "pear",[0m
-[33m[tester::#JW4] [0m[36m  "grape"[0m
+[33m[tester::#JW4] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [0m[36m  "banana"[0m
 [33m[tester::#JW4] [0m[36m][0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[92mReceived [[0m
+[33m[tester::#JW4] [0m[92m  "orange",[0m
 [33m[tester::#JW4] [0m[92m  "mango",[0m
-[33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "pear",[0m
-[33m[tester::#JW4] [0m[92m  "grape"[0m
+[33m[tester::#JW4] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [0m[92m  "banana"[0m
 [33m[tester::#JW4] [0m[92m][0m
 [33m[tester::#JW4] [0m[92m[0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2158,62 +2164,62 @@ Debug = true
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GC6] [0m[94mRunning tests for Stage #GC6 (gc6)[0m
-[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"pear": "raspberry"}[0m
+[33m[tester::#GC6] [0m[94mCreated RDB file with a single key-value pair: {"grape": "orange"}[0m
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
 [33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
-[33m[tester::#GC6] [0m[36m0030 | 65 61 72 09 72 61 73 70 62 65 72 72 79 ff 14 45 | ear.raspberry..E[0m
-[33m[tester::#GC6] [0m[36m0040 | 28 f1 bd 21 24 0b                               | (..!$.[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 ff df 76 69 ad | rape.orange..vi.[0m
+[33m[tester::#GC6] [0m[36m0040 | c7 19 1a 7f                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles3202548307 --dbfilename mango.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#GC6] [0m[92mReceived "raspberry"[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-4510245391833696574 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
+[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "orange"[0m
+[33m[tester::#GC6] [0m[92mReceived "orange"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JZ6] [0m[94mRunning tests for Stage #JZ6 (jz6)[0m
-[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["strawberry"][0m
+[33m[tester::#JZ6] [0m[94mCreated RDB file with a single key: ["pear"][0m
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 0a 73 | er.7.2.0.......s[0m
-[33m[tester::#JZ6] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 09 70 69 6e 65 61 70 | trawberry.pineap[0m
-[33m[tester::#JZ6] [0m[36m0040 | 70 6c 65 ff fa 28 ca 59 c3 49 35 9e             | ple..(.Y.I5.[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 09 70 69 6e 65 61 70 70 6c 65 ff a1 e2 | ear.pineapple...[0m
+[33m[tester::#JZ6] [0m[36m0040 | 16 a7 2d 81 76 2a                               | ..-.v*[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles211464190 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-5218263486714055450 --dbfilename grape.rdb[0m
 [33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["strawberry"][0m
+[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
+[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["pear"][0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["strawberry"][0m
+[33m[tester::#JZ6] [0m[92mReceived ["pear"][0m
 [33m[tester::#JZ6] [0m[92m[0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072 --dbfilename orange.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdbfiles-7768033789438484985 --dbfilename apple.rdb[0m
 [33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$89\r\n/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072\r\n"[0m
+[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$41\r\n/private/tmp/rdbfiles-7768033789438484985\r\n"[0m
 [33m[tester::#ZG5] [0m[36mclient: Received RESP array: [[0m
 [33m[tester::#ZG5] [0m[36m  "dir",[0m
-[33m[tester::#ZG5] [0m[36m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072"[0m
+[33m[tester::#ZG5] [0m[36m  "/private/tmp/rdbfiles-7768033789438484985"[0m
 [33m[tester::#ZG5] [0m[36m][0m
 [33m[tester::#ZG5] [0m[36m[0m
 [33m[tester::#ZG5] [0m[92mReceived [[0m
 [33m[tester::#ZG5] [0m[92m  "dir",[0m
-[33m[tester::#ZG5] [0m[92m  "/private/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/codecrafters-rdbfiles-2050404072"[0m
+[33m[tester::#ZG5] [0m[92m  "/private/tmp/rdbfiles-7768033789438484985"[0m
 [33m[tester::#ZG5] [0m[92m][0m
 [33m[tester::#ZG5] [0m[92m[0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
@@ -2222,22 +2228,22 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET pineapple mango px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [0m[94m$ redis-cli SET apple grape px 100[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 17:28:56.915[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 17:28:56.915 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET pineapple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "mango"[0m
-[33m[tester::#YZ1] [0m[92mReceived "mango"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 14:06:53.790[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:53.790 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#YZ1] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "pineapple" at 17:28:57.018 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET pineapple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:06:53.894 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
@@ -2247,29 +2253,29 @@ Debug = true
 
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LA7] [0m[36mSetting key apple to pear[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET apple pear[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LA7] [0m[36mSetting key pear to pineapple[0m
+[33m[tester::#LA7] [0m[94m$ redis-cli SET pear pineapple[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#LA7] [0m[92mReceived "OK"[0m
-[33m[tester::#LA7] [0m[36mGetting key apple[0m
-[33m[tester::#LA7] [0m[94m> GET apple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[tester::#LA7] [0m[92mReceived "pear"[0m
+[33m[tester::#LA7] [0m[36mGetting key pear[0m
+[33m[tester::#LA7] [0m[94m> GET pear[0m
+[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO banana[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "banana"[0m
-[33m[tester::#QQ0] [0m[92mReceived "banana"[0m
+[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO blueberry[0m
+[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#QQ0] [0m[92mReceived "blueberry"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m

--- a/internal/test_list_llen.go
+++ b/internal/test_list_llen.go
@@ -25,19 +25,19 @@ func testListLlen(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 	listSize := testerutils_random.RandomInt(4, 8)
-	randomList := testerutils_random.RandomWords(listSize)
+	elements := testerutils_random.RandomWords(listSize)
 	missingKey := fmt.Sprintf("missing_key_%d", testerutils_random.RandomInt(1, 100))
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomKey}, randomList...),
+				Command:   append([]string{"RPUSH", listKey}, elements...),
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			{
-				Command:   []string{"LLEN", randomKey},
+				Command:   []string{"LLEN", listKey},
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			{

--- a/internal/test_list_lpop1.go
+++ b/internal/test_list_lpop1.go
@@ -25,22 +25,22 @@ func testListLpop1(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 	listSize := testerutils_random.RandomInt(4, 8)
 	elements := testerutils_random.RandomWords(listSize)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, elements...),
+				Command:   append([]string{"RPUSH", listKey}, elements...),
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			{
-				Command:   []string{"LPOP", randomListKey},
+				Command:   []string{"LPOP", listKey},
 				Assertion: resp_assertions.NewStringAssertion(elements[0]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(0), strconv.Itoa(-1)},
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(0), strconv.Itoa(-1)},
 				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[1:]),
 			},
 		},

--- a/internal/test_list_lpop2.go
+++ b/internal/test_list_lpop2.go
@@ -25,7 +25,7 @@ func testListLpop2(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 	listSize := testerutils_random.RandomInt(5, 9)
 	elements := testerutils_random.RandomWords(listSize)
 	toRemoveCount := testerutils_random.RandomInt(2, 5)
@@ -33,15 +33,15 @@ func testListLpop2(stageHarness *test_case_harness.TestCaseHarness) error {
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, elements...),
+				Command:   append([]string{"RPUSH", listKey}, elements...),
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			{
-				Command:   []string{"LPOP", randomListKey, strconv.Itoa(toRemoveCount)},
+				Command:   []string{"LPOP", listKey, strconv.Itoa(toRemoveCount)},
 				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0:toRemoveCount]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(0), strconv.Itoa(-1)},
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(0), strconv.Itoa(-1)},
 				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[toRemoveCount:]),
 			},
 		},

--- a/internal/test_list_lpush.go
+++ b/internal/test_list_lpush.go
@@ -25,22 +25,22 @@ func testListLpush(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
-	randomValues := testerutils_random.RandomWords(3)
+	listKey := testerutils_random.RandomWord()
+	elements := testerutils_random.RandomWords(3)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"LPUSH", randomListKey, randomValues[2]},
+				Command:   []string{"LPUSH", listKey, elements[2]},
 				Assertion: resp_assertions.NewIntegerAssertion(1),
 			},
 			{
-				Command:   []string{"LPUSH", randomListKey, randomValues[1], randomValues[0]},
+				Command:   []string{"LPUSH", listKey, elements[1], elements[0]},
 				Assertion: resp_assertions.NewIntegerAssertion(3),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(0), strconv.Itoa(-1)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomValues),
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(0), strconv.Itoa(-1)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements),
 			},
 		},
 	}

--- a/internal/test_list_lrange_neg_index.go
+++ b/internal/test_list_lrange_neg_index.go
@@ -25,9 +25,9 @@ func testListLrangeNegIndex(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 	listSize := testerutils_random.RandomInt(4, 8)
-	randomElements := testerutils_random.RandomWords(listSize)
+	elements := testerutils_random.RandomWords(listSize)
 
 	startIndex := -listSize
 	endIndex := -1
@@ -38,31 +38,31 @@ func testListLrangeNegIndex(stageHarness *test_case_harness.TestCaseHarness) err
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, randomElements...),
+				Command:   append([]string{"RPUSH", listKey}, elements...),
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			// usual test cases
 			{
-				Command:   []string{"LRANGE", randomListKey, "0", strconv.Itoa(middleIndex)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomElements[0 : middleIndexTranslated+1]),
+				Command:   []string{"LRANGE", listKey, "0", strconv.Itoa(middleIndex)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0 : middleIndexTranslated+1]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(middleIndex), strconv.Itoa(endIndex)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomElements[middleIndexTranslated:listSize]),
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(middleIndex), strconv.Itoa(endIndex)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[middleIndexTranslated:listSize]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, "0", strconv.Itoa(endIndex)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomElements[0:listSize]),
+				Command:   []string{"LRANGE", listKey, "0", strconv.Itoa(endIndex)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0:listSize]),
 			},
 			// start index > end index
 			{
-				Command:   []string{"LRANGE", randomListKey, "-1", "-2"},
+				Command:   []string{"LRANGE", listKey, "-1", "-2"},
 				Assertion: resp_assertions.NewOrderedStringArrayAssertion([]string{}),
 			},
 			// end index out of bounds
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(startIndex - 1), strconv.Itoa(endIndex)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomElements[0:listSize]),
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(startIndex - 1), strconv.Itoa(endIndex)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0:listSize]),
 			},
 		},
 	}

--- a/internal/test_list_lrange_pos_index.go
+++ b/internal/test_list_lrange_pos_index.go
@@ -26,40 +26,40 @@ func testListLrangePosIdx(stageHarness *test_case_harness.TestCaseHarness) error
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 	listSize := testerutils_random.RandomInt(4, 8)
-	randomList := testerutils_random.RandomWords(listSize)
+	elements := testerutils_random.RandomWords(listSize)
 	middleIndex := testerutils_random.RandomInt(1, listSize-1)
 	missingKey := fmt.Sprintf("missing_key_%d", testerutils_random.RandomInt(1, 100))
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, randomList...),
+				Command:   append([]string{"RPUSH", listKey}, elements...),
 				Assertion: resp_assertions.NewIntegerAssertion(listSize),
 			},
 			// usual test cases
 			{
-				Command:   []string{"LRANGE", randomListKey, "0", strconv.Itoa(middleIndex)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomList[0 : middleIndex+1]),
+				Command:   []string{"LRANGE", listKey, "0", strconv.Itoa(middleIndex)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0 : middleIndex+1]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, strconv.Itoa(middleIndex), strconv.Itoa(listSize - 1)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomList[middleIndex:listSize]),
+				Command:   []string{"LRANGE", listKey, strconv.Itoa(middleIndex), strconv.Itoa(listSize - 1)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[middleIndex:listSize]),
 			},
 			{
-				Command:   []string{"LRANGE", randomListKey, "0", strconv.Itoa(listSize - 1)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomList[0:listSize]),
+				Command:   []string{"LRANGE", listKey, "0", strconv.Itoa(listSize - 1)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0:listSize]),
 			},
 			// start index > end index
 			{
-				Command:   []string{"LRANGE", randomListKey, "1", "0"},
+				Command:   []string{"LRANGE", listKey, "1", "0"},
 				Assertion: resp_assertions.NewOrderedStringArrayAssertion([]string{}),
 			},
 			// end index out of bounds
 			{
-				Command:   []string{"LRANGE", randomListKey, "0", strconv.Itoa(listSize * 2)},
-				Assertion: resp_assertions.NewOrderedStringArrayAssertion(randomList[0:listSize]),
+				Command:   []string{"LRANGE", listKey, "0", strconv.Itoa(listSize * 2)},
+				Assertion: resp_assertions.NewOrderedStringArrayAssertion(elements[0:listSize]),
 			},
 			// key doesn't exist
 			{

--- a/internal/test_list_rpush2.go
+++ b/internal/test_list_rpush2.go
@@ -23,21 +23,21 @@ func testListRpush2(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
-	randomElements := testerutils_random.RandomWords(3)
+	listKey := testerutils_random.RandomWord()
+	elements := testerutils_random.RandomWords(3)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"RPUSH", randomListKey, randomElements[0]},
+				Command:   []string{"RPUSH", listKey, elements[0]},
 				Assertion: resp_assertions.NewIntegerAssertion(1),
 			},
 			{
-				Command:   []string{"RPUSH", randomListKey, randomElements[1]},
+				Command:   []string{"RPUSH", listKey, elements[1]},
 				Assertion: resp_assertions.NewIntegerAssertion(2),
 			},
 			{
-				Command:   []string{"RPUSH", randomListKey, randomElements[2]},
+				Command:   []string{"RPUSH", listKey, elements[2]},
 				Assertion: resp_assertions.NewIntegerAssertion(3),
 			},
 		},

--- a/internal/test_list_rpush3.go
+++ b/internal/test_list_rpush3.go
@@ -23,7 +23,7 @@ func testListRpush3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomListKey := testerutils_random.RandomWord()
+	listKey := testerutils_random.RandomWord()
 
 	elementsForFirstCmd := testerutils_random.RandomWords(2)
 	elementsForSecondCmd := testerutils_random.RandomWords(3)
@@ -31,11 +31,11 @@ func testListRpush3(stageHarness *test_case_harness.TestCaseHarness) error {
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, elementsForFirstCmd...),
+				Command:   append([]string{"RPUSH", listKey}, elementsForFirstCmd...),
 				Assertion: resp_assertions.NewIntegerAssertion(2),
 			},
 			{
-				Command:   append([]string{"RPUSH", randomListKey}, elementsForSecondCmd...),
+				Command:   append([]string{"RPUSH", listKey}, elementsForSecondCmd...),
 				Assertion: resp_assertions.NewIntegerAssertion(5),
 			},
 		},

--- a/internal/test_rdb_config.go
+++ b/internal/test_rdb_config.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
@@ -15,18 +14,12 @@ import (
 )
 
 func testRdbConfig(stageHarness *test_case_harness.TestCaseHarness) error {
-	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles-")
+	tmpDir, err := MkdirTemp("rdbfiles")
 	if err != nil {
 		return err
 	}
 
 	// On MacOS, the tmpDir is a symlink to a directory in /var/folders/...
-	realPath, err := filepath.EvalSymlinks(tmpDir)
-	if err != nil {
-		return fmt.Errorf("CodeCrafters tester error: could not resolve symlink: %v", err)
-	}
-	tmpDir = realPath
-
 	b := redis_executable.NewRedisExecutable(stageHarness)
 	stageHarness.RegisterTeardownFunc(func() { os.RemoveAll(tmpDir) })
 	if err := b.Run("--dir", tmpDir,

--- a/internal/test_rdb_config.go
+++ b/internal/test_rdb_config.go
@@ -15,7 +15,7 @@ import (
 )
 
 func testRdbConfig(stageHarness *test_case_harness.TestCaseHarness) error {
-	tmpDir, err := os.MkdirTemp("", "rdbfiles")
+	tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles-")
 	if err != nil {
 		return err
 	}

--- a/internal/test_rdb_config.go
+++ b/internal/test_rdb_config.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testRdbConfig(stageHarness *test_case_harness.TestCaseHarness) error {
-	tmpDir, err := MkdirTemp("rdbfiles")
+	tmpDir, err := MkdirTemp("rdb")
 	if err != nil {
 		return err
 	}

--- a/internal/test_rdb_read_key.go
+++ b/internal/test_rdb_read_key.go
@@ -18,15 +18,15 @@ func testRdbReadKey(stageHarness *test_case_harness.TestCaseHarness) error {
 		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
 	}
 
-	randomKeyAndValue := testerutils_random.RandomWords(2)
-	randomKey, randomValue := randomKeyAndValue[0], randomKeyAndValue[1]
+	keyAndValue := testerutils_random.RandomWords(2)
+	key, value := keyAndValue[0], keyAndValue[1]
 
-	if err := RDBFileCreator.Write([]KeyValuePair{{key: randomKey, value: randomValue}}); err != nil {
+	if err := RDBFileCreator.Write([]KeyValuePair{{key: key, value: value}}); err != nil {
 		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
 	}
 
 	logger := stageHarness.Logger
-	logger.Infof("Created RDB file with a single key: [%q]", randomKey)
+	logger.Infof("Created RDB file with a single key: [%q]", key)
 	if err := RDBFileCreator.PrintContentHexdump(logger); err != nil {
 		return fmt.Errorf("CodeCrafters Tester Error: %s", err)
 	}
@@ -47,7 +47,7 @@ func testRdbReadKey(stageHarness *test_case_harness.TestCaseHarness) error {
 	commandTestCase := test_cases.SendCommandTestCase{
 		Command:                   "KEYS",
 		Args:                      []string{"*"},
-		Assertion:                 resp_assertions.NewCommandAssertion(randomKey),
+		Assertion:                 resp_assertions.NewCommandAssertion(key),
 		ShouldSkipUnreadDataCheck: false,
 	}
 

--- a/internal/test_repl_id.go
+++ b/internal/test_repl_id.go
@@ -40,7 +40,7 @@ func testReplReplicationID(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	responseValue := commandTestCase.ReceivedResponse
+	responseValue := commandTestCase.GetReceivedResponse()
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_repl_id.go
+++ b/internal/test_repl_id.go
@@ -40,7 +40,7 @@ func testReplReplicationID(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	responseValue := commandTestCase.GetReceivedResponse()
+	responseValue := commandTestCase.ReceivedResponse
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_repl_info.go
+++ b/internal/test_repl_info.go
@@ -38,7 +38,7 @@ func testReplInfo(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	responseValue := commandTestCase.GetReceivedResponse()
+	responseValue := commandTestCase.ReceivedResponse
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_repl_info.go
+++ b/internal/test_repl_info.go
@@ -38,7 +38,7 @@ func testReplInfo(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	responseValue := commandTestCase.ReceivedResponse
+	responseValue := commandTestCase.GetReceivedResponse()
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_repl_info_replica.go
+++ b/internal/test_repl_info_replica.go
@@ -74,7 +74,7 @@ func testReplInfoReplica(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	responseValue := commandTestCase.ReceivedResponse
+	responseValue := commandTestCase.GetReceivedResponse()
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_repl_info_replica.go
+++ b/internal/test_repl_info_replica.go
@@ -74,7 +74,7 @@ func testReplInfoReplica(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	responseValue := commandTestCase.GetReceivedResponse()
+	responseValue := commandTestCase.ReceivedResponse
 
 	if responseValue.Type != resp_value.BULK_STRING && responseValue.Type != resp_value.SIMPLE_STRING {
 		return fmt.Errorf("Expected simple string or bulk string, got %s", responseValue.Type)

--- a/internal/test_streams_type.go
+++ b/internal/test_streams_type.go
@@ -27,21 +27,21 @@ func testStreamsType(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
-	randomValue := random.RandomWord()
+	key := random.RandomWord()
+	value := random.RandomWord()
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"SET", randomKey, randomValue},
+				Command:   []string{"SET", key, value},
 				Assertion: resp_assertions.NewStringAssertion("OK"),
 			},
 			{
-				Command:   []string{"TYPE", randomKey},
+				Command:   []string{"TYPE", key},
 				Assertion: resp_assertions.NewStringAssertion("string"),
 			},
 			{
-				Command:   []string{"TYPE", fmt.Sprintf("missing_key_%s", randomValue)},
+				Command:   []string{"TYPE", fmt.Sprintf("missing_key_%s", value)},
 				Assertion: resp_assertions.NewStringAssertion("none"),
 			},
 		},

--- a/internal/test_streams_xadd.go
+++ b/internal/test_streams_xadd.go
@@ -25,16 +25,16 @@ func testStreamsXadd(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
+	streamKey := random.RandomWord()
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"XADD", randomKey, "0-1", "foo", "bar"},
+				Command:   []string{"XADD", streamKey, "0-1", "foo", "bar"},
 				Assertion: resp_assertions.NewStringAssertion("0-1"),
 			},
 			{
-				Command:   []string{"TYPE", randomKey},
+				Command:   []string{"TYPE", streamKey},
 				Assertion: resp_assertions.NewStringAssertion("stream"),
 			},
 		},

--- a/internal/test_streams_xadd_full_autoid.go
+++ b/internal/test_streams_xadd_full_autoid.go
@@ -44,7 +44,7 @@ func testStreamsXaddFullAutoid(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	responseValue := commandTestCase.GetReceivedResponse()
+	responseValue := commandTestCase.ReceivedResponse
 
 	if responseValue.Type != resp_value.BULK_STRING {
 		return fmt.Errorf("Expected bulk string, got %s", responseValue.Type)

--- a/internal/test_streams_xadd_full_autoid.go
+++ b/internal/test_streams_xadd_full_autoid.go
@@ -31,11 +31,11 @@ func testStreamsXaddFullAutoid(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
+	streamKey := random.RandomWord()
 
 	commandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "*", "foo", "bar"},
+		Args:                      []string{streamKey, "*", "foo", "bar"},
 		Assertion:                 resp_assertions.NewNoopAssertion(),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -44,7 +44,7 @@ func testStreamsXaddFullAutoid(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	responseValue := commandTestCase.ReceivedResponse
+	responseValue := commandTestCase.GetReceivedResponse()
 
 	if responseValue.Type != resp_value.BULK_STRING {
 		return fmt.Errorf("Expected bulk string, got %s", responseValue.Type)

--- a/internal/test_streams_xadd_partial_autoid.go
+++ b/internal/test_streams_xadd_partial_autoid.go
@@ -24,21 +24,21 @@ func testStreamsXaddPartialAutoid(stageHarness *test_case_harness.TestCaseHarnes
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
-	randomValues := random.RandomWords(3)
+	streamKey := random.RandomWord()
+	entryKeyAndValues := random.RandomWords(3)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"XADD", randomKey, "0-*", randomValues[0], randomValues[1]},
+				Command:   []string{"XADD", streamKey, "0-*", entryKeyAndValues[0], entryKeyAndValues[1]},
 				Assertion: resp_assertions.NewStringAssertion("0-1"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "1-*", randomValues[0], randomValues[1]},
+				Command:   []string{"XADD", streamKey, "1-*", entryKeyAndValues[0], entryKeyAndValues[1]},
 				Assertion: resp_assertions.NewStringAssertion("1-0"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "1-*", randomValues[1], randomValues[2]},
+				Command:   []string{"XADD", streamKey, "1-*", entryKeyAndValues[1], entryKeyAndValues[2]},
 				Assertion: resp_assertions.NewStringAssertion("1-1"),
 			},
 		},

--- a/internal/test_streams_xadd_validate_id.go
+++ b/internal/test_streams_xadd_validate_id.go
@@ -24,29 +24,29 @@ func testStreamsXaddValidateID(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
-	randomValues := random.RandomWords(10)
+	streamKey := random.RandomWord()
+	entryKeyAndValues := random.RandomWords(10)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"XADD", randomKey, "1-1", randomValues[0], randomValues[1]},
+				Command:   []string{"XADD", streamKey, "1-1", entryKeyAndValues[0], entryKeyAndValues[1]},
 				Assertion: resp_assertions.NewStringAssertion("1-1"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "1-2", randomValues[2], randomValues[3]},
+				Command:   []string{"XADD", streamKey, "1-2", entryKeyAndValues[2], entryKeyAndValues[3]},
 				Assertion: resp_assertions.NewStringAssertion("1-2"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "1-2", randomValues[4], randomValues[5]},
+				Command:   []string{"XADD", streamKey, "1-2", entryKeyAndValues[4], entryKeyAndValues[5]},
 				Assertion: resp_assertions.NewErrorAssertion("ERR The ID specified in XADD is equal or smaller than the target stream top item"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "0-3", randomValues[6], randomValues[7]},
+				Command:   []string{"XADD", streamKey, "0-3", entryKeyAndValues[6], entryKeyAndValues[7]},
 				Assertion: resp_assertions.NewErrorAssertion("ERR The ID specified in XADD is equal or smaller than the target stream top item"),
 			},
 			{
-				Command:   []string{"XADD", randomKey, "0-0", randomValues[8], randomValues[9]},
+				Command:   []string{"XADD", streamKey, "0-0", entryKeyAndValues[8], entryKeyAndValues[9]},
 				Assertion: resp_assertions.NewErrorAssertion("ERR The ID specified in XADD must be greater than 0-0"),
 			},
 		},

--- a/internal/test_streams_xrange.go
+++ b/internal/test_streams_xrange.go
@@ -25,7 +25,7 @@ func testStreamsXrange(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomStreamKey := testerutils_random.RandomWord()
+	streamKey := testerutils_random.RandomWord()
 
 	entryCount := testerutils_random.RandomInt(3, 5)
 	var entryIDs []string
@@ -33,15 +33,15 @@ func testStreamsXrange(stageHarness *test_case_harness.TestCaseHarness) error {
 		entryIDs = append(entryIDs, fmt.Sprintf("0-%d", i+1))
 	}
 
-	randomPairs := make([][]string, entryCount)
+	entryKeysAndValues := make([][]string, entryCount)
 	for i := range entryCount {
-		randomPairs[i] = testerutils_random.RandomWords(2)
+		entryKeysAndValues[i] = testerutils_random.RandomWords(2)
 	}
 
 	commandWithAssertions := []test_cases.CommandWithAssertion{}
 	for i := range entryCount {
 		commandWithAssertions = append(commandWithAssertions, test_cases.CommandWithAssertion{
-			Command:   []string{"XADD", randomStreamKey, entryIDs[i], randomPairs[i][0], randomPairs[i][1]},
+			Command:   []string{"XADD", streamKey, entryIDs[i], entryKeysAndValues[i][0], entryKeysAndValues[i][1]},
 			Assertion: resp_assertions.NewStringAssertion(entryIDs[i]),
 		})
 	}
@@ -59,13 +59,13 @@ func testStreamsXrange(stageHarness *test_case_harness.TestCaseHarness) error {
 	for i := startKey - 1; i < entryCount; i++ {
 		expectedStreamEntries = append(expectedStreamEntries, resp_assertions.StreamEntry{
 			Id:              entryIDs[i],
-			FieldValuePairs: [][]string{randomPairs[i]},
+			FieldValuePairs: [][]string{entryKeysAndValues[i]},
 		})
 	}
 
 	xrangeTestCase := test_cases.SendCommandTestCase{
 		Command:                   "XRANGE",
-		Args:                      []string{randomStreamKey, fmt.Sprintf("0-%d", startKey), fmt.Sprintf("0-%d", entryCount)},
+		Args:                      []string{streamKey, fmt.Sprintf("0-%d", startKey), fmt.Sprintf("0-%d", entryCount)},
 		Assertion:                 resp_assertions.NewXRangeResponseAssertion(expectedStreamEntries),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_streams_xrange_max_id.go
+++ b/internal/test_streams_xrange_max_id.go
@@ -26,7 +26,7 @@ func testStreamsXrangeMaxID(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 	defer client.Close()
 
-	randomStreamKey := testerutils_random.RandomWord()
+	streamKey := testerutils_random.RandomWord()
 
 	entryCount := testerutils_random.RandomInt(3, 5)
 	var entryIDs []string
@@ -34,15 +34,15 @@ func testStreamsXrangeMaxID(stageHarness *test_case_harness.TestCaseHarness) err
 		entryIDs = append(entryIDs, fmt.Sprintf("0-%d", i+1))
 	}
 
-	randomPairs := make([][]string, entryCount)
+	entryKeysAndValues := make([][]string, entryCount)
 	for i := range entryCount {
-		randomPairs[i] = testerutils_random.RandomWords(2)
+		entryKeysAndValues[i] = testerutils_random.RandomWords(2)
 	}
 
 	commandWithAssertions := []test_cases.CommandWithAssertion{}
 	for i := range entryCount {
 		commandWithAssertions = append(commandWithAssertions, test_cases.CommandWithAssertion{
-			Command:   []string{"XADD", randomStreamKey, entryIDs[i], randomPairs[i][0], randomPairs[i][1]},
+			Command:   []string{"XADD", streamKey, entryIDs[i], entryKeysAndValues[i][0], entryKeysAndValues[i][1]},
 			Assertion: resp_assertions.NewStringAssertion(entryIDs[i]),
 		})
 	}
@@ -62,13 +62,13 @@ func testStreamsXrangeMaxID(stageHarness *test_case_harness.TestCaseHarness) err
 	for i := startkey; i <= entryCount; i++ {
 		expectedStreamEntries = append(expectedStreamEntries, resp_assertions.StreamEntry{
 			Id:              entryIDs[i-1],
-			FieldValuePairs: [][]string{randomPairs[i-1]},
+			FieldValuePairs: [][]string{entryKeysAndValues[i-1]},
 		})
 	}
 
 	xrangeTestCase := test_cases.SendCommandTestCase{
 		Command:                   "XRANGE",
-		Args:                      []string{randomStreamKey, fmt.Sprintf("0-%d", startkey), "+"},
+		Args:                      []string{streamKey, fmt.Sprintf("0-%d", startkey), "+"},
 		Assertion:                 resp_assertions.NewXRangeResponseAssertion(expectedStreamEntries),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_streams_xrange_min_id.go
+++ b/internal/test_streams_xrange_min_id.go
@@ -26,7 +26,7 @@ func testStreamsXrangeMinID(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 	defer client.Close()
 
-	randomStreamKey := testerutils_random.RandomWord()
+	streamKey := testerutils_random.RandomWord()
 
 	entryCount := testerutils_random.RandomInt(3, 5)
 	var entryIDs []string
@@ -34,15 +34,15 @@ func testStreamsXrangeMinID(stageHarness *test_case_harness.TestCaseHarness) err
 		entryIDs = append(entryIDs, fmt.Sprintf("0-%d", i+1))
 	}
 
-	randomPairs := make([][]string, entryCount)
+	entryKeysAndValues := make([][]string, entryCount)
 	for i := range entryCount {
-		randomPairs[i] = testerutils_random.RandomWords(2)
+		entryKeysAndValues[i] = testerutils_random.RandomWords(2)
 	}
 
 	commandWithAssertions := []test_cases.CommandWithAssertion{}
 	for i := range entryCount {
 		commandWithAssertions = append(commandWithAssertions, test_cases.CommandWithAssertion{
-			Command:   []string{"XADD", randomStreamKey, entryIDs[i], randomPairs[i][0], randomPairs[i][1]},
+			Command:   []string{"XADD", streamKey, entryIDs[i], entryKeysAndValues[i][0], entryKeysAndValues[i][1]},
 			Assertion: resp_assertions.NewStringAssertion(entryIDs[i]),
 		})
 	}
@@ -61,13 +61,13 @@ func testStreamsXrangeMinID(stageHarness *test_case_harness.TestCaseHarness) err
 	for i := 1; i <= endKey; i++ {
 		expectedStreamEntries = append(expectedStreamEntries, resp_assertions.StreamEntry{
 			Id:              entryIDs[i-1],
-			FieldValuePairs: [][]string{randomPairs[i-1]},
+			FieldValuePairs: [][]string{entryKeysAndValues[i-1]},
 		})
 	}
 
 	xrangeTestCase := test_cases.SendCommandTestCase{
 		Command:                   "XRANGE",
-		Args:                      []string{randomStreamKey, "-", fmt.Sprintf("0-%d", endKey)},
+		Args:                      []string{streamKey, "-", fmt.Sprintf("0-%d", endKey)},
 		Assertion:                 resp_assertions.NewXRangeResponseAssertion(expectedStreamEntries),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_streams_xread.go
+++ b/internal/test_streams_xread.go
@@ -25,25 +25,25 @@ func testStreamsXread(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	randomKey := testerutils_random.RandomWord()
+	streamKey := testerutils_random.RandomWord()
 	entryID := "0-1"
-	randomInt := strconv.Itoa(testerutils_random.RandomInt(1, 100))
+	entryValue := strconv.Itoa(testerutils_random.RandomInt(1, 100))
 	temperature := "temperature"
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"XADD", randomKey, entryID, temperature, randomInt},
+				Command:   []string{"XADD", streamKey, entryID, temperature, entryValue},
 				Assertion: resp_assertions.NewStringAssertion(entryID),
 			},
 			{
-				Command: []string{"XREAD", "streams", randomKey, "0-0"},
+				Command: []string{"XREAD", "streams", streamKey, "0-0"},
 				Assertion: resp_assertions.NewXReadResponseAssertion([]resp_assertions.StreamResponse{
 					{
-						Key: randomKey,
+						Key: streamKey,
 						Entries: []resp_assertions.StreamEntry{{
 							Id:              entryID,
-							FieldValuePairs: [][]string{{temperature, randomInt}},
+							FieldValuePairs: [][]string{{temperature, entryValue}},
 						}},
 					},
 				}),

--- a/internal/test_streams_xread_block.go
+++ b/internal/test_streams_xread_block.go
@@ -27,12 +27,12 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 	}
 	defer client1.Close()
 
-	randomKey := testerutils_random.RandomWord()
-	randomInt := testerutils_random.RandomInt(1, 100)
+	streamKey := testerutils_random.RandomWord()
+	entryValue := testerutils_random.RandomInt(1, 100)
 
 	xaddCommandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-1", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-1", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-1"),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -42,19 +42,19 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 	}
 
 	xReadResult := make(chan error, 1)
-	randomInt = testerutils_random.RandomInt(1, 100)
+	entryValue = testerutils_random.RandomInt(1, 100)
 
 	xreadAssertion := resp_assertions.NewXReadResponseAssertion([]resp_assertions.StreamResponse{{
-		Key: randomKey,
+		Key: streamKey,
 		Entries: []resp_assertions.StreamEntry{{
 			Id:              "0-2",
-			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(randomInt)}},
+			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(entryValue)}},
 		}},
 	}})
 
 	xReadTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XREAD",
-		Args:                      []string{"block", "1000", "streams", randomKey, "0-1"},
+		Args:                      []string{"block", "1000", "streams", streamKey, "0-1"},
 		Assertion:                 xreadAssertion,
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -78,7 +78,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 	// from another client, send xadd
 	xaddCommandTestCase = &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-2", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-2", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-2"),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -96,7 +96,7 @@ func testStreamsXreadBlock(stageHarness *test_case_harness.TestCaseHarness) erro
 
 	xreadCommandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XREAD",
-		Args:                      []string{"block", "1000", "streams", randomKey, "0-2"},
+		Args:                      []string{"block", "1000", "streams", streamKey, "0-2"},
 		Assertion:                 resp_assertions.NewNilAssertion(),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_streams_xread_block_max_id.go
+++ b/internal/test_streams_xread_block_max_id.go
@@ -28,12 +28,12 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 	}
 	defer client1.Close()
 
-	randomKey := testerutils_random.RandomWord()
-	randomInt := testerutils_random.RandomInt(1, 100)
+	streamKey := testerutils_random.RandomWord()
+	entryValue := testerutils_random.RandomInt(1, 100)
 
 	xaddCommandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-1", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-1", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-1"),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -43,18 +43,18 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	xReadResult := make(chan error, 1)
-	randomInt = testerutils_random.RandomInt(1, 100)
+	entryValue = testerutils_random.RandomInt(1, 100)
 
 	xReadAssertion := resp_assertions.NewXReadResponseAssertion([]resp_assertions.StreamResponse{{
-		Key: randomKey,
+		Key: streamKey,
 		Entries: []resp_assertions.StreamEntry{{
 			Id:              "0-2",
-			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(randomInt)}},
+			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(entryValue)}},
 		}},
 	}})
 	xReadTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XREAD",
-		Args:                      []string{"block", "0", "streams", randomKey, "$"},
+		Args:                      []string{"block", "0", "streams", streamKey, "$"},
 		Assertion:                 xReadAssertion,
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -76,7 +76,7 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 
 	xaddCommandTestCase = &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-2", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-2", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-2"),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -94,7 +94,7 @@ func testStreamsXreadBlockMaxID(stageHarness *test_case_harness.TestCaseHarness)
 
 	xreadCommandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XREAD",
-		Args:                      []string{"block", "1000", "streams", randomKey, "$"},
+		Args:                      []string{"block", "1000", "streams", streamKey, "$"},
 		Assertion:                 resp_assertions.NewNilAssertion(),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_streams_xread_block_no_timeout.go
+++ b/internal/test_streams_xread_block_no_timeout.go
@@ -26,12 +26,12 @@ func testStreamsXreadBlockNoTimeout(stageHarness *test_case_harness.TestCaseHarn
 	}
 	defer client1.Close()
 
-	randomKey := testerutils_random.RandomWord()
-	randomInt := testerutils_random.RandomInt(1, 100)
+	streamKey := testerutils_random.RandomWord()
+	entryValue := testerutils_random.RandomInt(1, 100)
 
 	xaddCommandTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-1", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-1", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-1"),
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -41,17 +41,17 @@ func testStreamsXreadBlockNoTimeout(stageHarness *test_case_harness.TestCaseHarn
 	}
 
 	xreadResult := make(chan error, 1)
-	randomInt = testerutils_random.RandomInt(1, 100)
+	entryValue = testerutils_random.RandomInt(1, 100)
 	xreadAssertion := resp_assertions.NewXReadResponseAssertion([]resp_assertions.StreamResponse{{
-		Key: randomKey,
+		Key: streamKey,
 		Entries: []resp_assertions.StreamEntry{{
 			Id:              "0-2",
-			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(randomInt)}},
+			FieldValuePairs: [][]string{{"temperature", strconv.Itoa(entryValue)}},
 		}},
 	}})
 	xReadTestCase := &test_cases.SendCommandTestCase{
 		Command:                   "XREAD",
-		Args:                      []string{"block", "0", "streams", randomKey, "0-1"},
+		Args:                      []string{"block", "0", "streams", streamKey, "0-1"},
 		Assertion:                 xreadAssertion,
 		ShouldSkipUnreadDataCheck: true,
 	}
@@ -72,7 +72,7 @@ func testStreamsXreadBlockNoTimeout(stageHarness *test_case_harness.TestCaseHarn
 
 	xaddCommandTestCase = &test_cases.SendCommandTestCase{
 		Command:                   "XADD",
-		Args:                      []string{randomKey, "0-2", "temperature", strconv.Itoa(randomInt)},
+		Args:                      []string{streamKey, "0-2", "temperature", strconv.Itoa(entryValue)},
 		Assertion:                 resp_assertions.NewStringAssertion("0-2"),
 		ShouldSkipUnreadDataCheck: false,
 	}

--- a/internal/test_txn_discard.go
+++ b/internal/test_txn_discard.go
@@ -29,11 +29,11 @@ func testTxDiscard(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	uniqueKeys := random.RandomWords(2)
 	key1, key2 := uniqueKeys[0], uniqueKeys[1]
-	randomInt1, randomInt2 := random.RandomInt(1, 100), random.RandomInt(1, 100)
+	value1, value2 := random.RandomInt(1, 100), random.RandomInt(1, 100)
 
 	commandTestCase := test_cases.SendCommandTestCase{
 		Command:   "SET",
-		Args:      []string{key2, fmt.Sprint(randomInt2)},
+		Args:      []string{key2, fmt.Sprint(value2)},
 		Assertion: resp_assertions.NewStringAssertion("OK"),
 	}
 
@@ -43,7 +43,7 @@ func testTxDiscard(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	transactionTestCase := test_cases.TransactionTestCase{
 		CommandQueue: [][]string{
-			{"SET", key1, fmt.Sprint(randomInt1)},
+			{"SET", key1, fmt.Sprint(value1)},
 			{"INCR", key1},
 		},
 	}
@@ -64,7 +64,7 @@ func testTxDiscard(stageHarness *test_case_harness.TestCaseHarness) error {
 			},
 			{
 				Command:   []string{"GET", key2},
-				Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(randomInt2)),
+				Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(value2)),
 			},
 			{
 				Command:   []string{"DISCARD"},

--- a/internal/test_txn_incr1.go
+++ b/internal/test_txn_incr1.go
@@ -27,18 +27,18 @@ func testTxIncr1(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomValue := random.RandomInt(1, 100)
-	randomKey := random.RandomWord()
+	value := random.RandomInt(1, 100)
+	key := random.RandomWord()
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"SET", randomKey, fmt.Sprint(randomValue)},
+				Command:   []string{"SET", key, fmt.Sprint(value)},
 				Assertion: resp_assertions.NewStringAssertion("OK"),
 			},
 			{
-				Command:   []string{"INCR", randomKey},
-				Assertion: resp_assertions.NewIntegerAssertion(randomValue + 1),
+				Command:   []string{"INCR", key},
+				Assertion: resp_assertions.NewIntegerAssertion(value + 1),
 			},
 		},
 	}

--- a/internal/test_txn_incr2.go
+++ b/internal/test_txn_incr2.go
@@ -25,20 +25,20 @@ func testTxIncr2(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	randomKey := random.RandomWord()
+	key := random.RandomWord()
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"INCR", randomKey},
+				Command:   []string{"INCR", key},
 				Assertion: resp_assertions.NewIntegerAssertion(1),
 			},
 			{
-				Command:   []string{"INCR", randomKey},
+				Command:   []string{"INCR", key},
 				Assertion: resp_assertions.NewIntegerAssertion(2),
 			},
 			{
-				Command:   []string{"GET", randomKey},
+				Command:   []string{"GET", key},
 				Assertion: resp_assertions.NewStringAssertion("2"),
 			},
 		},

--- a/internal/test_txn_incr3.go
+++ b/internal/test_txn_incr3.go
@@ -25,17 +25,17 @@ func testTxIncr3(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	uniqueKeys := random.RandomWords(2)
-	randomKey, randomValue := uniqueKeys[0], uniqueKeys[1]
+	keyAndValue := random.RandomWords(2)
+	key, value := keyAndValue[0], keyAndValue[1]
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"SET", randomKey, randomValue},
+				Command:   []string{"SET", key, value},
 				Assertion: resp_assertions.NewStringAssertion("OK"),
 			},
 			{
-				Command:   []string{"INCR", randomKey},
+				Command:   []string{"INCR", key},
 				Assertion: resp_assertions.NewErrorAssertion("ERR value is not an integer or out of range"),
 			},
 		},

--- a/internal/test_txn_multi_tx.go
+++ b/internal/test_txn_multi_tx.go
@@ -29,13 +29,13 @@ func testTxMultiTx(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	uniqueKeys := random.RandomWords(2)
 	key1, key2 := uniqueKeys[0], uniqueKeys[1]
-	randomIntegerValue := random.RandomInt(1, 100)
+	value := random.RandomInt(1, 100)
 
 	for i, client := range clients {
 		multiCommandTestCase := test_cases.MultiCommandTestCase{
 			CommandWithAssertions: []test_cases.CommandWithAssertion{
 				{
-					Command:   []string{"SET", key2, fmt.Sprint(randomIntegerValue)},
+					Command:   []string{"SET", key2, fmt.Sprint(value)},
 					Assertion: resp_assertions.NewStringAssertion("OK"),
 				},
 				{
@@ -69,7 +69,7 @@ func testTxMultiTx(stageHarness *test_case_harness.TestCaseHarness) error {
 			// Inside each transaction, we run 1x INCR key1, key2
 			// So it increases by 1 for each transaction
 			// `i` here is 0-indexed, so we add 1 to the expected value
-			ExpectedResponseArray: []resp_assertions.RESPAssertion{resp_assertions.NewIntegerAssertion(3 + (1 + i)), resp_assertions.NewIntegerAssertion(randomIntegerValue + (1 + i))},
+			ExpectedResponseArray: []resp_assertions.RESPAssertion{resp_assertions.NewIntegerAssertion(3 + (1 + i)), resp_assertions.NewIntegerAssertion(value + (1 + i))},
 		}
 		if err := transactionTestCase.RunExec(client, logger); err != nil {
 			return err

--- a/internal/test_txn_queue.go
+++ b/internal/test_txn_queue.go
@@ -28,11 +28,11 @@ func testTxQueue(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	key := random.RandomWord()
-	randomIntegerValue := random.RandomInt(1, 100)
+	value := random.RandomInt(1, 100)
 
 	transactionTestCase := test_cases.TransactionTestCase{
 		CommandQueue: [][]string{
-			{"SET", key, fmt.Sprint(randomIntegerValue)},
+			{"SET", key, fmt.Sprint(value)},
 			{"INCR", key},
 		},
 	}

--- a/internal/test_txn_tx.go
+++ b/internal/test_txn_tx.go
@@ -29,16 +29,16 @@ func testTxSuccess(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	uniqueKeys := random.RandomWords(2)
 	key1, key2 := uniqueKeys[0], uniqueKeys[1]
-	randomIntegerValue := random.RandomInt(1, 100)
+	value := random.RandomInt(1, 100)
 
 	transactionTestCase := test_cases.TransactionTestCase{
 		CommandQueue: [][]string{
-			{"SET", key1, fmt.Sprint(randomIntegerValue)},
+			{"SET", key1, fmt.Sprint(value)},
 			{"INCR", key1},
 			{"INCR", key2},
 			{"GET", key2},
 		},
-		ExpectedResponseArray: []resp_assertions.RESPAssertion{resp_assertions.NewStringAssertion("OK"), resp_assertions.NewIntegerAssertion(randomIntegerValue + 1), resp_assertions.NewIntegerAssertion(1), resp_assertions.NewStringAssertion("1")},
+		ExpectedResponseArray: []resp_assertions.RESPAssertion{resp_assertions.NewStringAssertion("OK"), resp_assertions.NewIntegerAssertion(value + 1), resp_assertions.NewIntegerAssertion(1), resp_assertions.NewStringAssertion("1")},
 	}
 
 	if err := transactionTestCase.RunAll(clients[0], logger); err != nil {
@@ -48,7 +48,7 @@ func testTxSuccess(stageHarness *test_case_harness.TestCaseHarness) error {
 	commandTestCase := test_cases.SendCommandTestCase{
 		Command:   "GET",
 		Args:      []string{key1},
-		Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(randomIntegerValue + 1)),
+		Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(value + 1)),
 	}
 
 	return commandTestCase.Run(clients[1], logger)

--- a/internal/test_txn_tx_failure.go
+++ b/internal/test_txn_tx_failure.go
@@ -29,17 +29,17 @@ func testTxErr(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	uniqueKeys := random.RandomWords(3)
 	key1, key2 := uniqueKeys[0], uniqueKeys[1]
-	randomStringValue := uniqueKeys[2]
-	randomIntegerValue := random.RandomInt(1, 100)
+	value1 := uniqueKeys[2]
+	value2 := random.RandomInt(1, 100)
 
 	multiCommandTestCase := test_cases.MultiCommandTestCase{
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
-				Command:   []string{"SET", key1, randomStringValue},
+				Command:   []string{"SET", key1, value1},
 				Assertion: resp_assertions.NewStringAssertion("OK"),
 			},
 			{
-				Command:   []string{"SET", key2, fmt.Sprint(randomIntegerValue)},
+				Command:   []string{"SET", key2, fmt.Sprint(value2)},
 				Assertion: resp_assertions.NewStringAssertion("OK"),
 			},
 		},
@@ -56,7 +56,7 @@ func testTxErr(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 		ExpectedResponseArray: []resp_assertions.RESPAssertion{
 			resp_assertions.NewErrorAssertion("ERR value is not an integer or out of range"),
-			resp_assertions.NewIntegerAssertion(randomIntegerValue + 1),
+			resp_assertions.NewIntegerAssertion(value2 + 1),
 		},
 	}
 
@@ -68,11 +68,11 @@ func testTxErr(stageHarness *test_case_harness.TestCaseHarness) error {
 		CommandWithAssertions: []test_cases.CommandWithAssertion{
 			{
 				Command:   []string{"GET", key2},
-				Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(randomIntegerValue + 1)),
+				Assertion: resp_assertions.NewStringAssertion(fmt.Sprint(value2 + 1)),
 			},
 			{
 				Command:   []string{"GET", key1},
-				Assertion: resp_assertions.NewStringAssertion(randomStringValue),
+				Assertion: resp_assertions.NewStringAssertion(value1),
 			},
 		},
 	}

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,8 +160,8 @@ func FormatKeyValuePairs(keys []string, values []string) string {
 
 // MkdirTemp keeps fixtures consistent across macOS and Linux
 func MkdirTemp(prefix string) (string, error) {
-	// ensure the length of tmpDir is long enough to be printed on multiple lines
-	randomInt := testerutils_random.RandomInt(1000000, math.MaxInt)
+	// ensure the length of tmpDir is short enough to be printed on a single line
+	randomInt := testerutils_random.RandomInt(0, 10000)
 	tmpDir := filepath.Join("/tmp", fmt.Sprintf("%s-%d", prefix, randomInt))
 
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,13 +2,16 @@ package internal
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	resp_connection "github.com/codecrafters-io/redis-tester/internal/resp/connection"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/logger"
+	testerutils_random "github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 
 	resp_value "github.com/codecrafters-io/redis-tester/internal/resp/value"
@@ -154,4 +157,24 @@ func FormatKeyValuePairs(keys []string, values []string) string {
 	}
 
 	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
+}
+
+// MkdirTemp keeps fixtures consistent across macOS and Linux
+func MkdirTemp(prefix string) (string, error) {
+	// ensure the length of tmpDir is long enough to be printed on multiple lines
+	randomInt := testerutils_random.RandomInt(1000000, math.MaxInt)
+	tmpDir := filepath.Join("/tmp", fmt.Sprintf("%s-%d", prefix, randomInt))
+
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return "", err
+	}
+
+	// /tmp is a symlink in MacOS
+	realPath, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("CodeCrafters tester error: could not resolve symlink: %v", err)
+	}
+	tmpDir = realPath
+
+	return tmpDir, nil
 }


### PR DESCRIPTION
- Removed usage of `random` in variable names
- Re-used `ReceiveValueTestCase` inside `SendCommandTestCase`
- Updated the usage of `MkdirTemp` and updated fixtures (Reason below)


- Github Tests were failing randomly because of the following reason:

We are currently using the pretty library with options of width = 32, which means while printing, if the line is longer than 32 characters, it will split the json into separate line. I have experimented with different widths, and the logs looks readable at this width

In RDB test case ZG5, the `dir` parameter is a temporary directory, which is sth like `/var/folders/sn/8vpsm6lx6m53blpdh2yhlzw40000gn/T/`, which is pretty long compared to `/tmp/` in Linux. In case of MacOS, the length of temp directory is long, which automatically makes the array `["dir", "<temp_dir_name>"]` longer than pretty's width option, so it is splitted into different lines when printed.

However, in case of linux, whether or not that array will be longer than Pretty's width is random. `MkdirTemp` depends on this function:

```go
func nextRandom() string {
	return itoa.Uitoa(uint(uint32(runtime_rand())))
}
```

Due to this, the tests were randomly failing. For eg. you can see that the test passes for this PR #186 , but when it is merged, the tests fail. You can see this in the [repo homepage](https://github.com/codecrafters-io/redis-tester)

<img width="754" alt="Screenshot 2025-07-03 at 17 57 04" src="https://github.com/user-attachments/assets/215559d1-8a5d-493e-9f83-489ebd6b9378" />

So, I have changed the usage of `MkdirTemp` from

```
tmpDir, err := os.MkdirTemp("", "rdbfiles")
```

to

```
tmpDir, err := os.MkdirTemp("", "codecrafters-rdbfiles-")
```

This will cause the length of smallest possible length such array to be 39.

```python
>>> len('["dir", "/tmp/codecrafters-rdbfiles-0"]')
39
```
This will cause the array in that test case to be printed into separate lines, and will become consistent with the fixtures in macos.
