### PR TITLE
Update: Logger Improvements, Test Cases Update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.3
+	github.com/codecrafters-io/tester-utils v0.4.4
 	github.com/hdt3213/rdb v1.1.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/pretty v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
-github.com/codecrafters-io/tester-utils v0.4.3 h1:ZUA0BCvLK4LJ+yRYrA6nc1s5LymElYkv2JP7rpufhcc=
-github.com/codecrafters-io/tester-utils v0.4.3/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.4 h1:4xhJ2tgaIIIejPihB0dkiY2XfaQQHgqpNMDVfMP7FUM=
+github.com/codecrafters-io/tester-utils v0.4.4/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/resp/connection/connection.go
+++ b/internal/resp/connection/connection.go
@@ -77,11 +77,12 @@ func NewRespConnectionFromAddr(addr string, connIdentifier string, callbacks Res
 	}, nil
 }
 
-func NewRespConnectionFromConn(conn net.Conn, callbacks RespConnectionCallbacks) (*RespConnection, error) {
+func NewRespConnectionFromConn(conn net.Conn, callbacks RespConnectionCallbacks, connID string) (*RespConnection, error) {
 	return &RespConnection{
 		Conn:         conn,
 		UnreadBuffer: bytes.Buffer{},
 		Callbacks:    callbacks,
+		identifier:   connID,
 	}, nil
 }
 

--- a/internal/resp/connection/connection.go
+++ b/internal/resp/connection/connection.go
@@ -152,8 +152,12 @@ func (c *RespConnection) ReadFullResyncRDBFile() ([]byte, error) {
 
 	value, readBytesCount, err := resp_decoder.DecodeFullResyncRDBFile(c.UnreadBuffer.Bytes())
 
-	if c.Callbacks.AfterBytesReceived != nil && readBytesCount > 0 {
-		c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes()[:readBytesCount])
+	if c.Callbacks.AfterBytesReceived != nil {
+		if _, ok := err.(resp_decoder.InvalidRESPError); ok {
+			c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes())
+		} else if readBytesCount > 0 {
+			c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes()[:readBytesCount])
+		}
 	}
 
 	if err != nil {
@@ -206,8 +210,12 @@ func (c *RespConnection) ReadValueWithTimeout(timeout time.Duration) (resp_value
 
 	value, readBytesCount, err := resp_decoder.Decode(c.UnreadBuffer.Bytes())
 
-	if c.Callbacks.AfterBytesReceived != nil && readBytesCount > 0 {
-		c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes()[:readBytesCount])
+	if c.Callbacks.AfterBytesReceived != nil {
+		if _, ok := err.(resp_decoder.InvalidRESPError); ok {
+			c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes())
+		} else if readBytesCount > 0 {
+			c.Callbacks.AfterBytesReceived(c.UnreadBuffer.Bytes()[:readBytesCount])
+		}
 	}
 
 	if err != nil {

--- a/internal/resp/decoder/decode.go
+++ b/internal/resp/decoder/decode.go
@@ -13,9 +13,6 @@ func Decode(data []byte) (value resp_value.Value, readBytesCount int, err error)
 
 	value, err = doDecodeValue(reader)
 	if err != nil {
-		if _, ok := err.(InvalidRESPError); ok {
-			return resp_value.Value{}, len(data), err
-		}
 		return resp_value.Value{}, 0, err
 	}
 

--- a/internal/resp/decoder/decode.go
+++ b/internal/resp/decoder/decode.go
@@ -13,7 +13,10 @@ func Decode(data []byte) (value resp_value.Value, readBytesCount int, err error)
 
 	value, err = doDecodeValue(reader)
 	if err != nil {
-		return resp_value.Value{}, len(data), err
+		if _, ok := err.(InvalidRESPError); ok {
+			return resp_value.Value{}, len(data), err
+		}
+		return resp_value.Value{}, 0, err
 	}
 
 	return value, len(data) - reader.Len(), nil
@@ -42,7 +45,7 @@ func doDecodeValue(reader *bytes.Reader) (resp_value.Value, error) {
 	default:
 		reader.UnreadByte() // Ensure the error points to the correct byte
 
-		return resp_value.Value{}, InvalidInputError{
+		return resp_value.Value{}, InvalidRESPError{
 			Reader:  reader,
 			Message: fmt.Sprintf("%q is not a valid start of a RESP2 value (expected +, -, :, $ or *)", string(firstByte)),
 		}

--- a/internal/resp/decoder/decode.go
+++ b/internal/resp/decoder/decode.go
@@ -13,7 +13,7 @@ func Decode(data []byte) (value resp_value.Value, readBytesCount int, err error)
 
 	value, err = doDecodeValue(reader)
 	if err != nil {
-		return resp_value.Value{}, 0, err
+		return resp_value.Value{}, len(data), err
 	}
 
 	return value, len(data) - reader.Len(), nil

--- a/internal/resp/decoder/decode_full_resync_rdb_file.go
+++ b/internal/resp/decoder/decode_full_resync_rdb_file.go
@@ -12,7 +12,7 @@ func DecodeFullResyncRDBFile(data []byte) (rdbFileContents []byte, readBytesCoun
 
 	rdbFileContents, err = doDecodeFullResyncRDBFile(reader)
 	if err != nil {
-		return nil, 0, err
+		return nil, len(data), err
 	}
 
 	return rdbFileContents, len(data) - reader.Len(), nil

--- a/internal/resp/decoder/decode_full_resync_rdb_file.go
+++ b/internal/resp/decoder/decode_full_resync_rdb_file.go
@@ -12,9 +12,6 @@ func DecodeFullResyncRDBFile(data []byte) (rdbFileContents []byte, readBytesCoun
 
 	rdbFileContents, err = doDecodeFullResyncRDBFile(reader)
 	if err != nil {
-		if _, ok := err.(InvalidRESPError); ok {
-			return nil, len(data), err
-		}
 		return nil, 0, err
 	}
 

--- a/internal/resp/decoder/decode_full_resync_rdb_file.go
+++ b/internal/resp/decoder/decode_full_resync_rdb_file.go
@@ -12,7 +12,10 @@ func DecodeFullResyncRDBFile(data []byte) (rdbFileContents []byte, readBytesCoun
 
 	rdbFileContents, err = doDecodeFullResyncRDBFile(reader)
 	if err != nil {
-		return nil, len(data), err
+		if _, ok := err.(InvalidRESPError); ok {
+			return nil, len(data), err
+		}
+		return nil, 0, err
 	}
 
 	return rdbFileContents, len(data) - reader.Len(), nil
@@ -30,7 +33,7 @@ func doDecodeFullResyncRDBFile(reader *bytes.Reader) ([]byte, error) {
 	if firstByte != '$' {
 		reader.UnreadByte() // Ensure the error points to the correct byte
 
-		return nil, InvalidInputError{
+		return nil, InvalidRESPError{
 			Reader:  reader,
 			Message: fmt.Sprintf("Expected first byte of RDB file message to be $, got %q", string(firstByte)),
 		}

--- a/internal/resp/decoder/errors.go
+++ b/internal/resp/decoder/errors.go
@@ -18,11 +18,20 @@ type InvalidInputError struct {
 	Message string
 }
 
+type InvalidRESPError struct {
+	Reader  *bytes.Reader
+	Message string
+}
+
 func (e IncompleteInputError) Error() string {
 	return formatDetailedError(e.Reader, e.Message)
 }
 
 func (e InvalidInputError) Error() string {
+	return formatDetailedError(e.Reader, e.Message)
+}
+
+func (e InvalidRESPError) Error() string {
 	return formatDetailedError(e.Reader, e.Message)
 }
 

--- a/internal/resp/formatter/format.go
+++ b/internal/resp/formatter/format.go
@@ -1,6 +1,10 @@
 package formatter
 
-import "github.com/tidwall/pretty"
+import (
+	"bytes"
+
+	"github.com/tidwall/pretty"
+)
 
 var defaultOptions = &pretty.Options{
 	Indent: "  ",
@@ -8,5 +12,7 @@ var defaultOptions = &pretty.Options{
 }
 
 func Prettify(json []byte) string {
-	return string(pretty.PrettyOptions(json, defaultOptions))
+	prettified := pretty.PrettyOptions(json, defaultOptions)
+	prettified = bytes.TrimRight(prettified, "\n")
+	return string(prettified)
 }

--- a/internal/test_cases/receive_command_test_case.go
+++ b/internal/test_cases/receive_command_test_case.go
@@ -1,8 +1,6 @@
 package test_cases
 
 import (
-	"fmt"
-
 	resp_connection "github.com/codecrafters-io/redis-tester/internal/resp/connection"
 	resp_value "github.com/codecrafters-io/redis-tester/internal/resp/value"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
@@ -17,26 +15,15 @@ type ReceiveCommandTestCase struct {
 }
 
 func (t *ReceiveCommandTestCase) Run(conn *resp_connection.RespConnection, logger *logger.Logger) error {
-	value, err := conn.ReadValue()
+	receiveValueTestCase := ReceiveValueTestCase{
+		Assertion:                 t.Assertion,
+		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
+	}
+	err := receiveValueTestCase.Run(conn, logger)
 	if err != nil {
 		return err
 	}
-
-	t.ReceivedValue = value
-
-	if err = t.Assertion.Run(value); err != nil {
-		return err
-	}
-
-	logger.Successf("Received %s", value.FormattedString())
-
-	if !t.ShouldSkipUnreadDataCheck {
-		conn.ReadIntoBuffer() // Let's make sure there's no extra data
-
-		if conn.UnreadBuffer.Len() > 0 {
-			return fmt.Errorf("Found extra data: %q", conn.UnreadBuffer.String())
-		}
-	}
+	t.ReceivedValue = receiveValueTestCase.ActualValue
 
 	if err := conn.SendValue(t.Response); err != nil {
 		return err

--- a/internal/test_cases/receive_replication_handshake_test_case.go
+++ b/internal/test_cases/receive_replication_handshake_test_case.go
@@ -44,7 +44,9 @@ func (t ReceiveReplicationHandshakeTestCase) RunAll(client *resp_connection.Resp
 }
 
 func (t ReceiveReplicationHandshakeTestCase) RunPingStep(client *resp_connection.RespConnection, logger *logger.Logger) error {
-	logger.Infof("master: Waiting for replica to initiate handshake with %q command", "PING")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Infof("Waiting for replica to initiate handshake with %q command", "PING")
+	})
 
 	commandTest := ReceiveCommandTestCase{
 		Assertion: resp_assertions.NewCommandAssertion("PING"),
@@ -55,7 +57,9 @@ func (t ReceiveReplicationHandshakeTestCase) RunPingStep(client *resp_connection
 }
 
 func (t ReceiveReplicationHandshakeTestCase) RunReplconfStep1(client *resp_connection.RespConnection, logger *logger.Logger) error {
-	logger.Infof("master: Waiting for replica to send %q command", "REPLCONF listening-port 6380")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Infof("Waiting for replica to send %q command", "REPLCONF listening-port 6380")
+	})
 
 	commandTest := ReceiveCommandTestCase{
 		Assertion:                 resp_assertions.NewCommandAssertion("REPLCONF", "listening-port", "6380"),
@@ -67,7 +71,9 @@ func (t ReceiveReplicationHandshakeTestCase) RunReplconfStep1(client *resp_conne
 }
 
 func (t ReceiveReplicationHandshakeTestCase) RunReplconfStep2(client *resp_connection.RespConnection, logger *logger.Logger) error {
-	logger.Infof("master: Waiting for replica to send %q command", "REPLCONF capa")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Infof("Waiting for replica to send %q command", "REPLCONF capa")
+	})
 
 	commandTest := ReceiveCommandTestCase{
 		Assertion: resp_assertions.NewOnlyCommandAssertion("REPLCONF"),
@@ -113,7 +119,9 @@ func (t ReceiveReplicationHandshakeTestCase) RunReplconfStep2(client *resp_conne
 }
 
 func (t ReceiveReplicationHandshakeTestCase) RunPsyncStep(client *resp_connection.RespConnection, logger *logger.Logger) error {
-	logger.Infof("master: Waiting for replica to send %q command", "PSYNC")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Infof("Waiting for replica to send %q command", "PSYNC")
+	})
 
 	id := "75cd7bc10c49047e0d163660f3b90625b1af31dc"
 	commandTest := ReceiveCommandTestCase{
@@ -125,7 +133,9 @@ func (t ReceiveReplicationHandshakeTestCase) RunPsyncStep(client *resp_connectio
 }
 
 func (t ReceiveReplicationHandshakeTestCase) RunSendRDBStep(client *resp_connection.RespConnection, logger *logger.Logger) error {
-	logger.Debugln("Sending RDB file...")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Debugln("Sending RDB file...")
+	})
 
 	hexStr := "524544495330303131fa0972656469732d76657205372e322e30fa0a72656469732d62697473c040fa056374696d65c26d08bc65fa08757365642d6d656dc2b0c41000fa08616f662d62617365c000fff06e3bfec0ff5aa2"
 	bytes, err := hex.DecodeString(hexStr)
@@ -136,6 +146,8 @@ func (t ReceiveReplicationHandshakeTestCase) RunSendRDBStep(client *resp_connect
 	encodedValue := resp_encoder.EncodeFullResyncRDBFile(bytes)
 	client.SendBytes(encodedValue)
 
-	logger.Successf("Sent RDB file.")
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Successf("Sent RDB file.")
+	})
 	return nil
 }

--- a/internal/test_cases/receive_value_test_case.go
+++ b/internal/test_cases/receive_value_test_case.go
@@ -47,6 +47,8 @@ func (t *ReceiveValueTestCase) Assert(client *resp_client.RespConnection, logger
 		}
 	}
 
-	logger.Successf("Received %s", t.ActualValue.FormattedString())
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Successf("Received %s", t.ActualValue.FormattedString())
+	})
 	return nil
 }

--- a/internal/test_cases/transaction_test_case.go
+++ b/internal/test_cases/transaction_test_case.go
@@ -64,7 +64,7 @@ func (t TransactionTestCase) RunMulti(client *resp_client.RespConnection, logger
 
 func (t TransactionTestCase) RunQueueAll(client *resp_client.RespConnection, logger *logger.Logger) error {
 	for i, v := range t.CommandQueue {
-		logger.Debugf("Sending command: #%d/#%d", i+1, len(t.CommandQueue))
+		logger.Debugf("Sending command: %d/%d", i+1, len(t.CommandQueue))
 		commandTest := SendCommandTestCase{
 			Command:   v[0],
 			Args:      v[1:],

--- a/internal/test_echo.go
+++ b/internal/test_echo.go
@@ -18,7 +18,7 @@ func testEcho(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "")
+	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client")
 	if err != nil {
 		return err
 	}

--- a/internal/test_expiry.go
+++ b/internal/test_expiry.go
@@ -20,7 +20,7 @@ func testExpiry(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "")
+	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client")
 	if err != nil {
 		logFriendlyError(logger, err)
 		return err

--- a/internal/test_get_set.go
+++ b/internal/test_get_set.go
@@ -18,7 +18,7 @@ func testGetSet(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "")
+	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client")
 	if err != nil {
 		logFriendlyError(logger, err)
 		return err

--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -2,25 +2,25 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET apple blueberry px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:34:55.476[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:34:55.477 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
-[33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 08:59:45.096[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 08:59:45.096 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:34:55.580 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 08:59:45.199 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -28,89 +28,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key blueberry to raspberry[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET blueberry raspberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET blueberry raspberry[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key blueberry[0m
-[33m[tester::#LA7] [0m[94m> GET blueberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "raspberry"[0m
-[33m[tester::#LA7] [0m[92mReceived "raspberry"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET blueberry[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "raspberry"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO pear[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$4\r\npear\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[tester::#QQ0] [0m[92mReceived "pear"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO pear[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$4\r\npear\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "pear"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -118,11 +118,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -2,1169 +2,1108 @@ Debug = true
 
 [33m[tester::#XJ7] [0m[94mRunning tests for Stage #XJ7 (xj7)[0m
 [33m[tester::#XJ7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XJ7] [0m[94mclient: $ redis-cli BLPOP pear 0.2[0m
-[33m[tester::#XJ7] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$3\r\n0.2\r\n"[0m
-[33m[tester::#XJ7] [0m[36mclient: Received bytes: "*-1\r\n"[0m
-[33m[tester::#XJ7] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#XJ7] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#XJ7] [0m[94mclient-1: $ redis-cli BLPOP raspberry 0.2[0m
-[33m[tester::#XJ7] [0m[36mclient-1: Sent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.2\r\n"[0m
-[33m[tester::#XJ7] [0m[94mclient-2: $ redis-cli RPUSH raspberry mango[0m
-[33m[tester::#XJ7] [0m[36mclient-2: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#XJ7] [0m[36mclient-2: Received bytes: ":1\r\n"[0m
-[33m[tester::#XJ7] [0m[36mclient-2: Received RESP integer: 1[0m
-[33m[tester::#XJ7] [0m[92mReceived 1[0m
-[33m[tester::#XJ7] [0m[36mclient-1: Received bytes: "*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#XJ7] [0m[36mclient-1: Received RESP array: ["raspberry", "mango"][0m
-[33m[tester::#XJ7] [0m[36m[0m
-[33m[tester::#XJ7] [0m[92mReceived ["raspberry", "mango"][0m
-[33m[tester::#XJ7] [0m[92m[0m
+[33m[tester::#XJ7] [client] [0m[94m$ redis-cli BLPOP pear 0.2[0m
+[33m[tester::#XJ7] [client] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$3\r\n0.2\r\n"[0m
+[33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#XJ7] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#XJ7] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.2[0m
+[33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.2\r\n"[0m
+[33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry mango[0m
+[33m[tester::#XJ7] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#XJ7] [client-2] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#XJ7] [client-2] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#XJ7] [client-2] [0m[92mReceived 1[0m
+[33m[tester::#XJ7] [client-1] [0m[36mReceived bytes: "*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#XJ7] [client-1] [0m[36mReceived RESP array: ["raspberry", "mango"][0m
+[33m[tester::#XJ7] [client-1] [0m[92mReceived ["raspberry", "mango"][0m
 [33m[tester::#XJ7] [0m[92mTest passed.[0m
 [33m[tester::#XJ7] [0m[36mTerminating program[0m
 [33m[tester::#XJ7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [0m[94mclient-2: $ redis-cli BLPOP banana 0[0m
-[33m[tester::#EC3] [0m[36mclient-2: Sent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
-[33m[tester::#EC3] [0m[94mclient-3: $ redis-cli BLPOP banana 0[0m
-[33m[tester::#EC3] [0m[36mclient-3: Sent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
-[33m[tester::#EC3] [0m[94mclient-1: $ redis-cli RPUSH banana blueberry[0m
-[33m[tester::#EC3] [0m[36mclient-1: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#EC3] [0m[36mclient-1: Received bytes: ":1\r\n"[0m
-[33m[tester::#EC3] [0m[36mclient-1: Received RESP integer: 1[0m
-[33m[tester::#EC3] [0m[92mReceived 1[0m
-[33m[tester::#EC3] [0m[36mclient-2: Received bytes: "*2\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#EC3] [0m[36mclient-2: Received RESP array: ["banana", "blueberry"][0m
-[33m[tester::#EC3] [0m[36m[0m
-[33m[tester::#EC3] [0m[92mReceived ["banana", "blueberry"][0m
-[33m[tester::#EC3] [0m[92m[0m
+[33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP banana 0[0m
+[33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
+[33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP banana 0[0m
+[33m[tester::#EC3] [client-3] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
+[33m[tester::#EC3] [client-1] [0m[94m$ redis-cli RPUSH banana blueberry[0m
+[33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#EC3] [client-1] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#EC3] [client-1] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#EC3] [client-1] [0m[92mReceived 1[0m
+[33m[tester::#EC3] [client-2] [0m[36mReceived bytes: "*2\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#EC3] [client-2] [0m[36mReceived RESP array: ["banana", "blueberry"][0m
+[33m[tester::#EC3] [client-2] [0m[92mReceived ["banana", "blueberry"][0m
 [33m[tester::#EC3] [0m[92mTest passed.[0m
 [33m[tester::#EC3] [0m[36mTerminating program[0m
 [33m[tester::#EC3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JP1] [0m[94mRunning tests for Stage #JP1 (jp1)[0m
 [33m[tester::#JP1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JP1] [0m[94mclient: $ redis-cli RPUSH banana strawberry apple pear banana raspberry mango blueberry pineapple[0m
-[33m[tester::#JP1] [0m[36mclient: Sent bytes: "*10\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n$4\r\npear\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received bytes: ":8\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received RESP integer: 8[0m
-[33m[tester::#JP1] [0m[92mReceived 8[0m
-[33m[tester::#JP1] [0m[94mclient: > LPOP banana 2[0m
-[33m[tester::#JP1] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nLPOP\r\n$6\r\nbanana\r\n$1\r\n2\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received bytes: "*2\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received RESP array: ["strawberry", "apple"][0m
-[33m[tester::#JP1] [0m[36m[0m
-[33m[tester::#JP1] [0m[92mReceived ["strawberry", "apple"][0m
-[33m[tester::#JP1] [0m[92m[0m
-[33m[tester::#JP1] [0m[94mclient: > LRANGE banana 0 -1[0m
-[33m[tester::#JP1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received bytes: "*6\r\n$4\r\npear\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JP1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JP1] [0m[36m  "pear",[0m
-[33m[tester::#JP1] [0m[36m  "banana",[0m
-[33m[tester::#JP1] [0m[36m  "raspberry",[0m
-[33m[tester::#JP1] [0m[36m  "mango",[0m
-[33m[tester::#JP1] [0m[36m  "blueberry",[0m
-[33m[tester::#JP1] [0m[36m  "pineapple"[0m
-[33m[tester::#JP1] [0m[36m][0m
-[33m[tester::#JP1] [0m[36m[0m
-[33m[tester::#JP1] [0m[92mReceived [[0m
-[33m[tester::#JP1] [0m[92m  "pear",[0m
-[33m[tester::#JP1] [0m[92m  "banana",[0m
-[33m[tester::#JP1] [0m[92m  "raspberry",[0m
-[33m[tester::#JP1] [0m[92m  "mango",[0m
-[33m[tester::#JP1] [0m[92m  "blueberry",[0m
-[33m[tester::#JP1] [0m[92m  "pineapple"[0m
-[33m[tester::#JP1] [0m[92m][0m
-[33m[tester::#JP1] [0m[92m[0m
+[33m[tester::#JP1] [client] [0m[94m$ redis-cli RPUSH banana strawberry apple pear banana raspberry mango blueberry pineapple[0m
+[33m[tester::#JP1] [client] [0m[36mSent bytes: "*10\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n$4\r\npear\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived bytes: ":8\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived RESP integer: 8[0m
+[33m[tester::#JP1] [client] [0m[92mReceived 8[0m
+[33m[tester::#JP1] [client] [0m[94m> LPOP banana 2[0m
+[33m[tester::#JP1] [client] [0m[36mSent bytes: "*3\r\n$4\r\nLPOP\r\n$6\r\nbanana\r\n$1\r\n2\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived bytes: "*2\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived RESP array: ["strawberry", "apple"][0m
+[33m[tester::#JP1] [client] [0m[92mReceived ["strawberry", "apple"][0m
+[33m[tester::#JP1] [client] [0m[94m> LRANGE banana 0 -1[0m
+[33m[tester::#JP1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived bytes: "*6\r\n$4\r\npear\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JP1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JP1] [client] [0m[36m  "pear",[0m
+[33m[tester::#JP1] [client] [0m[36m  "banana",[0m
+[33m[tester::#JP1] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JP1] [client] [0m[36m  "mango",[0m
+[33m[tester::#JP1] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#JP1] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#JP1] [client] [0m[36m][0m
+[33m[tester::#JP1] [client] [0m[92mReceived [[0m
+[33m[tester::#JP1] [client] [0m[92m  "pear",[0m
+[33m[tester::#JP1] [client] [0m[92m  "banana",[0m
+[33m[tester::#JP1] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JP1] [client] [0m[92m  "mango",[0m
+[33m[tester::#JP1] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#JP1] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#JP1] [client] [0m[92m][0m
 [33m[tester::#JP1] [0m[92mTest passed.[0m
 [33m[tester::#JP1] [0m[36mTerminating program[0m
 [33m[tester::#JP1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#EF1] [0m[94mRunning tests for Stage #EF1 (ef1)[0m
 [33m[tester::#EF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EF1] [0m[94mclient: $ redis-cli RPUSH pear raspberry grape pineapple mango apple banana[0m
-[33m[tester::#EF1] [0m[36mclient: Sent bytes: "*8\r\n$5\r\nRPUSH\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received bytes: ":6\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received RESP integer: 6[0m
-[33m[tester::#EF1] [0m[92mReceived 6[0m
-[33m[tester::#EF1] [0m[94mclient: > LPOP pear[0m
-[33m[tester::#EF1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nLPOP\r\n$4\r\npear\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#EF1] [0m[92mReceived "raspberry"[0m
-[33m[tester::#EF1] [0m[94mclient: > LRANGE pear 0 -1[0m
-[33m[tester::#EF1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$4\r\npear\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received bytes: "*5\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#EF1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#EF1] [0m[36m  "grape",[0m
-[33m[tester::#EF1] [0m[36m  "pineapple",[0m
-[33m[tester::#EF1] [0m[36m  "mango",[0m
-[33m[tester::#EF1] [0m[36m  "apple",[0m
-[33m[tester::#EF1] [0m[36m  "banana"[0m
-[33m[tester::#EF1] [0m[36m][0m
-[33m[tester::#EF1] [0m[36m[0m
-[33m[tester::#EF1] [0m[92mReceived [[0m
-[33m[tester::#EF1] [0m[92m  "grape",[0m
-[33m[tester::#EF1] [0m[92m  "pineapple",[0m
-[33m[tester::#EF1] [0m[92m  "mango",[0m
-[33m[tester::#EF1] [0m[92m  "apple",[0m
-[33m[tester::#EF1] [0m[92m  "banana"[0m
-[33m[tester::#EF1] [0m[92m][0m
-[33m[tester::#EF1] [0m[92m[0m
+[33m[tester::#EF1] [client] [0m[94m$ redis-cli RPUSH pear raspberry grape pineapple mango apple banana[0m
+[33m[tester::#EF1] [client] [0m[36mSent bytes: "*8\r\n$5\r\nRPUSH\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived bytes: ":6\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived RESP integer: 6[0m
+[33m[tester::#EF1] [client] [0m[92mReceived 6[0m
+[33m[tester::#EF1] [client] [0m[94m> LPOP pear[0m
+[33m[tester::#EF1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nLPOP\r\n$4\r\npear\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#EF1] [client] [0m[92mReceived "raspberry"[0m
+[33m[tester::#EF1] [client] [0m[94m> LRANGE pear 0 -1[0m
+[33m[tester::#EF1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$4\r\npear\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived bytes: "*5\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$5\r\nmango\r\n$5\r\napple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#EF1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EF1] [client] [0m[36m  "grape",[0m
+[33m[tester::#EF1] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#EF1] [client] [0m[36m  "mango",[0m
+[33m[tester::#EF1] [client] [0m[36m  "apple",[0m
+[33m[tester::#EF1] [client] [0m[36m  "banana"[0m
+[33m[tester::#EF1] [client] [0m[36m][0m
+[33m[tester::#EF1] [client] [0m[92mReceived [[0m
+[33m[tester::#EF1] [client] [0m[92m  "grape",[0m
+[33m[tester::#EF1] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#EF1] [client] [0m[92m  "mango",[0m
+[33m[tester::#EF1] [client] [0m[92m  "apple",[0m
+[33m[tester::#EF1] [client] [0m[92m  "banana"[0m
+[33m[tester::#EF1] [client] [0m[92m][0m
 [33m[tester::#EF1] [0m[92mTest passed.[0m
 [33m[tester::#EF1] [0m[36mTerminating program[0m
 [33m[tester::#EF1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FV6] [0m[94mRunning tests for Stage #FV6 (fv6)[0m
 [33m[tester::#FV6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FV6] [0m[94mclient: $ redis-cli RPUSH banana blueberry orange pear strawberry grape banana raspberry[0m
-[33m[tester::#FV6] [0m[36mclient: Sent bytes: "*9\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$4\r\npear\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#FV6] [0m[92mReceived 7[0m
-[33m[tester::#FV6] [0m[94mclient: > LLEN banana[0m
-[33m[tester::#FV6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nLLEN\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#FV6] [0m[92mReceived 7[0m
-[33m[tester::#FV6] [0m[94mclient: > LLEN missing_key_50[0m
-[33m[tester::#FV6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nLLEN\r\n$14\r\nmissing_key_50\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received bytes: ":0\r\n"[0m
-[33m[tester::#FV6] [0m[36mclient: Received RESP integer: 0[0m
-[33m[tester::#FV6] [0m[92mReceived 0[0m
+[33m[tester::#FV6] [client] [0m[94m$ redis-cli RPUSH banana blueberry orange pear strawberry grape banana raspberry[0m
+[33m[tester::#FV6] [client] [0m[36mSent bytes: "*9\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$4\r\npear\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#FV6] [client] [0m[92mReceived 7[0m
+[33m[tester::#FV6] [client] [0m[94m> LLEN banana[0m
+[33m[tester::#FV6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nLLEN\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#FV6] [client] [0m[92mReceived 7[0m
+[33m[tester::#FV6] [client] [0m[94m> LLEN missing_key_50[0m
+[33m[tester::#FV6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nLLEN\r\n$14\r\nmissing_key_50\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived bytes: ":0\r\n"[0m
+[33m[tester::#FV6] [client] [0m[36mReceived RESP integer: 0[0m
+[33m[tester::#FV6] [client] [0m[92mReceived 0[0m
 [33m[tester::#FV6] [0m[92mTest passed.[0m
 [33m[tester::#FV6] [0m[36mTerminating program[0m
 [33m[tester::#FV6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#GU5] [0m[94mRunning tests for Stage #GU5 (gu5)[0m
 [33m[tester::#GU5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#GU5] [0m[94mclient: $ redis-cli LPUSH blueberry strawberry[0m
-[33m[tester::#GU5] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nLPUSH\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received RESP integer: 1[0m
-[33m[tester::#GU5] [0m[92mReceived 1[0m
-[33m[tester::#GU5] [0m[94mclient: > LPUSH blueberry pear grape[0m
-[33m[tester::#GU5] [0m[36mclient: Sent bytes: "*4\r\n$5\r\nLPUSH\r\n$9\r\nblueberry\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#GU5] [0m[92mReceived 3[0m
-[33m[tester::#GU5] [0m[94mclient: > LRANGE blueberry 0 -1[0m
-[33m[tester::#GU5] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$9\r\nblueberry\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received bytes: "*3\r\n$5\r\ngrape\r\n$4\r\npear\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#GU5] [0m[36mclient: Received RESP array: ["grape", "pear", "strawberry"][0m
-[33m[tester::#GU5] [0m[36m[0m
-[33m[tester::#GU5] [0m[92mReceived ["grape", "pear", "strawberry"][0m
-[33m[tester::#GU5] [0m[92m[0m
+[33m[tester::#GU5] [client] [0m[94m$ redis-cli LPUSH blueberry strawberry[0m
+[33m[tester::#GU5] [client] [0m[36mSent bytes: "*3\r\n$5\r\nLPUSH\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#GU5] [client] [0m[92mReceived 1[0m
+[33m[tester::#GU5] [client] [0m[94m> LPUSH blueberry pear grape[0m
+[33m[tester::#GU5] [client] [0m[36mSent bytes: "*4\r\n$5\r\nLPUSH\r\n$9\r\nblueberry\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#GU5] [client] [0m[92mReceived 3[0m
+[33m[tester::#GU5] [client] [0m[94m> LRANGE blueberry 0 -1[0m
+[33m[tester::#GU5] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$9\r\nblueberry\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived bytes: "*3\r\n$5\r\ngrape\r\n$4\r\npear\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#GU5] [client] [0m[36mReceived RESP array: ["grape", "pear", "strawberry"][0m
+[33m[tester::#GU5] [client] [0m[92mReceived ["grape", "pear", "strawberry"][0m
 [33m[tester::#GU5] [0m[92mTest passed.[0m
 [33m[tester::#GU5] [0m[36mTerminating program[0m
 [33m[tester::#GU5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RI1] [0m[94mRunning tests for Stage #RI1 (ri1)[0m
 [33m[tester::#RI1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RI1] [0m[94mclient: $ redis-cli RPUSH banana orange blueberry grape pineapple raspberry banana pear[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*9\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#RI1] [0m[92mReceived 7[0m
-[33m[tester::#RI1] [0m[94mclient: > LRANGE banana 0 -4[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-4\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RI1] [0m[36m  "orange",[0m
-[33m[tester::#RI1] [0m[36m  "blueberry",[0m
-[33m[tester::#RI1] [0m[36m  "grape",[0m
-[33m[tester::#RI1] [0m[36m  "pineapple"[0m
-[33m[tester::#RI1] [0m[36m][0m
-[33m[tester::#RI1] [0m[36m[0m
-[33m[tester::#RI1] [0m[92mReceived [[0m
-[33m[tester::#RI1] [0m[92m  "orange",[0m
-[33m[tester::#RI1] [0m[92m  "blueberry",[0m
-[33m[tester::#RI1] [0m[92m  "grape",[0m
-[33m[tester::#RI1] [0m[92m  "pineapple"[0m
-[33m[tester::#RI1] [0m[92m][0m
-[33m[tester::#RI1] [0m[92m[0m
-[33m[tester::#RI1] [0m[94mclient: > LRANGE banana -4 -1[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-4\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: "*4\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RI1] [0m[36m  "pineapple",[0m
-[33m[tester::#RI1] [0m[36m  "raspberry",[0m
-[33m[tester::#RI1] [0m[36m  "banana",[0m
-[33m[tester::#RI1] [0m[36m  "pear"[0m
-[33m[tester::#RI1] [0m[36m][0m
-[33m[tester::#RI1] [0m[36m[0m
-[33m[tester::#RI1] [0m[92mReceived [[0m
-[33m[tester::#RI1] [0m[92m  "pineapple",[0m
-[33m[tester::#RI1] [0m[92m  "raspberry",[0m
-[33m[tester::#RI1] [0m[92m  "banana",[0m
-[33m[tester::#RI1] [0m[92m  "pear"[0m
-[33m[tester::#RI1] [0m[92m][0m
-[33m[tester::#RI1] [0m[92m[0m
-[33m[tester::#RI1] [0m[94mclient: > LRANGE banana 0 -1[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: "*7\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RI1] [0m[36m  "orange",[0m
-[33m[tester::#RI1] [0m[36m  "blueberry",[0m
-[33m[tester::#RI1] [0m[36m  "grape",[0m
-[33m[tester::#RI1] [0m[36m  "pineapple",[0m
-[33m[tester::#RI1] [0m[36m  "raspberry",[0m
-[33m[tester::#RI1] [0m[36m  "banana",[0m
-[33m[tester::#RI1] [0m[36m  "pear"[0m
-[33m[tester::#RI1] [0m[36m][0m
-[33m[tester::#RI1] [0m[36m[0m
-[33m[tester::#RI1] [0m[92mReceived [[0m
-[33m[tester::#RI1] [0m[92m  "orange",[0m
-[33m[tester::#RI1] [0m[92m  "blueberry",[0m
-[33m[tester::#RI1] [0m[92m  "grape",[0m
-[33m[tester::#RI1] [0m[92m  "pineapple",[0m
-[33m[tester::#RI1] [0m[92m  "raspberry",[0m
-[33m[tester::#RI1] [0m[92m  "banana",[0m
-[33m[tester::#RI1] [0m[92m  "pear"[0m
-[33m[tester::#RI1] [0m[92m][0m
-[33m[tester::#RI1] [0m[92m[0m
-[33m[tester::#RI1] [0m[94mclient: > LRANGE banana -1 -2[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-1\r\n$2\r\n-2\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: "*0\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP array: [][0m
-[33m[tester::#RI1] [0m[36m[0m
-[33m[tester::#RI1] [0m[92mReceived [][0m
-[33m[tester::#RI1] [0m[92m[0m
-[33m[tester::#RI1] [0m[94mclient: > LRANGE banana -8 -1[0m
-[33m[tester::#RI1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-8\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received bytes: "*7\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#RI1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RI1] [0m[36m  "orange",[0m
-[33m[tester::#RI1] [0m[36m  "blueberry",[0m
-[33m[tester::#RI1] [0m[36m  "grape",[0m
-[33m[tester::#RI1] [0m[36m  "pineapple",[0m
-[33m[tester::#RI1] [0m[36m  "raspberry",[0m
-[33m[tester::#RI1] [0m[36m  "banana",[0m
-[33m[tester::#RI1] [0m[36m  "pear"[0m
-[33m[tester::#RI1] [0m[36m][0m
-[33m[tester::#RI1] [0m[36m[0m
-[33m[tester::#RI1] [0m[92mReceived [[0m
-[33m[tester::#RI1] [0m[92m  "orange",[0m
-[33m[tester::#RI1] [0m[92m  "blueberry",[0m
-[33m[tester::#RI1] [0m[92m  "grape",[0m
-[33m[tester::#RI1] [0m[92m  "pineapple",[0m
-[33m[tester::#RI1] [0m[92m  "raspberry",[0m
-[33m[tester::#RI1] [0m[92m  "banana",[0m
-[33m[tester::#RI1] [0m[92m  "pear"[0m
-[33m[tester::#RI1] [0m[92m][0m
-[33m[tester::#RI1] [0m[92m[0m
+[33m[tester::#RI1] [client] [0m[94m$ redis-cli RPUSH banana orange blueberry grape pineapple raspberry banana pear[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*9\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#RI1] [client] [0m[92mReceived 7[0m
+[33m[tester::#RI1] [client] [0m[94m> LRANGE banana 0 -4[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-4\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RI1] [client] [0m[36m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#RI1] [client] [0m[36m][0m
+[33m[tester::#RI1] [client] [0m[92mReceived [[0m
+[33m[tester::#RI1] [client] [0m[92m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#RI1] [client] [0m[92m][0m
+[33m[tester::#RI1] [client] [0m[94m> LRANGE banana -4 -1[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-4\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: "*4\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RI1] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[36m][0m
+[33m[tester::#RI1] [client] [0m[92mReceived [[0m
+[33m[tester::#RI1] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[92m][0m
+[33m[tester::#RI1] [client] [0m[94m> LRANGE banana 0 -1[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: "*7\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RI1] [client] [0m[36m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[36m][0m
+[33m[tester::#RI1] [client] [0m[92mReceived [[0m
+[33m[tester::#RI1] [client] [0m[92m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[92m][0m
+[33m[tester::#RI1] [client] [0m[94m> LRANGE banana -1 -2[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-1\r\n$2\r\n-2\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: "*0\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP array: [][0m
+[33m[tester::#RI1] [client] [0m[92mReceived [][0m
+[33m[tester::#RI1] [client] [0m[94m> LRANGE banana -8 -1[0m
+[33m[tester::#RI1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$2\r\n-8\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived bytes: "*7\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#RI1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RI1] [client] [0m[36m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[36m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[36m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[36m][0m
+[33m[tester::#RI1] [client] [0m[92mReceived [[0m
+[33m[tester::#RI1] [client] [0m[92m  "orange",[0m
+[33m[tester::#RI1] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "grape",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#RI1] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#RI1] [client] [0m[92m  "banana",[0m
+[33m[tester::#RI1] [client] [0m[92m  "pear"[0m
+[33m[tester::#RI1] [client] [0m[92m][0m
 [33m[tester::#RI1] [0m[92mTest passed.[0m
 [33m[tester::#RI1] [0m[36mTerminating program[0m
 [33m[tester::#RI1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SF6] [0m[94mRunning tests for Stage #SF6 (sf6)[0m
 [33m[tester::#SF6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SF6] [0m[94mclient: $ redis-cli RPUSH banana orange strawberry pineapple banana[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*6\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: ":4\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP integer: 4[0m
-[33m[tester::#SF6] [0m[92mReceived 4[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE banana 0 2[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n2\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*3\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#SF6] [0m[36m  "orange",[0m
-[33m[tester::#SF6] [0m[36m  "strawberry",[0m
-[33m[tester::#SF6] [0m[36m  "pineapple"[0m
-[33m[tester::#SF6] [0m[36m][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived [[0m
-[33m[tester::#SF6] [0m[92m  "orange",[0m
-[33m[tester::#SF6] [0m[92m  "strawberry",[0m
-[33m[tester::#SF6] [0m[92m  "pineapple"[0m
-[33m[tester::#SF6] [0m[92m][0m
-[33m[tester::#SF6] [0m[92m[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE banana 2 3[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n2\r\n$1\r\n3\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*2\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: ["pineapple", "banana"][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived ["pineapple", "banana"][0m
-[33m[tester::#SF6] [0m[92m[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE banana 0 3[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n3\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#SF6] [0m[36m  "orange",[0m
-[33m[tester::#SF6] [0m[36m  "strawberry",[0m
-[33m[tester::#SF6] [0m[36m  "pineapple",[0m
-[33m[tester::#SF6] [0m[36m  "banana"[0m
-[33m[tester::#SF6] [0m[36m][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived [[0m
-[33m[tester::#SF6] [0m[92m  "orange",[0m
-[33m[tester::#SF6] [0m[92m  "strawberry",[0m
-[33m[tester::#SF6] [0m[92m  "pineapple",[0m
-[33m[tester::#SF6] [0m[92m  "banana"[0m
-[33m[tester::#SF6] [0m[92m][0m
-[33m[tester::#SF6] [0m[92m[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE banana 1 0[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n1\r\n$1\r\n0\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*0\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: [][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived [][0m
-[33m[tester::#SF6] [0m[92m[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE banana 0 8[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n8\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#SF6] [0m[36m  "orange",[0m
-[33m[tester::#SF6] [0m[36m  "strawberry",[0m
-[33m[tester::#SF6] [0m[36m  "pineapple",[0m
-[33m[tester::#SF6] [0m[36m  "banana"[0m
-[33m[tester::#SF6] [0m[36m][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived [[0m
-[33m[tester::#SF6] [0m[92m  "orange",[0m
-[33m[tester::#SF6] [0m[92m  "strawberry",[0m
-[33m[tester::#SF6] [0m[92m  "pineapple",[0m
-[33m[tester::#SF6] [0m[92m  "banana"[0m
-[33m[tester::#SF6] [0m[92m][0m
-[33m[tester::#SF6] [0m[92m[0m
-[33m[tester::#SF6] [0m[94mclient: > LRANGE missing_key_38 0 1[0m
-[33m[tester::#SF6] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nLRANGE\r\n$14\r\nmissing_key_38\r\n$1\r\n0\r\n$1\r\n1\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received bytes: "*0\r\n"[0m
-[33m[tester::#SF6] [0m[36mclient: Received RESP array: [][0m
-[33m[tester::#SF6] [0m[36m[0m
-[33m[tester::#SF6] [0m[92mReceived [][0m
-[33m[tester::#SF6] [0m[92m[0m
+[33m[tester::#SF6] [client] [0m[94m$ redis-cli RPUSH banana orange strawberry pineapple banana[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*6\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: ":4\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP integer: 4[0m
+[33m[tester::#SF6] [client] [0m[92mReceived 4[0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE banana 0 2[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n2\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*3\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#SF6] [client] [0m[36m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#SF6] [client] [0m[36m][0m
+[33m[tester::#SF6] [client] [0m[92mReceived [[0m
+[33m[tester::#SF6] [client] [0m[92m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#SF6] [client] [0m[92m][0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE banana 2 3[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n2\r\n$1\r\n3\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*2\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: ["pineapple", "banana"][0m
+[33m[tester::#SF6] [client] [0m[92mReceived ["pineapple", "banana"][0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE banana 0 3[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n3\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#SF6] [client] [0m[36m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#SF6] [client] [0m[36m  "banana"[0m
+[33m[tester::#SF6] [client] [0m[36m][0m
+[33m[tester::#SF6] [client] [0m[92mReceived [[0m
+[33m[tester::#SF6] [client] [0m[92m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#SF6] [client] [0m[92m  "banana"[0m
+[33m[tester::#SF6] [client] [0m[92m][0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE banana 1 0[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n1\r\n$1\r\n0\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*0\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: [][0m
+[33m[tester::#SF6] [client] [0m[92mReceived [][0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE banana 0 8[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$6\r\nbanana\r\n$1\r\n0\r\n$1\r\n8\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#SF6] [client] [0m[36m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#SF6] [client] [0m[36m  "banana"[0m
+[33m[tester::#SF6] [client] [0m[36m][0m
+[33m[tester::#SF6] [client] [0m[92mReceived [[0m
+[33m[tester::#SF6] [client] [0m[92m  "orange",[0m
+[33m[tester::#SF6] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#SF6] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#SF6] [client] [0m[92m  "banana"[0m
+[33m[tester::#SF6] [client] [0m[92m][0m
+[33m[tester::#SF6] [client] [0m[94m> LRANGE missing_key_38 0 1[0m
+[33m[tester::#SF6] [client] [0m[36mSent bytes: "*4\r\n$6\r\nLRANGE\r\n$14\r\nmissing_key_38\r\n$1\r\n0\r\n$1\r\n1\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived bytes: "*0\r\n"[0m
+[33m[tester::#SF6] [client] [0m[36mReceived RESP array: [][0m
+[33m[tester::#SF6] [client] [0m[92mReceived [][0m
 [33m[tester::#SF6] [0m[92mTest passed.[0m
 [33m[tester::#SF6] [0m[36mTerminating program[0m
 [33m[tester::#SF6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#LX4] [0m[94mRunning tests for Stage #LX4 (lx4)[0m
 [33m[tester::#LX4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LX4] [0m[94mclient: $ redis-cli RPUSH banana banana raspberry[0m
-[33m[tester::#LX4] [0m[36mclient: Sent bytes: "*4\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#LX4] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[tester::#LX4] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#LX4] [0m[92mReceived 2[0m
-[33m[tester::#LX4] [0m[94mclient: > RPUSH banana strawberry orange apple[0m
-[33m[tester::#LX4] [0m[36mclient: Sent bytes: "*5\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
-[33m[tester::#LX4] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#LX4] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#LX4] [0m[92mReceived 5[0m
+[33m[tester::#LX4] [client] [0m[94m$ redis-cli RPUSH banana banana raspberry[0m
+[33m[tester::#LX4] [client] [0m[36mSent bytes: "*4\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#LX4] [client] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#LX4] [client] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#LX4] [client] [0m[92mReceived 2[0m
+[33m[tester::#LX4] [client] [0m[94m> RPUSH banana strawberry orange apple[0m
+[33m[tester::#LX4] [client] [0m[36mSent bytes: "*5\r\n$5\r\nRPUSH\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
+[33m[tester::#LX4] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#LX4] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#LX4] [client] [0m[92mReceived 5[0m
 [33m[tester::#LX4] [0m[92mTest passed.[0m
 [33m[tester::#LX4] [0m[36mTerminating program[0m
 [33m[tester::#LX4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#TN7] [0m[94mRunning tests for Stage #TN7 (tn7)[0m
 [33m[tester::#TN7] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#TN7] [0m[94mclient: $ redis-cli RPUSH pineapple mango[0m
-[33m[tester::#TN7] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received RESP integer: 1[0m
-[33m[tester::#TN7] [0m[92mReceived 1[0m
-[33m[tester::#TN7] [0m[94mclient: > RPUSH pineapple pear[0m
-[33m[tester::#TN7] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#TN7] [0m[92mReceived 2[0m
-[33m[tester::#TN7] [0m[94mclient: > RPUSH pineapple blueberry[0m
-[33m[tester::#TN7] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#TN7] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#TN7] [0m[92mReceived 3[0m
+[33m[tester::#TN7] [client] [0m[94m$ redis-cli RPUSH pineapple mango[0m
+[33m[tester::#TN7] [client] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#TN7] [client] [0m[92mReceived 1[0m
+[33m[tester::#TN7] [client] [0m[94m> RPUSH pineapple pear[0m
+[33m[tester::#TN7] [client] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#TN7] [client] [0m[92mReceived 2[0m
+[33m[tester::#TN7] [client] [0m[94m> RPUSH pineapple blueberry[0m
+[33m[tester::#TN7] [client] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$9\r\npineapple\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#TN7] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#TN7] [client] [0m[92mReceived 3[0m
 [33m[tester::#TN7] [0m[92mTest passed.[0m
 [33m[tester::#TN7] [0m[36mTerminating program[0m
 [33m[tester::#TN7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MH6] [0m[94mRunning tests for Stage #MH6 (mh6)[0m
 [33m[tester::#MH6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#MH6] [0m[94mclient: $ redis-cli RPUSH apple pear[0m
-[33m[tester::#MH6] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nRPUSH\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#MH6] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#MH6] [0m[36mclient: Received RESP integer: 1[0m
-[33m[tester::#MH6] [0m[92mReceived 1[0m
+[33m[tester::#MH6] [client] [0m[94m$ redis-cli RPUSH apple pear[0m
+[33m[tester::#MH6] [client] [0m[36mSent bytes: "*3\r\n$5\r\nRPUSH\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#MH6] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#MH6] [client] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#MH6] [client] [0m[92mReceived 1[0m
 [33m[tester::#MH6] [0m[92mTest passed.[0m
 [33m[tester::#MH6] [0m[36mTerminating program[0m
 [33m[tester::#MH6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [0m[94mclient-1: $ redis-cli SET apple 44[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: ":1\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP integer: 1[0m
-[33m[tester::#JF8] [0m[92mReceived 1[0m
-[33m[tester::#JF8] [0m[94mclient-2: $ redis-cli SET apple 44[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: ":2\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP integer: 2[0m
-[33m[tester::#JF8] [0m[92mReceived 2[0m
-[33m[tester::#JF8] [0m[94mclient-3: $ redis-cli SET apple 44[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: ":3\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP integer: 3[0m
-[33m[tester::#JF8] [0m[92mReceived 3[0m
-[33m[tester::#JF8] [0m[94mclient-1: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-2: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-3: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR pineapple[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "*2\r\n:4\r\n:45\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP array: [4, 45][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [4, 45][0m
-[33m[tester::#JF8] [0m[92m[0m
-[33m[tester::#JF8] [0m[94mclient-2: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "*2\r\n:5\r\n:46\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP array: [5, 46][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [5, 46][0m
-[33m[tester::#JF8] [0m[92m[0m
-[33m[tester::#JF8] [0m[94mclient-3: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "*2\r\n:6\r\n:47\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP array: [6, 47][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [6, 47][0m
-[33m[tester::#JF8] [0m[92m[0m
+[33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 44[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived 1[0m
+[33m[tester::#JF8] [client-2] [0m[94m$ redis-cli SET apple 44[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived 2[0m
+[33m[tester::#JF8] [client-3] [0m[94m$ redis-cli SET apple 44[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived 3[0m
+[33m[tester::#JF8] [client-1] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR pineapple[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "*2\r\n:4\r\n:45\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP array: [4, 45][0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived [4, 45][0m
+[33m[tester::#JF8] [client-2] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "*2\r\n:5\r\n:46\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP array: [5, 46][0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived [5, 46][0m
+[33m[tester::#JF8] [client-3] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "*2\r\n:6\r\n:47\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP array: [6, 47][0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived [6, 47][0m
 [33m[tester::#JF8] [0m[92mTest passed.[0m
 [33m[tester::#JF8] [0m[36mTerminating program[0m
 [33m[tester::#JF8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [0m[94mclient-1: $ redis-cli SET banana pear[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > SET pineapple 70[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$2\r\n70\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > MULTI[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#SG9] [0m[94mclient-1: > INCR banana[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#SG9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#SG9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#SG9] [0m[94mclient-1: > INCR pineapple[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#SG9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "*2\r\n-ERR value is not an integer or out of range\r\n:71\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#SG9] [0m[36m  "ERR value is not an integer or out of range",[0m
-[33m[tester::#SG9] [0m[36m  71[0m
-[33m[tester::#SG9] [0m[36m][0m
-[33m[tester::#SG9] [0m[36m[0m
-[33m[tester::#SG9] [0m[92mReceived [[0m
-[33m[tester::#SG9] [0m[92m  "ERR value is not an integer or out of range",[0m
-[33m[tester::#SG9] [0m[92m  71[0m
-[33m[tester::#SG9] [0m[92m][0m
-[33m[tester::#SG9] [0m[92m[0m
-[33m[tester::#SG9] [0m[94mclient-2: $ redis-cli GET pineapple[0m
-[33m[tester::#SG9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received bytes: "$2\r\n71\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received RESP bulk string: "71"[0m
-[33m[tester::#SG9] [0m[92mReceived "71"[0m
-[33m[tester::#SG9] [0m[94mclient-2: > GET banana[0m
-[33m[tester::#SG9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received RESP bulk string: "pear"[0m
-[33m[tester::#SG9] [0m[92mReceived "pear"[0m
+[33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET banana pear[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> SET pineapple 70[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$2\r\n70\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> MULTI[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [0m[36mSending command: 1/2[0m
+[33m[tester::#SG9] [client-1] [0m[94m> INCR banana[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#SG9] [0m[36mSending command: 2/2[0m
+[33m[tester::#SG9] [client-1] [0m[94m> INCR pineapple[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "*2\r\n-ERR value is not an integer or out of range\r\n:71\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#SG9] [client-1] [0m[36m  "ERR value is not an integer or out of range",[0m
+[33m[tester::#SG9] [client-1] [0m[36m  71[0m
+[33m[tester::#SG9] [client-1] [0m[36m][0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived [[0m
+[33m[tester::#SG9] [client-1] [0m[92m  "ERR value is not an integer or out of range",[0m
+[33m[tester::#SG9] [client-1] [0m[92m  71[0m
+[33m[tester::#SG9] [client-1] [0m[92m][0m
+[33m[tester::#SG9] [client-2] [0m[94m$ redis-cli GET pineapple[0m
+[33m[tester::#SG9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived bytes: "$2\r\n71\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived RESP bulk string: "71"[0m
+[33m[tester::#SG9] [client-2] [0m[92mReceived "71"[0m
+[33m[tester::#SG9] [client-2] [0m[94m> GET banana[0m
+[33m[tester::#SG9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#SG9] [client-2] [0m[92mReceived "pear"[0m
 [33m[tester::#SG9] [0m[92mTest passed.[0m
 [33m[tester::#SG9] [0m[36mTerminating program[0m
 [33m[tester::#SG9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RL9] [0m[94mRunning tests for Stage #RL9 (rl9)[0m
 [33m[tester::#RL9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RL9] [0m[94mclient: $ redis-cli SET apple 34[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n34\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[94mclient: > MULTI[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#RL9] [0m[94mclient: > SET raspberry 95[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$2\r\n95\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RL9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RL9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#RL9] [0m[94mclient: > INCR raspberry[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RL9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RL9] [0m[94mclient: > DISCARD[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[94mclient: > GET apple[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "$2\r\n34\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP bulk string: "34"[0m
-[33m[tester::#RL9] [0m[92mReceived "34"[0m
-[33m[tester::#RL9] [0m[94mclient: > DISCARD[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "-ERR DISCARD without MULTI\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP error: "ERR: ERR DISCARD without MULTI"[0m
-[33m[tester::#RL9] [0m[92mReceived "ERR: ERR DISCARD without MULTI"[0m
+[33m[tester::#RL9] [client] [0m[94m$ redis-cli SET apple 34[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n34\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [client] [0m[94m> MULTI[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [0m[36mSending command: 1/2[0m
+[33m[tester::#RL9] [client] [0m[94m> SET raspberry 95[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$2\r\n95\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RL9] [0m[36mSending command: 2/2[0m
+[33m[tester::#RL9] [client] [0m[94m> INCR raspberry[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[94m> DISCARD[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [client] [0m[94m> GET raspberry[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[94m> GET apple[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "$2\r\n34\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP bulk string: "34"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "34"[0m
+[33m[tester::#RL9] [client] [0m[94m> DISCARD[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "-ERR DISCARD without MULTI\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP error: "ERR: ERR DISCARD without MULTI"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "ERR: ERR DISCARD without MULTI"[0m
 [33m[tester::#RL9] [0m[92mTest passed.[0m
 [33m[tester::#RL9] [0m[36mTerminating program[0m
 [33m[tester::#RL9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [0m[94mclient-1: $ redis-cli MULTI[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#FY6] [0m[92mReceived "OK"[0m
-[33m[tester::#FY6] [0m[36mSending command: #1/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > SET apple 90[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n90\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #2/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > INCR apple[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #3/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > INCR grape[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #4/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > GET grape[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "*4\r\n+OK\r\n:91\r\n:1\r\n$1\r\n1\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP array: ["OK", 91, 1, "1"][0m
-[33m[tester::#FY6] [0m[36m[0m
-[33m[tester::#FY6] [0m[92mReceived ["OK", 91, 1, "1"][0m
-[33m[tester::#FY6] [0m[92m[0m
-[33m[tester::#FY6] [0m[94mclient-2: $ redis-cli GET apple[0m
-[33m[tester::#FY6] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-2: Received bytes: "$2\r\n91\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-2: Received RESP bulk string: "91"[0m
-[33m[tester::#FY6] [0m[92mReceived "91"[0m
+[33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#FY6] [0m[36mSending command: 1/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> SET apple 90[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n90\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 2/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> INCR apple[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 3/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> INCR grape[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 4/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> GET grape[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "*4\r\n+OK\r\n:91\r\n:1\r\n$1\r\n1\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP array: ["OK", 91, 1, "1"][0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived ["OK", 91, 1, "1"][0m
+[33m[tester::#FY6] [client-2] [0m[94m$ redis-cli GET apple[0m
+[33m[tester::#FY6] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#FY6] [client-2] [0m[36mReceived bytes: "$2\r\n91\r\n"[0m
+[33m[tester::#FY6] [client-2] [0m[36mReceived RESP bulk string: "91"[0m
+[33m[tester::#FY6] [client-2] [0m[92mReceived "91"[0m
 [33m[tester::#FY6] [0m[92mTest passed.[0m
 [33m[tester::#FY6] [0m[36mTerminating program[0m
 [33m[tester::#FY6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [0m[94mclient-1: $ redis-cli MULTI[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#RS9] [0m[92mReceived "OK"[0m
-[33m[tester::#RS9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#RS9] [0m[94mclient-1: > SET mango 13[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$2\r\n13\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RS9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RS9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#RS9] [0m[94mclient-1: > INCR mango[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RS9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RS9] [0m[94mclient-2: $ redis-cli GET mango[0m
-[33m[tester::#RS9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-2: Received bytes: "$-1\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-2: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#RS9] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#RS9] [0m[36mSending command: 1/2[0m
+[33m[tester::#RS9] [client-1] [0m[94m> SET mango 13[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$2\r\n13\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RS9] [0m[36mSending command: 2/2[0m
+[33m[tester::#RS9] [client-1] [0m[94m> INCR mango[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RS9] [client-2] [0m[94m$ redis-cli GET mango[0m
+[33m[tester::#RS9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#RS9] [0m[92mTest passed.[0m
 [33m[tester::#RS9] [0m[36mTerminating program[0m
 [33m[tester::#RS9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WE1] [0m[94mRunning tests for Stage #WE1 (we1)[0m
 [33m[tester::#WE1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WE1] [0m[94mclient: $ redis-cli MULTI[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#WE1] [0m[92mReceived "OK"[0m
-[33m[tester::#WE1] [0m[94mclient: > EXEC[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "*0\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP array: [][0m
-[33m[tester::#WE1] [0m[36m[0m
-[33m[tester::#WE1] [0m[92mReceived [][0m
-[33m[tester::#WE1] [0m[92m[0m
-[33m[tester::#WE1] [0m[94mclient: > EXEC[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "-ERR EXEC without MULTI\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP error: "ERR: ERR EXEC without MULTI"[0m
-[33m[tester::#WE1] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#WE1] [client] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#WE1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#WE1] [client] [0m[94m> EXEC[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "*0\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP array: [][0m
+[33m[tester::#WE1] [client] [0m[92mReceived [][0m
+[33m[tester::#WE1] [client] [0m[94m> EXEC[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "-ERR EXEC without MULTI\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP error: "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#WE1] [client] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
 [33m[tester::#WE1] [0m[92mTest passed.[0m
 [33m[tester::#WE1] [0m[36mTerminating program[0m
 [33m[tester::#WE1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#LO4] [0m[94mRunning tests for Stage #LO4 (lo4)[0m
 [33m[tester::#LO4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LO4] [0m[94mclient: $ redis-cli EXEC[0m
-[33m[tester::#LO4] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#LO4] [0m[36mclient: Received bytes: "-ERR EXEC without MULTI\r\n"[0m
-[33m[tester::#LO4] [0m[36mclient: Received RESP error: "ERR: ERR EXEC without MULTI"[0m
-[33m[tester::#LO4] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#LO4] [client] [0m[94m$ redis-cli EXEC[0m
+[33m[tester::#LO4] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#LO4] [client] [0m[36mReceived bytes: "-ERR EXEC without MULTI\r\n"[0m
+[33m[tester::#LO4] [client] [0m[36mReceived RESP error: "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#LO4] [client] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
 [33m[tester::#LO4] [0m[92mTest passed.[0m
 [33m[tester::#LO4] [0m[36mTerminating program[0m
 [33m[tester::#LO4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#PN0] [0m[94mRunning tests for Stage #PN0 (pn0)[0m
 [33m[tester::#PN0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#PN0] [0m[94mclient: $ redis-cli MULTI[0m
-[33m[tester::#PN0] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#PN0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#PN0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#PN0] [0m[92mReceived "OK"[0m
+[33m[tester::#PN0] [client] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#PN0] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#PN0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#PN0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#PN0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#PN0] [0m[92mTest passed.[0m
 [33m[tester::#PN0] [0m[36mTerminating program[0m
 [33m[tester::#PN0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MK1] [0m[94mRunning tests for Stage #MK1 (mk1)[0m
 [33m[tester::#MK1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#MK1] [0m[94mclient: $ redis-cli SET strawberry pear[0m
-[33m[tester::#MK1] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$4\r\npear\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#MK1] [0m[92mReceived "OK"[0m
-[33m[tester::#MK1] [0m[94mclient: > INCR strawberry[0m
-[33m[tester::#MK1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received bytes: "-ERR value is not an integer or out of range\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received RESP error: "ERR: ERR value is not an integer or out of range"[0m
-[33m[tester::#MK1] [0m[92mReceived "ERR: ERR value is not an integer or out of range"[0m
+[33m[tester::#MK1] [client] [0m[94m$ redis-cli SET strawberry pear[0m
+[33m[tester::#MK1] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$4\r\npear\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#MK1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#MK1] [client] [0m[94m> INCR strawberry[0m
+[33m[tester::#MK1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived bytes: "-ERR value is not an integer or out of range\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived RESP error: "ERR: ERR value is not an integer or out of range"[0m
+[33m[tester::#MK1] [client] [0m[92mReceived "ERR: ERR value is not an integer or out of range"[0m
 [33m[tester::#MK1] [0m[92mTest passed.[0m
 [33m[tester::#MK1] [0m[36mTerminating program[0m
 [33m[tester::#MK1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#LZ8] [0m[94mRunning tests for Stage #LZ8 (lz8)[0m
 [33m[tester::#LZ8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LZ8] [0m[94mclient: $ redis-cli INCR mango[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP integer: 1[0m
-[33m[tester::#LZ8] [0m[92mReceived 1[0m
-[33m[tester::#LZ8] [0m[94mclient: > INCR mango[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#LZ8] [0m[92mReceived 2[0m
-[33m[tester::#LZ8] [0m[94mclient: > GET mango[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: "$1\r\n2\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP bulk string: "2"[0m
-[33m[tester::#LZ8] [0m[92mReceived "2"[0m
+[33m[tester::#LZ8] [client] [0m[94m$ redis-cli INCR mango[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived 1[0m
+[33m[tester::#LZ8] [client] [0m[94m> INCR mango[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived 2[0m
+[33m[tester::#LZ8] [client] [0m[94m> GET mango[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: "$1\r\n2\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP bulk string: "2"[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived "2"[0m
 [33m[tester::#LZ8] [0m[92mTest passed.[0m
 [33m[tester::#LZ8] [0m[36mTerminating program[0m
 [33m[tester::#LZ8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SI4] [0m[94mRunning tests for Stage #SI4 (si4)[0m
 [33m[tester::#SI4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SI4] [0m[94mclient: $ redis-cli SET apple 29[0m
-[33m[tester::#SI4] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n29\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#SI4] [0m[92mReceived "OK"[0m
-[33m[tester::#SI4] [0m[94mclient: > INCR apple[0m
-[33m[tester::#SI4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received bytes: ":30\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received RESP integer: 30[0m
-[33m[tester::#SI4] [0m[92mReceived 30[0m
+[33m[tester::#SI4] [client] [0m[94m$ redis-cli SET apple 29[0m
+[33m[tester::#SI4] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n29\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SI4] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#SI4] [client] [0m[94m> INCR apple[0m
+[33m[tester::#SI4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived bytes: ":30\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived RESP integer: 30[0m
+[33m[tester::#SI4] [client] [0m[92mReceived 30[0m
 [33m[tester::#SI4] [0m[92mTest passed.[0m
 [33m[tester::#SI4] [0m[36mTerminating program[0m
 [33m[tester::#SI4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XU1] [0m[94mRunning tests for Stage #XU1 (xu1)[0m
 [33m[tester::#XU1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU1] [0m[94mredis-cli: $ redis-cli XADD blueberry 0-1 temperature 52[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n52\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP bulk string: "0-1"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-1"[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 0 streams blueberry $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[94mother-redis-cli: $ redis-cli XADD blueberry 0-2 temperature 90[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n90\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received RESP bulk string: "0-2"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-2"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n90\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP array: [[0m
-[33m[tester::#XU1] [0m[36m  [[0m
-[33m[tester::#XU1] [0m[36m    "blueberry",[0m
-[33m[tester::#XU1] [0m[36m    [[0m
-[33m[tester::#XU1] [0m[36m      [[0m
-[33m[tester::#XU1] [0m[36m        "0-2",[0m
-[33m[tester::#XU1] [0m[36m        ["temperature", "90"][0m
-[33m[tester::#XU1] [0m[36m      ][0m
-[33m[tester::#XU1] [0m[36m    ][0m
-[33m[tester::#XU1] [0m[36m  ][0m
-[33m[tester::#XU1] [0m[36m][0m
-[33m[tester::#XU1] [0m[36m[0m
-[33m[tester::#XU1] [0m[92mReceived [[0m
-[33m[tester::#XU1] [0m[92m  [[0m
-[33m[tester::#XU1] [0m[92m    "blueberry",[0m
-[33m[tester::#XU1] [0m[92m    [[0m
-[33m[tester::#XU1] [0m[92m      [[0m
-[33m[tester::#XU1] [0m[92m        "0-2",[0m
-[33m[tester::#XU1] [0m[92m        ["temperature", "90"][0m
-[33m[tester::#XU1] [0m[92m      ][0m
-[33m[tester::#XU1] [0m[92m    ][0m
-[33m[tester::#XU1] [0m[92m  ][0m
-[33m[tester::#XU1] [0m[92m][0m
-[33m[tester::#XU1] [0m[92m[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 1000 streams blueberry $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#XU1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94m$ redis-cli XADD blueberry 0-1 temperature 52[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n52\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 0 streams blueberry $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94mSleeping for 1000 ms[0m
+[33m[tester::#XU1] [client-2] [0m[94m$ redis-cli XADD blueberry 0-2 temperature 90[0m
+[33m[tester::#XU1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n90\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#XU1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n90\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XU1] [client-1] [0m[36m  [[0m
+[33m[tester::#XU1] [client-1] [0m[36m    "blueberry",[0m
+[33m[tester::#XU1] [client-1] [0m[36m    [[0m
+[33m[tester::#XU1] [client-1] [0m[36m      [[0m
+[33m[tester::#XU1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[36m        ["temperature", "90"][0m
+[33m[tester::#XU1] [client-1] [0m[36m      ][0m
+[33m[tester::#XU1] [client-1] [0m[36m    ][0m
+[33m[tester::#XU1] [client-1] [0m[36m  ][0m
+[33m[tester::#XU1] [client-1] [0m[36m][0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#XU1] [client-1] [0m[92m  [[0m
+[33m[tester::#XU1] [client-1] [0m[92m    "blueberry",[0m
+[33m[tester::#XU1] [client-1] [0m[92m    [[0m
+[33m[tester::#XU1] [client-1] [0m[92m      [[0m
+[33m[tester::#XU1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[92m        ["temperature", "90"][0m
+[33m[tester::#XU1] [client-1] [0m[92m      ][0m
+[33m[tester::#XU1] [client-1] [0m[92m    ][0m
+[33m[tester::#XU1] [client-1] [0m[92m  ][0m
+[33m[tester::#XU1] [client-1] [0m[92m][0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 1000 streams blueberry $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#XU1] [0m[92mTest passed.[0m
 [33m[tester::#XU1] [0m[36mTerminating program[0m
 [33m[tester::#XU1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HW1] [0m[94mRunning tests for Stage #HW1 (hw1)[0m
 [33m[tester::#HW1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HW1] [0m[94mclient-1: $ redis-cli XADD pineapple 0-1 temperature 68[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-1"[0m
-[33m[tester::#HW1] [0m[94mclient-1: > XREAD block 0 streams pineapple 0-1[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[94mclient-2: $ redis-cli XADD pineapple 0-2 temperature 68[0m
-[33m[tester::#HW1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-2"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#HW1] [0m[36m  [[0m
-[33m[tester::#HW1] [0m[36m    "pineapple",[0m
-[33m[tester::#HW1] [0m[36m    [[0m
-[33m[tester::#HW1] [0m[36m      [[0m
-[33m[tester::#HW1] [0m[36m        "0-2",[0m
-[33m[tester::#HW1] [0m[36m        ["temperature", "68"][0m
-[33m[tester::#HW1] [0m[36m      ][0m
-[33m[tester::#HW1] [0m[36m    ][0m
-[33m[tester::#HW1] [0m[36m  ][0m
-[33m[tester::#HW1] [0m[36m][0m
-[33m[tester::#HW1] [0m[36m[0m
-[33m[tester::#HW1] [0m[92mReceived [[0m
-[33m[tester::#HW1] [0m[92m  [[0m
-[33m[tester::#HW1] [0m[92m    "pineapple",[0m
-[33m[tester::#HW1] [0m[92m    [[0m
-[33m[tester::#HW1] [0m[92m      [[0m
-[33m[tester::#HW1] [0m[92m        "0-2",[0m
-[33m[tester::#HW1] [0m[92m        ["temperature", "68"][0m
-[33m[tester::#HW1] [0m[92m      ][0m
-[33m[tester::#HW1] [0m[92m    ][0m
-[33m[tester::#HW1] [0m[92m  ][0m
-[33m[tester::#HW1] [0m[92m][0m
-[33m[tester::#HW1] [0m[92m[0m
+[33m[tester::#HW1] [client-1] [0m[94m$ redis-cli XADD pineapple 0-1 temperature 68[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[94m> XREAD block 0 streams pineapple 0-1[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[94m$ redis-cli XADD pineapple 0-2 temperature 68[0m
+[33m[tester::#HW1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#HW1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n68\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#HW1] [client-1] [0m[36m  [[0m
+[33m[tester::#HW1] [client-1] [0m[36m    "pineapple",[0m
+[33m[tester::#HW1] [client-1] [0m[36m    [[0m
+[33m[tester::#HW1] [client-1] [0m[36m      [[0m
+[33m[tester::#HW1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[36m        ["temperature", "68"][0m
+[33m[tester::#HW1] [client-1] [0m[36m      ][0m
+[33m[tester::#HW1] [client-1] [0m[36m    ][0m
+[33m[tester::#HW1] [client-1] [0m[36m  ][0m
+[33m[tester::#HW1] [client-1] [0m[36m][0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#HW1] [client-1] [0m[92m  [[0m
+[33m[tester::#HW1] [client-1] [0m[92m    "pineapple",[0m
+[33m[tester::#HW1] [client-1] [0m[92m    [[0m
+[33m[tester::#HW1] [client-1] [0m[92m      [[0m
+[33m[tester::#HW1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[92m        ["temperature", "68"][0m
+[33m[tester::#HW1] [client-1] [0m[92m      ][0m
+[33m[tester::#HW1] [client-1] [0m[92m    ][0m
+[33m[tester::#HW1] [client-1] [0m[92m  ][0m
+[33m[tester::#HW1] [client-1] [0m[92m][0m
 [33m[tester::#HW1] [0m[92mTest passed.[0m
 [33m[tester::#HW1] [0m[36mTerminating program[0m
 [33m[tester::#HW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#BS1] [0m[94mRunning tests for Stage #BS1 (bs1)[0m
 [33m[tester::#BS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#BS1] [0m[94mclient-1: $ redis-cli XADD strawberry 0-1 temperature 99[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#BS1] [0m[94mWaiting for 500ms[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams strawberry 0-1[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[94mclient-2: $ redis-cli XADD strawberry 0-2 temperature 72[0m
-[33m[tester::#BS1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n72\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n72\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#BS1] [0m[36m  [[0m
-[33m[tester::#BS1] [0m[36m    "strawberry",[0m
-[33m[tester::#BS1] [0m[36m    [[0m
-[33m[tester::#BS1] [0m[36m      [[0m
-[33m[tester::#BS1] [0m[36m        "0-2",[0m
-[33m[tester::#BS1] [0m[36m        ["temperature", "72"][0m
-[33m[tester::#BS1] [0m[36m      ][0m
-[33m[tester::#BS1] [0m[36m    ][0m
-[33m[tester::#BS1] [0m[36m  ][0m
-[33m[tester::#BS1] [0m[36m][0m
-[33m[tester::#BS1] [0m[36m[0m
-[33m[tester::#BS1] [0m[92mReceived [[0m
-[33m[tester::#BS1] [0m[92m  [[0m
-[33m[tester::#BS1] [0m[92m    "strawberry",[0m
-[33m[tester::#BS1] [0m[92m    [[0m
-[33m[tester::#BS1] [0m[92m      [[0m
-[33m[tester::#BS1] [0m[92m        "0-2",[0m
-[33m[tester::#BS1] [0m[92m        ["temperature", "72"][0m
-[33m[tester::#BS1] [0m[92m      ][0m
-[33m[tester::#BS1] [0m[92m    ][0m
-[33m[tester::#BS1] [0m[92m  ][0m
-[33m[tester::#BS1] [0m[92m][0m
-[33m[tester::#BS1] [0m[92m[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams strawberry 0-2[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#BS1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94m$ redis-cli XADD strawberry 0-1 temperature 99[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams strawberry 0-1[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94mWaiting for 500 ms[0m
+[33m[tester::#BS1] [client-2] [0m[94m$ redis-cli XADD strawberry 0-2 temperature 72[0m
+[33m[tester::#BS1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n72\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#BS1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n72\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#BS1] [client-1] [0m[36m  [[0m
+[33m[tester::#BS1] [client-1] [0m[36m    "strawberry",[0m
+[33m[tester::#BS1] [client-1] [0m[36m    [[0m
+[33m[tester::#BS1] [client-1] [0m[36m      [[0m
+[33m[tester::#BS1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[36m        ["temperature", "72"][0m
+[33m[tester::#BS1] [client-1] [0m[36m      ][0m
+[33m[tester::#BS1] [client-1] [0m[36m    ][0m
+[33m[tester::#BS1] [client-1] [0m[36m  ][0m
+[33m[tester::#BS1] [client-1] [0m[36m][0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#BS1] [client-1] [0m[92m  [[0m
+[33m[tester::#BS1] [client-1] [0m[92m    "strawberry",[0m
+[33m[tester::#BS1] [client-1] [0m[92m    [[0m
+[33m[tester::#BS1] [client-1] [0m[92m      [[0m
+[33m[tester::#BS1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[92m        ["temperature", "72"][0m
+[33m[tester::#BS1] [client-1] [0m[92m      ][0m
+[33m[tester::#BS1] [client-1] [0m[92m    ][0m
+[33m[tester::#BS1] [client-1] [0m[92m  ][0m
+[33m[tester::#BS1] [client-1] [0m[92m][0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams strawberry 0-2[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#BS1] [0m[92mTest passed.[0m
 [33m[tester::#BS1] [0m[36mTerminating program[0m
 [33m[tester::#BS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RU9] [0m[94mRunning tests for Stage #RU9 (ru9)[0m
 [33m[tester::#RU9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RU9] [0m[94mclient: $ redis-cli XADD pineapple 0-1 temperature 0[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-1"[0m
-[33m[tester::#RU9] [0m[94mclient: > XADD orange 0-2 humidity 1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-2"[0m
-[33m[tester::#RU9] [0m[94mclient: > XREAD streams pineapple orange 0-0 0-1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$6\r\norange\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "*2\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$6\r\norange\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "pineapple",[0m
-[33m[tester::#RU9] [0m[36m    [[0m
-[33m[tester::#RU9] [0m[36m      [[0m
-[33m[tester::#RU9] [0m[36m        "0-1",[0m
-[33m[tester::#RU9] [0m[36m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[36m      ][0m
-[33m[tester::#RU9] [0m[36m    ][0m
-[33m[tester::#RU9] [0m[36m  ],[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "orange",[0m
-[33m[tester::#RU9] [0m[36m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[36m  ][0m
-[33m[tester::#RU9] [0m[36m][0m
-[33m[tester::#RU9] [0m[36m[0m
-[33m[tester::#RU9] [0m[92mReceived [[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "pineapple",[0m
-[33m[tester::#RU9] [0m[92m    [[0m
-[33m[tester::#RU9] [0m[92m      [[0m
-[33m[tester::#RU9] [0m[92m        "0-1",[0m
-[33m[tester::#RU9] [0m[92m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[92m      ][0m
-[33m[tester::#RU9] [0m[92m    ][0m
-[33m[tester::#RU9] [0m[92m  ],[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "orange",[0m
-[33m[tester::#RU9] [0m[92m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[92m  ][0m
-[33m[tester::#RU9] [0m[92m][0m
-[33m[tester::#RU9] [0m[92m[0m
+[33m[tester::#RU9] [client] [0m[94m$ redis-cli XADD pineapple 0-1 temperature 0[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#RU9] [client] [0m[94m> XADD orange 0-2 humidity 1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#RU9] [client] [0m[94m> XREAD streams pineapple orange 0-0 0-1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$6\r\norange\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "*2\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$6\r\norange\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "pineapple",[0m
+[33m[tester::#RU9] [client] [0m[36m    [[0m
+[33m[tester::#RU9] [client] [0m[36m      [[0m
+[33m[tester::#RU9] [client] [0m[36m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[36m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[36m      ][0m
+[33m[tester::#RU9] [client] [0m[36m    ][0m
+[33m[tester::#RU9] [client] [0m[36m  ],[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "orange",[0m
+[33m[tester::#RU9] [client] [0m[36m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[36m  ][0m
+[33m[tester::#RU9] [client] [0m[36m][0m
+[33m[tester::#RU9] [client] [0m[92mReceived [[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "pineapple",[0m
+[33m[tester::#RU9] [client] [0m[92m    [[0m
+[33m[tester::#RU9] [client] [0m[92m      [[0m
+[33m[tester::#RU9] [client] [0m[92m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[92m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[92m      ][0m
+[33m[tester::#RU9] [client] [0m[92m    ][0m
+[33m[tester::#RU9] [client] [0m[92m  ],[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "orange",[0m
+[33m[tester::#RU9] [client] [0m[92m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[92m  ][0m
+[33m[tester::#RU9] [client] [0m[92m][0m
 [33m[tester::#RU9] [0m[92mTest passed.[0m
 [33m[tester::#RU9] [0m[36mTerminating program[0m
 [33m[tester::#RU9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#UM0] [0m[94mRunning tests for Stage #UM0 (um0)[0m
 [33m[tester::#UM0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#UM0] [0m[94mclient: $ redis-cli XADD strawberry 0-1 temperature 75[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n75\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#UM0] [0m[92mReceived "0-1"[0m
-[33m[tester::#UM0] [0m[94mclient: > XREAD streams strawberry 0-0[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-0\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "*1\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n75\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#UM0] [0m[36m  [[0m
-[33m[tester::#UM0] [0m[36m    "strawberry",[0m
-[33m[tester::#UM0] [0m[36m    [[0m
-[33m[tester::#UM0] [0m[36m      [[0m
-[33m[tester::#UM0] [0m[36m        "0-1",[0m
-[33m[tester::#UM0] [0m[36m        ["temperature", "75"][0m
-[33m[tester::#UM0] [0m[36m      ][0m
-[33m[tester::#UM0] [0m[36m    ][0m
-[33m[tester::#UM0] [0m[36m  ][0m
-[33m[tester::#UM0] [0m[36m][0m
-[33m[tester::#UM0] [0m[36m[0m
-[33m[tester::#UM0] [0m[92mReceived [[0m
-[33m[tester::#UM0] [0m[92m  [[0m
-[33m[tester::#UM0] [0m[92m    "strawberry",[0m
-[33m[tester::#UM0] [0m[92m    [[0m
-[33m[tester::#UM0] [0m[92m      [[0m
-[33m[tester::#UM0] [0m[92m        "0-1",[0m
-[33m[tester::#UM0] [0m[92m        ["temperature", "75"][0m
-[33m[tester::#UM0] [0m[92m      ][0m
-[33m[tester::#UM0] [0m[92m    ][0m
-[33m[tester::#UM0] [0m[92m  ][0m
-[33m[tester::#UM0] [0m[92m][0m
-[33m[tester::#UM0] [0m[92m[0m
+[33m[tester::#UM0] [client] [0m[94m$ redis-cli XADD strawberry 0-1 temperature 75[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n75\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#UM0] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#UM0] [client] [0m[94m> XREAD streams strawberry 0-0[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$3\r\n0-0\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "*1\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n75\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#UM0] [client] [0m[36m  [[0m
+[33m[tester::#UM0] [client] [0m[36m    "strawberry",[0m
+[33m[tester::#UM0] [client] [0m[36m    [[0m
+[33m[tester::#UM0] [client] [0m[36m      [[0m
+[33m[tester::#UM0] [client] [0m[36m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[36m        ["temperature", "75"][0m
+[33m[tester::#UM0] [client] [0m[36m      ][0m
+[33m[tester::#UM0] [client] [0m[36m    ][0m
+[33m[tester::#UM0] [client] [0m[36m  ][0m
+[33m[tester::#UM0] [client] [0m[36m][0m
+[33m[tester::#UM0] [client] [0m[92mReceived [[0m
+[33m[tester::#UM0] [client] [0m[92m  [[0m
+[33m[tester::#UM0] [client] [0m[92m    "strawberry",[0m
+[33m[tester::#UM0] [client] [0m[92m    [[0m
+[33m[tester::#UM0] [client] [0m[92m      [[0m
+[33m[tester::#UM0] [client] [0m[92m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[92m        ["temperature", "75"][0m
+[33m[tester::#UM0] [client] [0m[92m      ][0m
+[33m[tester::#UM0] [client] [0m[92m    ][0m
+[33m[tester::#UM0] [client] [0m[92m  ][0m
+[33m[tester::#UM0] [client] [0m[92m][0m
 [33m[tester::#UM0] [0m[92mTest passed.[0m
 [33m[tester::#UM0] [0m[36mTerminating program[0m
 [33m[tester::#UM0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FS1] [0m[94mRunning tests for Stage #FS1 (fs1)[0m
 [33m[tester::#FS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FS1] [0m[94mclient: $ redis-cli XADD grape 0-1 grape blueberry[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD grape 0-2 apple pear[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-2\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD grape 0-3 pear blueberry[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-3\r\n$4\r\npear\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-3"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD grape 0-4 banana pineapple[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-4\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-4\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-4"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-4"[0m
-[33m[tester::#FS1] [0m[94mclient: > XRANGE grape 0-1 +[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$1\r\n+\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "*4\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\napple\r\n$4\r\npear\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$4\r\npear\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#FS1] [0m[36m  [[0m
-[33m[tester::#FS1] [0m[36m    "0-1",[0m
-[33m[tester::#FS1] [0m[36m    ["grape", "blueberry"][0m
-[33m[tester::#FS1] [0m[36m  ],[0m
-[33m[tester::#FS1] [0m[36m  ["0-2", ["apple", "pear"]],[0m
-[33m[tester::#FS1] [0m[36m  ["0-3", ["pear", "blueberry"]],[0m
-[33m[tester::#FS1] [0m[36m  [[0m
-[33m[tester::#FS1] [0m[36m    "0-4",[0m
-[33m[tester::#FS1] [0m[36m    ["banana", "pineapple"][0m
-[33m[tester::#FS1] [0m[36m  ][0m
-[33m[tester::#FS1] [0m[36m][0m
-[33m[tester::#FS1] [0m[36m[0m
-[33m[tester::#FS1] [0m[92mReceived [[0m
-[33m[tester::#FS1] [0m[92m  [[0m
-[33m[tester::#FS1] [0m[92m    "0-1",[0m
-[33m[tester::#FS1] [0m[92m    ["grape", "blueberry"][0m
-[33m[tester::#FS1] [0m[92m  ],[0m
-[33m[tester::#FS1] [0m[92m  ["0-2", ["apple", "pear"]],[0m
-[33m[tester::#FS1] [0m[92m  ["0-3", ["pear", "blueberry"]],[0m
-[33m[tester::#FS1] [0m[92m  [[0m
-[33m[tester::#FS1] [0m[92m    "0-4",[0m
-[33m[tester::#FS1] [0m[92m    ["banana", "pineapple"][0m
-[33m[tester::#FS1] [0m[92m  ][0m
-[33m[tester::#FS1] [0m[92m][0m
-[33m[tester::#FS1] [0m[92m[0m
+[33m[tester::#FS1] [client] [0m[94m$ redis-cli XADD grape 0-1 grape blueberry[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD grape 0-2 apple pear[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-2\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD grape 0-3 pear blueberry[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-3\r\n$4\r\npear\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD grape 0-4 banana pineapple[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-4\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-4\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-4"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-4"[0m
+[33m[tester::#FS1] [client] [0m[94m> XRANGE grape 0-1 +[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$1\r\n+\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "*4\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\napple\r\n$4\r\npear\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$4\r\npear\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#FS1] [client] [0m[36m  [[0m
+[33m[tester::#FS1] [client] [0m[36m    "0-1",[0m
+[33m[tester::#FS1] [client] [0m[36m    ["grape", "blueberry"][0m
+[33m[tester::#FS1] [client] [0m[36m  ],[0m
+[33m[tester::#FS1] [client] [0m[36m  ["0-2", ["apple", "pear"]],[0m
+[33m[tester::#FS1] [client] [0m[36m  ["0-3", ["pear", "blueberry"]],[0m
+[33m[tester::#FS1] [client] [0m[36m  [[0m
+[33m[tester::#FS1] [client] [0m[36m    "0-4",[0m
+[33m[tester::#FS1] [client] [0m[36m    ["banana", "pineapple"][0m
+[33m[tester::#FS1] [client] [0m[36m  ][0m
+[33m[tester::#FS1] [client] [0m[36m][0m
+[33m[tester::#FS1] [client] [0m[92mReceived [[0m
+[33m[tester::#FS1] [client] [0m[92m  [[0m
+[33m[tester::#FS1] [client] [0m[92m    "0-1",[0m
+[33m[tester::#FS1] [client] [0m[92m    ["grape", "blueberry"][0m
+[33m[tester::#FS1] [client] [0m[92m  ],[0m
+[33m[tester::#FS1] [client] [0m[92m  ["0-2", ["apple", "pear"]],[0m
+[33m[tester::#FS1] [client] [0m[92m  ["0-3", ["pear", "blueberry"]],[0m
+[33m[tester::#FS1] [client] [0m[92m  [[0m
+[33m[tester::#FS1] [client] [0m[92m    "0-4",[0m
+[33m[tester::#FS1] [client] [0m[92m    ["banana", "pineapple"][0m
+[33m[tester::#FS1] [client] [0m[92m  ][0m
+[33m[tester::#FS1] [client] [0m[92m][0m
 [33m[tester::#FS1] [0m[92mTest passed.[0m
 [33m[tester::#FS1] [0m[36mTerminating program[0m
 [33m[tester::#FS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YP1] [0m[94mRunning tests for Stage #YP1 (yp1)[0m
 [33m[tester::#YP1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YP1] [0m[94mclient: $ redis-cli XADD pineapple 0-1 pineapple raspberry[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-1"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD pineapple 0-2 blueberry strawberry[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-2"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD pineapple 0-3 banana pear[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-3\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-3"[0m
-[33m[tester::#YP1] [0m[94mclient: > XRANGE pineapple - 0-3[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\npineapple\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-1",[0m
-[33m[tester::#YP1] [0m[36m    ["pineapple", "raspberry"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-2",[0m
-[33m[tester::#YP1] [0m[36m    ["blueberry", "strawberry"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  ["0-3", ["banana", "pear"]][0m
-[33m[tester::#YP1] [0m[36m][0m
-[33m[tester::#YP1] [0m[36m[0m
-[33m[tester::#YP1] [0m[92mReceived [[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-1",[0m
-[33m[tester::#YP1] [0m[92m    ["pineapple", "raspberry"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-2",[0m
-[33m[tester::#YP1] [0m[92m    ["blueberry", "strawberry"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  ["0-3", ["banana", "pear"]][0m
-[33m[tester::#YP1] [0m[92m][0m
-[33m[tester::#YP1] [0m[92m[0m
+[33m[tester::#YP1] [client] [0m[94m$ redis-cli XADD pineapple 0-1 pineapple raspberry[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD pineapple 0-2 blueberry strawberry[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD pineapple 0-3 banana pear[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-3\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#YP1] [client] [0m[94m> XRANGE pineapple - 0-3[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\npineapple\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["pineapple", "raspberry"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["blueberry", "strawberry"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  ["0-3", ["banana", "pear"]][0m
+[33m[tester::#YP1] [client] [0m[36m][0m
+[33m[tester::#YP1] [client] [0m[92mReceived [[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["pineapple", "raspberry"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["blueberry", "strawberry"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  ["0-3", ["banana", "pear"]][0m
+[33m[tester::#YP1] [client] [0m[92m][0m
 [33m[tester::#YP1] [0m[92mTest passed.[0m
 [33m[tester::#YP1] [0m[36mTerminating program[0m
 [33m[tester::#YP1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZX1] [0m[94mRunning tests for Stage #ZX1 (zx1)[0m
 [33m[tester::#ZX1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZX1] [0m[94mclient: $ redis-cli XADD apple 0-1 apple mango[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-1\r\n$5\r\napple\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-1"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD apple 0-2 mango pear[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-2"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD apple 0-3 raspberry grape[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-3\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-3"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD apple 0-4 pineapple grape[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-4\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-4\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-4"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-4"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XRANGE apple 0-2 0-4[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\napple\r\n$3\r\n0-2\r\n$3\r\n0-4\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "*3\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\nmango\r\n$4\r\npear\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZX1] [0m[36m  ["0-2", ["mango", "pear"]],[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-3",[0m
-[33m[tester::#ZX1] [0m[36m    ["raspberry", "grape"][0m
-[33m[tester::#ZX1] [0m[36m  ],[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-4",[0m
-[33m[tester::#ZX1] [0m[36m    ["pineapple", "grape"][0m
-[33m[tester::#ZX1] [0m[36m  ][0m
-[33m[tester::#ZX1] [0m[36m][0m
-[33m[tester::#ZX1] [0m[36m[0m
-[33m[tester::#ZX1] [0m[92mReceived [[0m
-[33m[tester::#ZX1] [0m[92m  ["0-2", ["mango", "pear"]],[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-3",[0m
-[33m[tester::#ZX1] [0m[92m    ["raspberry", "grape"][0m
-[33m[tester::#ZX1] [0m[92m  ],[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-4",[0m
-[33m[tester::#ZX1] [0m[92m    ["pineapple", "grape"][0m
-[33m[tester::#ZX1] [0m[92m  ][0m
-[33m[tester::#ZX1] [0m[92m][0m
-[33m[tester::#ZX1] [0m[92m[0m
+[33m[tester::#ZX1] [client] [0m[94m$ redis-cli XADD apple 0-1 apple mango[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-1\r\n$5\r\napple\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD apple 0-2 mango pear[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD apple 0-3 raspberry grape[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-3\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD apple 0-4 pineapple grape[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-4\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-4\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-4"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-4"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XRANGE apple 0-2 0-4[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\napple\r\n$3\r\n0-2\r\n$3\r\n0-4\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "*3\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\nmango\r\n$4\r\npear\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#ZX1] [client] [0m[36m  ["0-2", ["mango", "pear"]],[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["raspberry", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ],[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-4",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["pineapple", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ][0m
+[33m[tester::#ZX1] [client] [0m[36m][0m
+[33m[tester::#ZX1] [client] [0m[92mReceived [[0m
+[33m[tester::#ZX1] [client] [0m[92m  ["0-2", ["mango", "pear"]],[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["raspberry", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ],[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-4",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["pineapple", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ][0m
+[33m[tester::#ZX1] [client] [0m[92m][0m
 [33m[tester::#ZX1] [0m[92mTest passed.[0m
 [33m[tester::#ZX1] [0m[36mTerminating program[0m
 [33m[tester::#ZX1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XU6] [0m[94mRunning tests for Stage #XU6 (xu6)[0m
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD pear * foo bar[0m
-[33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946729976-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946729976-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751946729976-0"[0m
+[33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD pear * foo bar[0m
+[33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752030908717-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752030908717-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1752030908717-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1173,89 +1112,89 @@ Debug = true
 
 [33m[tester::#YH3] [0m[94mRunning tests for Stage #YH3 (yh3)[0m
 [33m[tester::#YH3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YH3] [0m[94mclient: $ redis-cli XADD pineapple 0-* raspberry orange[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-*\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "0-1"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD pineapple 1-* raspberry orange[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-*\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-0\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-0"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-0"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD pineapple 1-* orange pineapple[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-*\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-1"[0m
+[33m[tester::#YH3] [client] [0m[94m$ redis-cli XADD pineapple 0-* raspberry orange[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-*\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD pineapple 1-* raspberry orange[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-*\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-0\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-0"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-0"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD pineapple 1-* orange pineapple[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-*\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-1"[0m
 [33m[tester::#YH3] [0m[92mTest passed.[0m
 [33m[tester::#YH3] [0m[36mTerminating program[0m
 [33m[tester::#YH3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HQ8] [0m[94mRunning tests for Stage #HQ8 (hq8)[0m
 [33m[tester::#HQ8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HQ8] [0m[94mclient: $ redis-cli XADD strawberry 1-1 blueberry strawberry[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-1\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-1"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD strawberry 1-2 pineapple apple[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-2\r\n$9\r\npineapple\r\n$5\r\napple\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-2\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-2"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-2"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD strawberry 1-2 mango banana[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-2\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD strawberry 0-3 grape orange[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-3\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD strawberry 0-0 raspberry pear[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-0\r\n$9\r\nraspberry\r\n$4\r\npear\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[94m$ redis-cli XADD strawberry 1-1 blueberry strawberry[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-1\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD strawberry 1-2 pineapple apple[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-2\r\n$9\r\npineapple\r\n$5\r\napple\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-2\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD strawberry 1-2 mango banana[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n1-2\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD strawberry 0-3 grape orange[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-3\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD strawberry 0-0 raspberry pear[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-0\r\n$9\r\nraspberry\r\n$4\r\npear\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
 [33m[tester::#HQ8] [0m[92mTest passed.[0m
 [33m[tester::#HQ8] [0m[36mTerminating program[0m
 [33m[tester::#HQ8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF6] [0m[94mRunning tests for Stage #CF6 (cf6)[0m
 [33m[tester::#CF6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CF6] [0m[94mclient: $ redis-cli XADD orange 0-1 foo bar[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#CF6] [0m[92mReceived "0-1"[0m
-[33m[tester::#CF6] [0m[94mclient: > TYPE orange[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$6\r\norange\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "+stream\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP simple string: "stream"[0m
-[33m[tester::#CF6] [0m[92mReceived "stream"[0m
+[33m[tester::#CF6] [client] [0m[94m$ redis-cli XADD orange 0-1 foo bar[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\norange\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#CF6] [client] [0m[94m> TYPE orange[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$6\r\norange\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "+stream\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP simple string: "stream"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "stream"[0m
 [33m[tester::#CF6] [0m[92mTest passed.[0m
 [33m[tester::#CF6] [0m[36mTerminating program[0m
 [33m[tester::#CF6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CC3] [0m[94mRunning tests for Stage #CC3 (cc3)[0m
 [33m[tester::#CC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CC3] [0m[94mclient: $ redis-cli SET raspberry blueberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CC3] [0m[92mReceived "OK"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE raspberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+string\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "string"[0m
-[33m[tester::#CC3] [0m[92mReceived "string"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE missing_key_blueberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$21\r\nmissing_key_blueberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+none\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "none"[0m
-[33m[tester::#CC3] [0m[92mReceived "none"[0m
+[33m[tester::#CC3] [client] [0m[94m$ redis-cli SET raspberry blueberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE raspberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+string\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "string"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "string"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE missing_key_blueberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$21\r\nmissing_key_blueberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+none\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "none"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "none"[0m
 [33m[tester::#CC3] [0m[92mTest passed.[0m
 [33m[tester::#CC3] [0m[36mTerminating program[0m
 [33m[tester::#CC3] [0m[36mProgram terminated successfully[0m
@@ -1268,196 +1207,169 @@ Debug = true
 [33m[tester::#NA2] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#NA2] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6380[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\x9c\xc6k\x95\xe5\xfbc"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime½\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3bd8914a3dd7ecf4a0562390386aa2764ccf77eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffCϰo\xcbK\x0f\xbf"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff>\\\x91E\x889\xa1\x7f"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime½\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3bd8914a3dd7ecf4a0562390386aa2764ccf77eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfc\x0f\xe7A֗U\xa3"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC ca7b9303f1aa2ecb5436cb67553e43eb2a356765 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 3bd8914a3dd7ecf4a0562390386aa2764ccf77eb 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ca7b9303f1aa2ecb5436cb67553e43eb2a356765\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;\x8er\xdf\x14\r\xcf\xdf"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime½\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3bd8914a3dd7ecf4a0562390386aa2764ccf77eb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9\xdd\x04\xdbJ\xa3;\x03"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 1 500[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 1 500[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 54[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 54[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 1[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#NA2] [test] [0m[92mPassed first WAIT test.[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 3 2000[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$4\r\n2000\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 3 2000[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$4\r\n2000\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2006 ms[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2102 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1474,204 +1386,204 @@ Debug = true
 [33m[tester::#TU8] [setup] [0m[94m6. replica@6385 (Listening port = 6385)[0m
 [33m[tester::#TU8] [setup] [0m[94m7. replica@6386 (Listening port = 6386)[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6380[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmz\f\x9c\x19\a\x01M"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¿\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\x80\x131k͎\xb6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҺ[\xb2\x04\xdb[Q"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff+\xd7W\xca%\x1f\xf5\x92"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd7h\xb8(\x98\xef5\xf1"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.\x05\xb4P\xb9+\x9b2"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbe}\x8c\xe6 \xb5\\\x94"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffG\x10\x80\x9e\x01q\xf2W"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF listening-port 6384[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF listening-port 6384[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh\x12\x06Q\xadx͌"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x91\x7f\n)\x8c\xbccO"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > REPLCONF listening-port 6385[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> REPLCONF listening-port 6385[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xc0\xe5\xcb1L\xa3,"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x94\xad\xe9\xb3\x10\x88\r\xef"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > REPLCONF listening-port 6386[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6386\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b7564b9d0300593e3fea7bfe750d7ebb90a41b41 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> REPLCONF listening-port 6386[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6386\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 6287ec0278282e71658239a8deb0dc95391ff206 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\x95lh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b7564b9d0300593e3fea7bfe750d7ebb90a41b41\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x04\xd5\xd1\x05\x89\x16\xcaI"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\xdemh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6287ec0278282e71658239a8deb0dc95391ff206\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd\xb8\xdd}\xa8\xd2d\x8a"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 5 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 7 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 9 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n9\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 5 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 7 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 9 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n9\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
 [33m[tester::#TU8] [0m[92mTest passed.[0m
 [33m[tester::#TU8] [0m[36mTerminating program[0m
 [33m[tester::#TU8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MY8] [0m[94mRunning tests for Stage #MY8 (my8)[0m
 [33m[tester::#MY8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#MY8] [0m[94mclient: $ redis-cli WAIT 0 60000[0m
-[33m[tester::#MY8] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received bytes: ":0\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received RESP integer: 0[0m
-[33m[tester::#MY8] [0m[92mReceived 0[0m
+[33m[tester::#MY8] [client] [0m[94m$ redis-cli WAIT 0 60000[0m
+[33m[tester::#MY8] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived bytes: ":0\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived RESP integer: 0[0m
+[33m[tester::#MY8] [client] [0m[92mReceived 0[0m
 [33m[tester::#MY8] [0m[92mTest passed.[0m
 [33m[tester::#MY8] [0m[36mTerminating program[0m
 [33m[tester::#MY8] [0m[36mProgram terminated successfully[0m
@@ -1679,92 +1591,78 @@ Debug = true
 [33m[tester::#YD3] [0m[94mRunning tests for Stage #YD3 (yd3)[0m
 [33m[tester::#YD3] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YD3] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YD3] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > PING[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET strawberry raspberry[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET pear raspberry[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n171\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "171"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "171"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> PING[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET strawberry raspberry[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET pear raspberry[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n171\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "171"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "171"][0m
 [33m[tester::#YD3] [0m[92mTest passed.[0m
 [33m[tester::#YD3] [0m[36mTerminating program[0m
 [33m[tester::#YD3] [0m[36mProgram terminated successfully[0m
@@ -1772,72 +1670,62 @@ Debug = true
 [33m[tester::#XV6] [0m[94mRunning tests for Stage #XV6 (xv6)[0m
 [33m[tester::#XV6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#XV6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#XV6] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#XV6] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[36m[0m
-[33m[tester::#XV6] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[92m[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#XV6] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#XV6] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#XV6] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
 [33m[tester::#XV6] [0m[92mTest passed.[0m
 [33m[tester::#XV6] [0m[36mTerminating program[0m
 [33m[tester::#XV6] [0m[36mProgram terminated successfully[0m
@@ -1845,89 +1733,81 @@ Debug = true
 [33m[tester::#YG4] [0m[94mRunning tests for Stage #YG4 (yg4)[0m
 [33m[tester::#YG4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YG4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YG4] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET foo 123[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET bar 456[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET baz 789[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [0m[94mclient: $ redis-cli GET foo[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "123"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "123"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key bar[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET bar[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "456"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET bar[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "456"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key baz[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET baz[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "789"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET baz[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "789"[0m
 [33m[tester::#YG4] [0m[92mTest passed.[0m
 [33m[tester::#YG4] [0m[36mTerminating program[0m
 [33m[tester::#YG4] [0m[36mProgram terminated successfully[0m
@@ -1939,252 +1819,224 @@ Debug = true
 [33m[tester::#HD5] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#HD5] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6380[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7\xe0\xf6o+\x1d\x80\x18"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a207599d9b1e5da96345225369de2e1400c30d98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\x13\x88Wag\xf1\xad"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\x86\xc5!9s\x8d\xf8"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\xdemh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a207599d9b1e5da96345225369de2e1400c30d98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12u\xbb\x19s\t\xfcM"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d5111b312ed94ce85a6215708268b459ce2e2b48 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC a207599d9b1e5da96345225369de2e1400c30d98 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d5111b312ed94ce85a6215708268b459ce2e2b48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14[M\x82\x17\xd1\xe3\x9d"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc2\xdemh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a207599d9b1e5da96345225369de2e1400c30d98\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf5%MN\x03_0a"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 1/3: replica@6380[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 2/3: replica@6381[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 3/3: replica@6382[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [0m[92mTest passed.[0m
 [33m[tester::#HD5] [0m[36mTerminating program[0m
 [33m[tester::#HD5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZN8] [0m[94mRunning tests for Stage #ZN8 (zn8)[0m
 [33m[tester::#ZN8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: $ redis-cli PING[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF listening-port 6380[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF capa psync2[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC eab64bbe7f973ec5ab5890785e9d10913c7ab576 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC eab64bbe7f973ec5ab5890785e9d10913c7ab576 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC eab64bbe7f973ec5ab5890785e9d10913c7ab576 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6fcf1f0f7037c8fc248b8283b6f833c0c7a4efeb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe2\x92j\xe8d\x15]8"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc2\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eab64bbe7f973ec5ab5890785e9d10913c7ab576\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa7\xae\xdeQ\x19\xd3@\x19"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [test] [0m[92mSent 3 SET commands to master successfully.[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#ZN8] [0m[92mTest passed.[0m
 [33m[tester::#ZN8] [0m[36mTerminating program[0m
 [33m[tester::#ZN8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF8] [0m[94mRunning tests for Stage #CF8 (cf8)[0m
 [33m[tester::#CF8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#CF8] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#CF8] [0m[92mReceived "PONG"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 7b87f875117a557edb1eba1e578200fa10062e5c 0"[0m
+[33m[tester::#CF8] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 66baae8e447691947b52685edaf9fdf3253f84db 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 66baae8e447691947b52685edaf9fdf3253f84db 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 66baae8e447691947b52685edaf9fdf3253f84db 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xef\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b87f875117a557edb1eba1e578200fa10062e5c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffzڧ(BY\x96\xb7"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc2\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(66baae8e447691947b52685edaf9fdf3253f84db\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\n\xf7\xbb25ET\xe3"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2192,47 +2044,47 @@ Debug = true
 
 [33m[tester::#VM3] [0m[94mRunning tests for Stage #VM3 (vm3)[0m
 [33m[tester::#VM3] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#VM3] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#VM3] [0m[92mReceived "PONG"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 667ddaa36881ccf21911929d14b39a0a81052367 0"[0m
+[33m[tester::#VM3] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC de14db834c30fe6fe8d31be86b90794effcc4bd5 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC de14db834c30fe6fe8d31be86b90794effcc4bd5 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC de14db834c30fe6fe8d31be86b90794effcc4bd5 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FJ0] [0m[94mRunning tests for Stage #FJ0 (fj0)[0m
 [33m[tester::#FJ0] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#FJ0] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#FJ0] [0m[92mReceived "PONG"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#FJ0] [0m[92mTest passed.[0m
 [33m[tester::#FJ0] [0m[36mTerminating program[0m
 [33m[tester::#FJ0] [0m[36mProgram terminated successfully[0m
@@ -2240,62 +2092,54 @@ Debug = true
 [33m[tester::#JU6] [0m[94mRunning tests for Stage #JU6 (ju6)[0m
 [33m[tester::#JU6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#JU6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PING"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "listening-port",[0m
-[33m[tester::#JU6] [0m[36m  "6380"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "listening-port",[0m
-[33m[tester::#JU6] [0m[92m  "6380"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "eof",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "psync2",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "eof",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "psync2",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[36m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[92m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
 [33m[tester::#JU6] [0m[92mTest passed.[0m
 [33m[tester::#JU6] [0m[36mTerminating program[0m
 [33m[tester::#JU6] [0m[36mProgram terminated successfully[0m
@@ -2303,54 +2147,48 @@ Debug = true
 [33m[tester::#EH4] [0m[94mRunning tests for Stage #EH4 (eh4)[0m
 [33m[tester::#EH4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#EH4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived ["PING"][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "listening-port",[0m
-[33m[tester::#EH4] [0m[36m  "6380"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "listening-port",[0m
-[33m[tester::#EH4] [0m[92m  "6380"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "eof",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "psync2",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "eof",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "psync2",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#EH4] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#EH4] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[36m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[92m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
 [33m[tester::#EH4] [0m[92mTest passed.[0m
 [33m[tester::#EH4] [0m[36mTerminating program[0m
 [33m[tester::#EH4] [0m[36mProgram terminated successfully[0m
@@ -2358,25 +2196,23 @@ Debug = true
 [33m[tester::#GL7] [0m[94mRunning tests for Stage #GL7 (gl7)[0m
 [33m[tester::#GL7] [0m[94mMaster is running on port 6379.[0m
 [33m[tester::#GL7] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#GL7] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#GL7] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#GL7] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#GL7] [0m[36m[0m
-[33m[tester::#GL7] [0m[92mReceived ["PING"][0m
-[33m[tester::#GL7] [0m[92m[0m
-[33m[tester::#GL7] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#GL7] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
+[33m[tester::#GL7] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#GL7] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#GL7] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#GL7] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#GL7] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#GL7] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
 [33m[tester::#GL7] [0m[92mTest passed.[0m
 [33m[tester::#GL7] [0m[36mTerminating program[0m
 [33m[tester::#GL7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XC1] [0m[94mRunning tests for Stage #XC1 (xc1)[0m
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f9e49d4f3ee52cab682a209eea6bf1558492c78f\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:262deb40329695e3fc62cbdb9f91ed2b97080db1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:262deb40329695e3fc62cbdb9f91ed2b97080db1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:262deb40329695e3fc62cbdb9f91ed2b97080db1\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2386,11 +2222,11 @@ Debug = true
 [33m[tester::#HC6] [0m[94mRunning tests for Stage #HC6 (hc6)[0m
 [33m[tester::#HC6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#HC6] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#HC6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -2398,11 +2234,11 @@ Debug = true
 
 [33m[tester::#YE5] [0m[94mRunning tests for Stage #YE5 (ye5)[0m
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22f773bcc340819ffa59916cdd179002dae9aaa7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:24f45d1c20862c829858bf2bba48f35ceeebad04\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:24f45d1c20862c829858bf2bba48f35ceeebad04\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:24f45d1c20862c829858bf2bba48f35ceeebad04\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2432,21 +2268,21 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9439 --dbfilename pineapple.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET banana[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pineapple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#SM4] [0m[92mReceived "apple"[0m
+[33m[tester::#SM4] [client] [0m[94m$ redis-cli GET banana[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET pineapple[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET grape[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "apple"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
@@ -2466,26 +2302,26 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0070 | 22 42 53 9d 9d 75 69 c1                         | "BS..ui.[0m
 [33m[tester::#DQ3] [0m[36m[0m
 [33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2904 --dbfilename raspberry.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET orange[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
-[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "blueberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET grape[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#DQ3] [0m[92mReceived "banana"[0m
+[33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET orange[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "grape"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET raspberry[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "blueberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET pear[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET grape[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "banana"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "banana"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
@@ -2506,25 +2342,23 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9251 --dbfilename blueberry.rdb[0m
-[33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [0m[36m  "pineapple",[0m
-[33m[tester::#JW4] [0m[36m  "pear",[0m
-[33m[tester::#JW4] [0m[36m  "grape"[0m
-[33m[tester::#JW4] [0m[36m][0m
-[33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [0m[92m  "pineapple",[0m
-[33m[tester::#JW4] [0m[92m  "pear",[0m
-[33m[tester::#JW4] [0m[92m  "grape"[0m
-[33m[tester::#JW4] [0m[92m][0m
-[33m[tester::#JW4] [0m[92m[0m
+[33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pear",[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape"[0m
+[33m[tester::#JW4] [client] [0m[36m][0m
+[33m[tester::#JW4] [client] [0m[92mReceived [[0m
+[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pear",[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape"[0m
+[33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -2541,11 +2375,11 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0040 | 21 94                                           | !.[0m
 [33m[tester::#GC6] [0m[36m[0m
 [33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2337 --dbfilename apple.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pear[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#GC6] [0m[92mReceived "apple"[0m
+[33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pear[0m
+[33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#GC6] [client] [0m[92mReceived "apple"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
@@ -2562,51 +2396,47 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0040 | 43 23 e0 5a 6e 28 62                            | C#.Zn(b[0m
 [33m[tester::#JZ6] [0m[36m[0m
 [33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1316 --dbfilename apple.rdb[0m
-[33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["raspberry"][0m
-[33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["raspberry"][0m
-[33m[tester::#JZ6] [0m[92m[0m
+[33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived RESP array: ["raspberry"][0m
+[33m[tester::#JZ6] [client] [0m[92mReceived ["raspberry"][0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
 [33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5701 --dbfilename pineapple.rdb[0m
-[33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
-[33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5701\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-5701"][0m
-[33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-5701"][0m
-[33m[tester::#ZG5] [0m[92m[0m
+[33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
+[33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5701\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-5701"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-5701"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET mango blueberry px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:37:18.939[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:37:18.939 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET mango[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
-[33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET mango blueberry px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:00:17.840[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:00:17.840 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:37:19.042 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET mango[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 09:00:17.944 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -2614,89 +2444,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key mango to raspberry[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET mango raspberry[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET mango raspberry[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key mango[0m
-[33m[tester::#LA7] [0m[94m> GET mango[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "raspberry"[0m
-[33m[tester::#LA7] [0m[92mReceived "raspberry"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET mango[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "raspberry"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO orange[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "orange"[0m
-[33m[tester::#QQ0] [0m[92mReceived "orange"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO orange[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "orange"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -2704,11 +2534,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/ping-pong/eof
+++ b/internal/test_helpers/fixtures/ping-pong/eof
@@ -4,8 +4,8 @@ Debug = true
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mhey, binding to 6379
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[tester::#RG2] [0m[91mReceived: "" (no content received)[0m
 [33m[tester::#RG2] [0m[91m           ^ error[0m
 [33m[tester::#RG2] [0m[91mError: Expected start of a new RESP2 value (either +, -, :, $ or *)[0m

--- a/internal/test_helpers/fixtures/ping-pong/slow_response
+++ b/internal/test_helpers/fixtures/ping-pong/slow_response
@@ -1,8 +1,8 @@
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mhey, binding to 6379
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 
 [33m[tester::#JM1] [0m[94mRunning tests for Stage #JM1 (jm1)[0m

--- a/internal/test_helpers/fixtures/ping-pong/without_crlf
+++ b/internal/test_helpers/fixtures/ping-pong/without_crlf
@@ -1,7 +1,7 @@
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mhey, binding to 6379
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
 [33m[tester::#RG2] [0m[91mReceived: "+PONG"[0m
 [33m[tester::#RG2] [0m[91m                ^ error[0m
 [33m[tester::#RG2] [0m[91mError: Expected \r\n at the end of a simple string[0m

--- a/internal/test_helpers/fixtures/ping-pong/without_read_multiple_pongs
+++ b/internal/test_helpers/fixtures/ping-pong/without_read_multiple_pongs
@@ -1,6 +1,6 @@
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mLogs from your program will appear here!
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
 [33m[tester::#RG2] [0m[91mFound extra data: "+PONG\r\n+PONG\r\n"[0m
 [33m[tester::#RG2] [0m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -17,26 +17,26 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0090 | bd e8 ad 48 6f                                  | ...Ho[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6623 --dbfilename orange.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET blueberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#SM4] [0m[92mReceived "pear"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET mango[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pear[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#SM4] [0m[92mReceived "orange"[0m
+[33m[tester::#SM4] [client] [0m[94m$ redis-cli GET blueberry[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "pear"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET mango[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET grape[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET pear[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "orange"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
@@ -55,21 +55,21 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 91                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
 [33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2020 --dbfilename apple.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET apple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET grape[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#DQ3] [0m[92mReceived "orange"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pineapple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pear"[0m
+[33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET apple[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "mango"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "mango"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET grape[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "orange"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET pineapple[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "pear"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
@@ -88,13 +88,11 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 79 ff 68 0f 5f 46 25 26 d0 08                   | y.h._F%&..[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-7468 --dbfilename banana.rdb[0m
-[33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*3\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: ["blueberry", "mango", "apple"][0m
-[33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived ["blueberry", "mango", "apple"][0m
-[33m[tester::#JW4] [0m[92m[0m
+[33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$9\r\nblueberry\r\n$5\r\nmango\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: ["blueberry", "mango", "apple"][0m
+[33m[tester::#JW4] [client] [0m[92mReceived ["blueberry", "mango", "apple"][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -111,11 +109,11 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0040 | 6c 65 ff 6c 09 59 cc 38 db e8 71                | le.l.Y.8..q[0m
 [33m[tester::#GC6] [0m[36m[0m
 [33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1000 --dbfilename banana.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET raspberry[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[tester::#GC6] [0m[92mReceived "pineapple"[0m
+[33m[tester::#GC6] [client] [0m[94m$ redis-cli GET raspberry[0m
+[33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#GC6] [client] [0m[92mReceived "pineapple"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
@@ -132,51 +130,47 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0040 | c5 21 ea c1 d2 83 0b 3f                         | .!.....?[0m
 [33m[tester::#JZ6] [0m[36m[0m
 [33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-816 --dbfilename banana.rdb[0m
-[33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["banana"][0m
-[33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["banana"][0m
-[33m[tester::#JZ6] [0m[92m[0m
+[33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived RESP array: ["banana"][0m
+[33m[tester::#JZ6] [client] [0m[92mReceived ["banana"][0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
 [33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5582 --dbfilename blueberry.rdb[0m
-[33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
-[33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5582\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-5582"][0m
-[33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-5582"][0m
-[33m[tester::#ZG5] [0m[92m[0m
+[33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
+[33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5582\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-5582"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-5582"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET orange apple px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:09.464[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 09:36:09.464 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET orange[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "apple"[0m
-[33m[tester::#YZ1] [0m[92mReceived "apple"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET orange apple px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 08:59:47.817[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 08:59:47.817 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET orange[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 09:36:09.568 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET orange[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 08:59:47.920 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET orange[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -184,89 +178,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key apple to grape[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET apple grape[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET apple grape[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key apple[0m
-[33m[tester::#LA7] [0m[94m> GET apple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "grape"[0m
-[33m[tester::#LA7] [0m[92mReceived "grape"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET apple[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO orange[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "orange"[0m
-[33m[tester::#QQ0] [0m[92mReceived "orange"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO orange[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "orange"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -274,11 +268,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -9,253 +9,217 @@ Debug = true
 [33m[tester::#NA2] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#NA2] [setup] [0m[94m4. replica@6383 (Listening port = 6383)[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6380[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc8\xf3\xee\xf0\n\xe0\xe0\xd3"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime©\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6d551434fb2eb982e26221d6b4d28d01fee376a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8bFg\x90=\xf5\x89\x1d"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw3\xb9\xde\x17<\xba\xcf"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime©\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6d551434fb2eb982e26221d6b4d28d01fee376a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4\x860\xbe )\xd3\x01"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\xe1ZD\x8b\b\xd4o"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime©\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6d551434fb2eb982e26221d6b4d28d01fee376a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1T\xd3$\xbc\x1d\xbd\xa1"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC 3580746e81d58c1b18a39c1ddf0927642114da08 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 6d551434fb2eb982e26221d6b4d28d01fee376a5 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ŕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3580746e81d58c1b18a39c1ddf0927642114da08\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1b\xf4n\x8a3R\xbd\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime©\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6d551434fb2eb982e26221d6b4d28d01fee376a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffXA\xe7\xea\x04G\xd4\xc4"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 1 500[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 1 500[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 54[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 54[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 1[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#NA2] [test] [0m[92mPassed first WAIT test.[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 4 2000[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 4 2000[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2012 ms[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2102 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -272,204 +236,204 @@ Debug = true
 [33m[tester::#TU8] [setup] [0m[94m6. replica@6385 (Listening port = 6385)[0m
 [33m[tester::#TU8] [setup] [0m[94m7. replica@6386 (Listening port = 6386)[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6380[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\b\xad\xb5\xf3\x8d\xff\xc0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\t\x7f\xb1\v\xc1v\x92"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\xc8\xfa\x9b\xeeQ\xa5\xdc"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa7\xc9(\x9f\x16\x1d,\x8e"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Ǖlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xce\x1a\x19\x01re\xcb|"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\x1b\xcb\x05\x8a)B."[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh$>\xb2\xbc<\xd2]"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\x0e\xff\xcb2s+K"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF listening-port 6384[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF listening-port 6384[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbeK\xb4\x051\xf1CE"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1dau|\xbf\xbe\xbaS"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > REPLCONF listening-port 6385[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6385: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> REPLCONF listening-port 6385[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6385\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6385: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbb\x99W\x9f\xad\xc5-\xe5"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\xb3\x96\xe6#\x8a\xd4\xf3"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > REPLCONF listening-port 6386[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6386\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6386: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "+FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received RESP simple string: "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> REPLCONF listening-port 6386[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6386\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 78e3a8026a244fec0d0eb6cf22b797df71d8bddc 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6386: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ȕlh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(75ac3e2dfc0205f1938b2a5ec7bd8725492e8fd7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffҌcQ\x15\x9fD\x80"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¬\xdemh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(78e3a8026a244fec0d0eb6cf22b797df71d8bddc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffq\xa6\xa2(\x9bн\x96"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 5 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 7 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 9 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n9\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":7\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 7[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 5 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 7 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 9 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n9\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":7\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 7[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 7[0m
 [33m[tester::#TU8] [0m[92mTest passed.[0m
 [33m[tester::#TU8] [0m[36mTerminating program[0m
 [33m[tester::#TU8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MY8] [0m[94mRunning tests for Stage #MY8 (my8)[0m
 [33m[tester::#MY8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#MY8] [0m[94mclient: $ redis-cli WAIT 0 60000[0m
-[33m[tester::#MY8] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received bytes: ":0\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received RESP integer: 0[0m
-[33m[tester::#MY8] [0m[92mReceived 0[0m
+[33m[tester::#MY8] [client] [0m[94m$ redis-cli WAIT 0 60000[0m
+[33m[tester::#MY8] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived bytes: ":0\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived RESP integer: 0[0m
+[33m[tester::#MY8] [client] [0m[92mReceived 0[0m
 [33m[tester::#MY8] [0m[92mTest passed.[0m
 [33m[tester::#MY8] [0m[36mTerminating program[0m
 [33m[tester::#MY8] [0m[36mProgram terminated successfully[0m
@@ -477,92 +441,78 @@ Debug = true
 [33m[tester::#YD3] [0m[94mRunning tests for Stage #YD3 (yd3)[0m
 [33m[tester::#YD3] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YD3] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YD3] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > PING[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET mango pear[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET banana blueberry[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n162\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "162"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "162"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> PING[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET mango pear[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET banana blueberry[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n162\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "162"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "162"][0m
 [33m[tester::#YD3] [0m[92mTest passed.[0m
 [33m[tester::#YD3] [0m[36mTerminating program[0m
 [33m[tester::#YD3] [0m[36mProgram terminated successfully[0m
@@ -570,72 +520,62 @@ Debug = true
 [33m[tester::#XV6] [0m[94mRunning tests for Stage #XV6 (xv6)[0m
 [33m[tester::#XV6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#XV6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#XV6] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#XV6] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[36m[0m
-[33m[tester::#XV6] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[92m[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#XV6] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#XV6] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#XV6] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
 [33m[tester::#XV6] [0m[92mTest passed.[0m
 [33m[tester::#XV6] [0m[36mTerminating program[0m
 [33m[tester::#XV6] [0m[36mProgram terminated successfully[0m
@@ -643,89 +583,81 @@ Debug = true
 [33m[tester::#YG4] [0m[94mRunning tests for Stage #YG4 (yg4)[0m
 [33m[tester::#YG4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YG4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YG4] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET foo 123[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET bar 456[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET baz 789[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [0m[94mclient: $ redis-cli GET foo[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "123"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "123"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key bar[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET bar[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "456"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET bar[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "456"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key baz[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET baz[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "789"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET baz[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "789"[0m
 [33m[tester::#YG4] [0m[92mTest passed.[0m
 [33m[tester::#YG4] [0m[36mTerminating program[0m
 [33m[tester::#YG4] [0m[36mProgram terminated successfully[0m
@@ -737,252 +669,224 @@ Debug = true
 [33m[tester::#HD5] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#HD5] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6380[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ɕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffν\x1d\x99\x82i\x81I"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime®\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5d541823564b3d80ea86aa2b50f1467288eaea5c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffnV\x98\r'\xfe\xc7B"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ɕlh\xfa\bused-mem\xc2 \xf1\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffq\x8f\x83?\xc8\xf1\xf0\xcb"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime®\xdemh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5d541823564b3d80ea86aa2b50f1467288eaea5c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde0\xabC5\x90ʢ"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC 8fa66ad67a7c35e8580476ade2f044532c1f5201 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 5d541823564b3d80ea86aa2b50f1467288eaea5c 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8fa66ad67a7c35e8580476ade2f044532c1f5201\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x99\x8b\u0600\xe0Q@\x85"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime®\xdemh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5d541823564b3d80ea86aa2b50f1467288eaea5c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffM\xed#\xe0\x1b2\xa4\xc7"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 1/3: replica@6380[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 2/3: replica@6381[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 3/3: replica@6382[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [0m[92mTest passed.[0m
 [33m[tester::#HD5] [0m[36mTerminating program[0m
 [33m[tester::#HD5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZN8] [0m[94mRunning tests for Stage #ZN8 (zn8)[0m
 [33m[tester::#ZN8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: $ redis-cli PING[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF listening-port 6380[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF capa psync2[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 65d6ca7edf0a79b1be58b76cbf1927a16d1e3e2a 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 65d6ca7edf0a79b1be58b76cbf1927a16d1e3e2a 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 65d6ca7edf0a79b1be58b76cbf1927a16d1e3e2a 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(af1f9e6d018b4f06f5e7775bd6a3b3826a8523e7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffM\n\x9cZ\a\xc9\x13\xda"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime®\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(65d6ca7edf0a79b1be58b76cbf1927a16d1e3e2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@,\x86\x9c[S%&"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [test] [0m[92mSent 3 SET commands to master successfully.[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#ZN8] [0m[92mTest passed.[0m
 [33m[tester::#ZN8] [0m[36mTerminating program[0m
 [33m[tester::#ZN8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF8] [0m[94mRunning tests for Stage #CF8 (cf8)[0m
 [33m[tester::#CF8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#CF8] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#CF8] [0m[92mReceived "PONG"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 50bbc8eb5afc0ea40021b4f912d3e2496beba3b2 0"[0m
+[33m[tester::#CF8] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC ae72769f6b876a9755824335b24c479be8ae10e5 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC ae72769f6b876a9755824335b24c479be8ae10e5 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC ae72769f6b876a9755824335b24c479be8ae10e5 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ʕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50bbc8eb5afc0ea40021b4f912d3e2496beba3b2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17Hd\x8dX\xe64r"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¯\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae72769f6b876a9755824335b24c479be8ae10e5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xe1\xe1\x7f\xd8\xcdl\x9e"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -990,47 +894,47 @@ Debug = true
 
 [33m[tester::#VM3] [0m[94mRunning tests for Stage #VM3 (vm3)[0m
 [33m[tester::#VM3] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#VM3] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#VM3] [0m[92mReceived "PONG"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC aa680ee6fae46b4c7a2a0f18b7b78faf79956759 0"[0m
+[33m[tester::#VM3] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 5dee75f613c7db4c7fb5dd6d8f7851af2fcc7e0c 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 5dee75f613c7db4c7fb5dd6d8f7851af2fcc7e0c 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 5dee75f613c7db4c7fb5dd6d8f7851af2fcc7e0c 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FJ0] [0m[94mRunning tests for Stage #FJ0 (fj0)[0m
 [33m[tester::#FJ0] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#FJ0] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#FJ0] [0m[92mReceived "PONG"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#FJ0] [0m[92mTest passed.[0m
 [33m[tester::#FJ0] [0m[36mTerminating program[0m
 [33m[tester::#FJ0] [0m[36mProgram terminated successfully[0m
@@ -1038,62 +942,54 @@ Debug = true
 [33m[tester::#JU6] [0m[94mRunning tests for Stage #JU6 (ju6)[0m
 [33m[tester::#JU6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#JU6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PING"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "listening-port",[0m
-[33m[tester::#JU6] [0m[36m  "6380"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "listening-port",[0m
-[33m[tester::#JU6] [0m[92m  "6380"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "eof",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "psync2",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "eof",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "psync2",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[36m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[92m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
 [33m[tester::#JU6] [0m[92mTest passed.[0m
 [33m[tester::#JU6] [0m[36mTerminating program[0m
 [33m[tester::#JU6] [0m[36mProgram terminated successfully[0m
@@ -1101,54 +997,48 @@ Debug = true
 [33m[tester::#EH4] [0m[94mRunning tests for Stage #EH4 (eh4)[0m
 [33m[tester::#EH4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#EH4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived ["PING"][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "listening-port",[0m
-[33m[tester::#EH4] [0m[36m  "6380"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "listening-port",[0m
-[33m[tester::#EH4] [0m[92m  "6380"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "eof",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "psync2",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "eof",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "psync2",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#EH4] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#EH4] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[36m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[92m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
 [33m[tester::#EH4] [0m[92mTest passed.[0m
 [33m[tester::#EH4] [0m[36mTerminating program[0m
 [33m[tester::#EH4] [0m[36mProgram terminated successfully[0m
@@ -1156,25 +1046,23 @@ Debug = true
 [33m[tester::#GL7] [0m[94mRunning tests for Stage #GL7 (gl7)[0m
 [33m[tester::#GL7] [0m[94mMaster is running on port 6379.[0m
 [33m[tester::#GL7] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#GL7] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#GL7] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#GL7] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#GL7] [0m[36m[0m
-[33m[tester::#GL7] [0m[92mReceived ["PING"][0m
-[33m[tester::#GL7] [0m[92m[0m
-[33m[tester::#GL7] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#GL7] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
+[33m[tester::#GL7] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#GL7] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#GL7] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#GL7] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#GL7] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#GL7] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
 [33m[tester::#GL7] [0m[92mTest passed.[0m
 [33m[tester::#GL7] [0m[36mTerminating program[0m
 [33m[tester::#GL7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XC1] [0m[94mRunning tests for Stage #XC1 (xc1)[0m
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:658b7f779bc75c87a70baa15ebeeeec15af9c5ca\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:652f7903cec499764463f4a354da4c5589823140\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:652f7903cec499764463f4a354da4c5589823140\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:652f7903cec499764463f4a354da4c5589823140\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1184,11 +1072,11 @@ Debug = true
 [33m[tester::#HC6] [0m[94mRunning tests for Stage #HC6 (hc6)[0m
 [33m[tester::#HC6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#HC6] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#HC6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -1196,11 +1084,11 @@ Debug = true
 
 [33m[tester::#YE5] [0m[94mRunning tests for Stage #YE5 (ye5)[0m
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8d83603e9d31b4f058e0cc7b28758f37a8a9e072\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fc2354485f9732848136d045c790731710e06570\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fc2354485f9732848136d045c790731710e06570\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fc2354485f9732848136d045c790731710e06570\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1231,26 +1119,26 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0090 | 61 70 70 6c 65 ff 92 f1 de f7 06 f6 06 ae       | apple.........[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3943 --dbfilename orange.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[tester::#SM4] [0m[92mReceived "pineapple"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#SM4] [0m[92mReceived "orange"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET pear[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET blueberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#SM4] [0m[92mReceived "apple"[0m
+[33m[tester::#SM4] [client] [0m[94m$ redis-cli GET pineapple[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "pineapple"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET grape[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "orange"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET pear[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET blueberry[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "apple"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
@@ -1269,21 +1157,21 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | ff d2 b9 68 6d 79 81 2e 5d                      | ...hmy..][0m
 [33m[tester::#DQ3] [0m[36m[0m
 [33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-662 --dbfilename pear.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#DQ3] [0m[92mReceived "pear"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#DQ3] [0m[92mReceived "apple"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET pineapple[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "pear"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET raspberry[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "apple"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET apple[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "strawberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
@@ -1303,23 +1191,21 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0070 | 72 72 79 ff 1e 60 ef 0f 40 01 3a b1             | rry..`..@.:.[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5147 --dbfilename banana.rdb[0m
-[33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "blueberry",[0m
-[33m[tester::#JW4] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [0m[36m  "pineapple"[0m
-[33m[tester::#JW4] [0m[36m][0m
-[33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "blueberry",[0m
-[33m[tester::#JW4] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [0m[92m  "pineapple"[0m
-[33m[tester::#JW4] [0m[92m][0m
-[33m[tester::#JW4] [0m[92m[0m
+[33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$5\r\ngrape\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "orange",[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
+[33m[tester::#JW4] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[36m][0m
+[33m[tester::#JW4] [client] [0m[92mReceived [[0m
+[33m[tester::#JW4] [client] [0m[92m  "orange",[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
+[33m[tester::#JW4] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -1336,11 +1222,11 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
 [33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1473 --dbfilename raspberry.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET apple[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#GC6] [0m[92mReceived "banana"[0m
+[33m[tester::#GC6] [client] [0m[94m$ redis-cli GET apple[0m
+[33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived RESP bulk string: "banana"[0m
+[33m[tester::#GC6] [client] [0m[92mReceived "banana"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
@@ -1357,51 +1243,47 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0040 | 97 93 08 f8                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
 [33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-181 --dbfilename apple.rdb[0m
-[33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["apple"][0m
-[33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["apple"][0m
-[33m[tester::#JZ6] [0m[92m[0m
+[33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived RESP array: ["apple"][0m
+[33m[tester::#JZ6] [client] [0m[92mReceived ["apple"][0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
 [33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2445 --dbfilename blueberry.rdb[0m
-[33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
-[33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-2445\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-2445"][0m
-[33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-2445"][0m
-[33m[tester::#ZG5] [0m[92m[0m
+[33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
+[33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-2445\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-2445"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-2445"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET apple blueberry px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:41.721[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:41.721 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "blueberry"[0m
-[33m[tester::#YZ1] [0m[92mReceived "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 08:59:58.406[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 08:59:58.406 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:41.824 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 08:59:58.509 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -1409,89 +1291,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key orange to pineapple[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET orange pineapple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET orange pineapple[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key orange[0m
-[33m[tester::#LA7] [0m[94m> GET orange[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
-[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET orange[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "pineapple"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO pear[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$4\r\npear\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "pear"[0m
-[33m[tester::#QQ0] [0m[92mReceived "pear"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO pear[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$4\r\npear\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "pear"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -1499,11 +1381,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -2,385 +2,370 @@ Debug = true
 
 [33m[tester::#XU1] [0m[94mRunning tests for Stage #XU1 (xu1)[0m
 [33m[tester::#XU1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU1] [0m[94mredis-cli: $ redis-cli XADD pear 0-1 temperature 70[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n70\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP bulk string: "0-1"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-1"[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 0 streams pear $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$4\r\npear\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[94mother-redis-cli: $ redis-cli XADD pear 0-2 temperature 74[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n74\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received RESP bulk string: "0-2"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-2"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*1\r\n*2\r\n$4\r\npear\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n74\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP array: [[0m
-[33m[tester::#XU1] [0m[36m  [[0m
-[33m[tester::#XU1] [0m[36m    "pear",[0m
-[33m[tester::#XU1] [0m[36m    [[0m
-[33m[tester::#XU1] [0m[36m      [[0m
-[33m[tester::#XU1] [0m[36m        "0-2",[0m
-[33m[tester::#XU1] [0m[36m        ["temperature", "74"][0m
-[33m[tester::#XU1] [0m[36m      ][0m
-[33m[tester::#XU1] [0m[36m    ][0m
-[33m[tester::#XU1] [0m[36m  ][0m
-[33m[tester::#XU1] [0m[36m][0m
-[33m[tester::#XU1] [0m[36m[0m
-[33m[tester::#XU1] [0m[92mReceived [[0m
-[33m[tester::#XU1] [0m[92m  [[0m
-[33m[tester::#XU1] [0m[92m    "pear",[0m
-[33m[tester::#XU1] [0m[92m    [[0m
-[33m[tester::#XU1] [0m[92m      [[0m
-[33m[tester::#XU1] [0m[92m        "0-2",[0m
-[33m[tester::#XU1] [0m[92m        ["temperature", "74"][0m
-[33m[tester::#XU1] [0m[92m      ][0m
-[33m[tester::#XU1] [0m[92m    ][0m
-[33m[tester::#XU1] [0m[92m  ][0m
-[33m[tester::#XU1] [0m[92m][0m
-[33m[tester::#XU1] [0m[92m[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 1000 streams pear $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$4\r\npear\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#XU1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94m$ redis-cli XADD pear 0-1 temperature 70[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n70\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 0 streams pear $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$4\r\npear\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94mSleeping for 1000 ms[0m
+[33m[tester::#XU1] [client-2] [0m[94m$ redis-cli XADD pear 0-2 temperature 74[0m
+[33m[tester::#XU1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n74\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#XU1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$4\r\npear\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n74\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XU1] [client-1] [0m[36m  [[0m
+[33m[tester::#XU1] [client-1] [0m[36m    "pear",[0m
+[33m[tester::#XU1] [client-1] [0m[36m    [[0m
+[33m[tester::#XU1] [client-1] [0m[36m      [[0m
+[33m[tester::#XU1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[36m        ["temperature", "74"][0m
+[33m[tester::#XU1] [client-1] [0m[36m      ][0m
+[33m[tester::#XU1] [client-1] [0m[36m    ][0m
+[33m[tester::#XU1] [client-1] [0m[36m  ][0m
+[33m[tester::#XU1] [client-1] [0m[36m][0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#XU1] [client-1] [0m[92m  [[0m
+[33m[tester::#XU1] [client-1] [0m[92m    "pear",[0m
+[33m[tester::#XU1] [client-1] [0m[92m    [[0m
+[33m[tester::#XU1] [client-1] [0m[92m      [[0m
+[33m[tester::#XU1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[92m        ["temperature", "74"][0m
+[33m[tester::#XU1] [client-1] [0m[92m      ][0m
+[33m[tester::#XU1] [client-1] [0m[92m    ][0m
+[33m[tester::#XU1] [client-1] [0m[92m  ][0m
+[33m[tester::#XU1] [client-1] [0m[92m][0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 1000 streams pear $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$4\r\npear\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#XU1] [0m[92mTest passed.[0m
 [33m[tester::#XU1] [0m[36mTerminating program[0m
 [33m[tester::#XU1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HW1] [0m[94mRunning tests for Stage #HW1 (hw1)[0m
 [33m[tester::#HW1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HW1] [0m[94mclient-1: $ redis-cli XADD mango 0-1 temperature 20[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n20\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-1"[0m
-[33m[tester::#HW1] [0m[94mclient-1: > XREAD block 0 streams mango 0-1[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$5\r\nmango\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[94mclient-2: $ redis-cli XADD mango 0-2 temperature 30[0m
-[33m[tester::#HW1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n30\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-2"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$5\r\nmango\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n30\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#HW1] [0m[36m  [[0m
-[33m[tester::#HW1] [0m[36m    "mango",[0m
-[33m[tester::#HW1] [0m[36m    [[0m
-[33m[tester::#HW1] [0m[36m      [[0m
-[33m[tester::#HW1] [0m[36m        "0-2",[0m
-[33m[tester::#HW1] [0m[36m        ["temperature", "30"][0m
-[33m[tester::#HW1] [0m[36m      ][0m
-[33m[tester::#HW1] [0m[36m    ][0m
-[33m[tester::#HW1] [0m[36m  ][0m
-[33m[tester::#HW1] [0m[36m][0m
-[33m[tester::#HW1] [0m[36m[0m
-[33m[tester::#HW1] [0m[92mReceived [[0m
-[33m[tester::#HW1] [0m[92m  [[0m
-[33m[tester::#HW1] [0m[92m    "mango",[0m
-[33m[tester::#HW1] [0m[92m    [[0m
-[33m[tester::#HW1] [0m[92m      [[0m
-[33m[tester::#HW1] [0m[92m        "0-2",[0m
-[33m[tester::#HW1] [0m[92m        ["temperature", "30"][0m
-[33m[tester::#HW1] [0m[92m      ][0m
-[33m[tester::#HW1] [0m[92m    ][0m
-[33m[tester::#HW1] [0m[92m  ][0m
-[33m[tester::#HW1] [0m[92m][0m
-[33m[tester::#HW1] [0m[92m[0m
+[33m[tester::#HW1] [client-1] [0m[94m$ redis-cli XADD mango 0-1 temperature 20[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n20\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[94m> XREAD block 0 streams mango 0-1[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$5\r\nmango\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[94m$ redis-cli XADD mango 0-2 temperature 30[0m
+[33m[tester::#HW1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n30\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#HW1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$5\r\nmango\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n30\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#HW1] [client-1] [0m[36m  [[0m
+[33m[tester::#HW1] [client-1] [0m[36m    "mango",[0m
+[33m[tester::#HW1] [client-1] [0m[36m    [[0m
+[33m[tester::#HW1] [client-1] [0m[36m      [[0m
+[33m[tester::#HW1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[36m        ["temperature", "30"][0m
+[33m[tester::#HW1] [client-1] [0m[36m      ][0m
+[33m[tester::#HW1] [client-1] [0m[36m    ][0m
+[33m[tester::#HW1] [client-1] [0m[36m  ][0m
+[33m[tester::#HW1] [client-1] [0m[36m][0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#HW1] [client-1] [0m[92m  [[0m
+[33m[tester::#HW1] [client-1] [0m[92m    "mango",[0m
+[33m[tester::#HW1] [client-1] [0m[92m    [[0m
+[33m[tester::#HW1] [client-1] [0m[92m      [[0m
+[33m[tester::#HW1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[92m        ["temperature", "30"][0m
+[33m[tester::#HW1] [client-1] [0m[92m      ][0m
+[33m[tester::#HW1] [client-1] [0m[92m    ][0m
+[33m[tester::#HW1] [client-1] [0m[92m  ][0m
+[33m[tester::#HW1] [client-1] [0m[92m][0m
 [33m[tester::#HW1] [0m[92mTest passed.[0m
 [33m[tester::#HW1] [0m[36mTerminating program[0m
 [33m[tester::#HW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#BS1] [0m[94mRunning tests for Stage #BS1 (bs1)[0m
 [33m[tester::#BS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#BS1] [0m[94mclient-1: $ redis-cli XADD blueberry 0-1 temperature 12[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n12\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#BS1] [0m[94mWaiting for 500ms[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams blueberry 0-1[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[94mclient-2: $ redis-cli XADD blueberry 0-2 temperature 24[0m
-[33m[tester::#BS1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n24\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n24\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#BS1] [0m[36m  [[0m
-[33m[tester::#BS1] [0m[36m    "blueberry",[0m
-[33m[tester::#BS1] [0m[36m    [[0m
-[33m[tester::#BS1] [0m[36m      [[0m
-[33m[tester::#BS1] [0m[36m        "0-2",[0m
-[33m[tester::#BS1] [0m[36m        ["temperature", "24"][0m
-[33m[tester::#BS1] [0m[36m      ][0m
-[33m[tester::#BS1] [0m[36m    ][0m
-[33m[tester::#BS1] [0m[36m  ][0m
-[33m[tester::#BS1] [0m[36m][0m
-[33m[tester::#BS1] [0m[36m[0m
-[33m[tester::#BS1] [0m[92mReceived [[0m
-[33m[tester::#BS1] [0m[92m  [[0m
-[33m[tester::#BS1] [0m[92m    "blueberry",[0m
-[33m[tester::#BS1] [0m[92m    [[0m
-[33m[tester::#BS1] [0m[92m      [[0m
-[33m[tester::#BS1] [0m[92m        "0-2",[0m
-[33m[tester::#BS1] [0m[92m        ["temperature", "24"][0m
-[33m[tester::#BS1] [0m[92m      ][0m
-[33m[tester::#BS1] [0m[92m    ][0m
-[33m[tester::#BS1] [0m[92m  ][0m
-[33m[tester::#BS1] [0m[92m][0m
-[33m[tester::#BS1] [0m[92m[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams blueberry 0-2[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#BS1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94m$ redis-cli XADD blueberry 0-1 temperature 12[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n12\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams blueberry 0-1[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94mWaiting for 500 ms[0m
+[33m[tester::#BS1] [client-2] [0m[94m$ redis-cli XADD blueberry 0-2 temperature 24[0m
+[33m[tester::#BS1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n24\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#BS1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n24\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#BS1] [client-1] [0m[36m  [[0m
+[33m[tester::#BS1] [client-1] [0m[36m    "blueberry",[0m
+[33m[tester::#BS1] [client-1] [0m[36m    [[0m
+[33m[tester::#BS1] [client-1] [0m[36m      [[0m
+[33m[tester::#BS1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[36m        ["temperature", "24"][0m
+[33m[tester::#BS1] [client-1] [0m[36m      ][0m
+[33m[tester::#BS1] [client-1] [0m[36m    ][0m
+[33m[tester::#BS1] [client-1] [0m[36m  ][0m
+[33m[tester::#BS1] [client-1] [0m[36m][0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#BS1] [client-1] [0m[92m  [[0m
+[33m[tester::#BS1] [client-1] [0m[92m    "blueberry",[0m
+[33m[tester::#BS1] [client-1] [0m[92m    [[0m
+[33m[tester::#BS1] [client-1] [0m[92m      [[0m
+[33m[tester::#BS1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[92m        ["temperature", "24"][0m
+[33m[tester::#BS1] [client-1] [0m[92m      ][0m
+[33m[tester::#BS1] [client-1] [0m[92m    ][0m
+[33m[tester::#BS1] [client-1] [0m[92m  ][0m
+[33m[tester::#BS1] [client-1] [0m[92m][0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams blueberry 0-2[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#BS1] [0m[92mTest passed.[0m
 [33m[tester::#BS1] [0m[36mTerminating program[0m
 [33m[tester::#BS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RU9] [0m[94mRunning tests for Stage #RU9 (ru9)[0m
 [33m[tester::#RU9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RU9] [0m[94mclient: $ redis-cli XADD strawberry 0-1 temperature 0[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-1"[0m
-[33m[tester::#RU9] [0m[94mclient: > XADD apple 0-2 humidity 1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-2"[0m
-[33m[tester::#RU9] [0m[94mclient: > XREAD streams strawberry apple 0-0 0-1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "*2\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$5\r\napple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "strawberry",[0m
-[33m[tester::#RU9] [0m[36m    [[0m
-[33m[tester::#RU9] [0m[36m      [[0m
-[33m[tester::#RU9] [0m[36m        "0-1",[0m
-[33m[tester::#RU9] [0m[36m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[36m      ][0m
-[33m[tester::#RU9] [0m[36m    ][0m
-[33m[tester::#RU9] [0m[36m  ],[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "apple",[0m
-[33m[tester::#RU9] [0m[36m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[36m  ][0m
-[33m[tester::#RU9] [0m[36m][0m
-[33m[tester::#RU9] [0m[36m[0m
-[33m[tester::#RU9] [0m[92mReceived [[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "strawberry",[0m
-[33m[tester::#RU9] [0m[92m    [[0m
-[33m[tester::#RU9] [0m[92m      [[0m
-[33m[tester::#RU9] [0m[92m        "0-1",[0m
-[33m[tester::#RU9] [0m[92m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[92m      ][0m
-[33m[tester::#RU9] [0m[92m    ][0m
-[33m[tester::#RU9] [0m[92m  ],[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "apple",[0m
-[33m[tester::#RU9] [0m[92m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[92m  ][0m
-[33m[tester::#RU9] [0m[92m][0m
-[33m[tester::#RU9] [0m[92m[0m
+[33m[tester::#RU9] [client] [0m[94m$ redis-cli XADD strawberry 0-1 temperature 0[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$10\r\nstrawberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#RU9] [client] [0m[94m> XADD apple 0-2 humidity 1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#RU9] [client] [0m[94m> XREAD streams strawberry apple 0-0 0-1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$10\r\nstrawberry\r\n$5\r\napple\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "*2\r\n*2\r\n$10\r\nstrawberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$5\r\napple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "strawberry",[0m
+[33m[tester::#RU9] [client] [0m[36m    [[0m
+[33m[tester::#RU9] [client] [0m[36m      [[0m
+[33m[tester::#RU9] [client] [0m[36m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[36m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[36m      ][0m
+[33m[tester::#RU9] [client] [0m[36m    ][0m
+[33m[tester::#RU9] [client] [0m[36m  ],[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "apple",[0m
+[33m[tester::#RU9] [client] [0m[36m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[36m  ][0m
+[33m[tester::#RU9] [client] [0m[36m][0m
+[33m[tester::#RU9] [client] [0m[92mReceived [[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "strawberry",[0m
+[33m[tester::#RU9] [client] [0m[92m    [[0m
+[33m[tester::#RU9] [client] [0m[92m      [[0m
+[33m[tester::#RU9] [client] [0m[92m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[92m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[92m      ][0m
+[33m[tester::#RU9] [client] [0m[92m    ][0m
+[33m[tester::#RU9] [client] [0m[92m  ],[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "apple",[0m
+[33m[tester::#RU9] [client] [0m[92m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[92m  ][0m
+[33m[tester::#RU9] [client] [0m[92m][0m
 [33m[tester::#RU9] [0m[92mTest passed.[0m
 [33m[tester::#RU9] [0m[36mTerminating program[0m
 [33m[tester::#RU9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#UM0] [0m[94mRunning tests for Stage #UM0 (um0)[0m
 [33m[tester::#UM0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#UM0] [0m[94mclient: $ redis-cli XADD banana 0-1 temperature 39[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n39\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#UM0] [0m[92mReceived "0-1"[0m
-[33m[tester::#UM0] [0m[94mclient: > XREAD streams banana 0-0[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$6\r\nbanana\r\n$3\r\n0-0\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "*1\r\n*2\r\n$6\r\nbanana\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n39\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#UM0] [0m[36m  [[0m
-[33m[tester::#UM0] [0m[36m    "banana",[0m
-[33m[tester::#UM0] [0m[36m    [[0m
-[33m[tester::#UM0] [0m[36m      [[0m
-[33m[tester::#UM0] [0m[36m        "0-1",[0m
-[33m[tester::#UM0] [0m[36m        ["temperature", "39"][0m
-[33m[tester::#UM0] [0m[36m      ][0m
-[33m[tester::#UM0] [0m[36m    ][0m
-[33m[tester::#UM0] [0m[36m  ][0m
-[33m[tester::#UM0] [0m[36m][0m
-[33m[tester::#UM0] [0m[36m[0m
-[33m[tester::#UM0] [0m[92mReceived [[0m
-[33m[tester::#UM0] [0m[92m  [[0m
-[33m[tester::#UM0] [0m[92m    "banana",[0m
-[33m[tester::#UM0] [0m[92m    [[0m
-[33m[tester::#UM0] [0m[92m      [[0m
-[33m[tester::#UM0] [0m[92m        "0-1",[0m
-[33m[tester::#UM0] [0m[92m        ["temperature", "39"][0m
-[33m[tester::#UM0] [0m[92m      ][0m
-[33m[tester::#UM0] [0m[92m    ][0m
-[33m[tester::#UM0] [0m[92m  ][0m
-[33m[tester::#UM0] [0m[92m][0m
-[33m[tester::#UM0] [0m[92m[0m
+[33m[tester::#UM0] [client] [0m[94m$ redis-cli XADD banana 0-1 temperature 39[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n39\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#UM0] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#UM0] [client] [0m[94m> XREAD streams banana 0-0[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$6\r\nbanana\r\n$3\r\n0-0\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "*1\r\n*2\r\n$6\r\nbanana\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n39\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#UM0] [client] [0m[36m  [[0m
+[33m[tester::#UM0] [client] [0m[36m    "banana",[0m
+[33m[tester::#UM0] [client] [0m[36m    [[0m
+[33m[tester::#UM0] [client] [0m[36m      [[0m
+[33m[tester::#UM0] [client] [0m[36m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[36m        ["temperature", "39"][0m
+[33m[tester::#UM0] [client] [0m[36m      ][0m
+[33m[tester::#UM0] [client] [0m[36m    ][0m
+[33m[tester::#UM0] [client] [0m[36m  ][0m
+[33m[tester::#UM0] [client] [0m[36m][0m
+[33m[tester::#UM0] [client] [0m[92mReceived [[0m
+[33m[tester::#UM0] [client] [0m[92m  [[0m
+[33m[tester::#UM0] [client] [0m[92m    "banana",[0m
+[33m[tester::#UM0] [client] [0m[92m    [[0m
+[33m[tester::#UM0] [client] [0m[92m      [[0m
+[33m[tester::#UM0] [client] [0m[92m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[92m        ["temperature", "39"][0m
+[33m[tester::#UM0] [client] [0m[92m      ][0m
+[33m[tester::#UM0] [client] [0m[92m    ][0m
+[33m[tester::#UM0] [client] [0m[92m  ][0m
+[33m[tester::#UM0] [client] [0m[92m][0m
 [33m[tester::#UM0] [0m[92mTest passed.[0m
 [33m[tester::#UM0] [0m[36mTerminating program[0m
 [33m[tester::#UM0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FS1] [0m[94mRunning tests for Stage #FS1 (fs1)[0m
 [33m[tester::#FS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FS1] [0m[94mclient: $ redis-cli XADD raspberry 0-1 grape apple[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-1\r\n$5\r\ngrape\r\n$5\r\napple\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD raspberry 0-2 pineapple raspberry[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD raspberry 0-3 pear apple[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-3\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-3"[0m
-[33m[tester::#FS1] [0m[94mclient: > XRANGE raspberry 0-2 +[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$1\r\n+\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "*2\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#FS1] [0m[36m  [[0m
-[33m[tester::#FS1] [0m[36m    "0-2",[0m
-[33m[tester::#FS1] [0m[36m    ["pineapple", "raspberry"][0m
-[33m[tester::#FS1] [0m[36m  ],[0m
-[33m[tester::#FS1] [0m[36m  ["0-3", ["pear", "apple"]][0m
-[33m[tester::#FS1] [0m[36m][0m
-[33m[tester::#FS1] [0m[36m[0m
-[33m[tester::#FS1] [0m[92mReceived [[0m
-[33m[tester::#FS1] [0m[92m  [[0m
-[33m[tester::#FS1] [0m[92m    "0-2",[0m
-[33m[tester::#FS1] [0m[92m    ["pineapple", "raspberry"][0m
-[33m[tester::#FS1] [0m[92m  ],[0m
-[33m[tester::#FS1] [0m[92m  ["0-3", ["pear", "apple"]][0m
-[33m[tester::#FS1] [0m[92m][0m
-[33m[tester::#FS1] [0m[92m[0m
+[33m[tester::#FS1] [client] [0m[94m$ redis-cli XADD raspberry 0-1 grape apple[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-1\r\n$5\r\ngrape\r\n$5\r\napple\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD raspberry 0-2 pineapple raspberry[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD raspberry 0-3 pear apple[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-3\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#FS1] [client] [0m[94m> XRANGE raspberry 0-2 +[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$1\r\n+\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "*2\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#FS1] [client] [0m[36m  [[0m
+[33m[tester::#FS1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#FS1] [client] [0m[36m    ["pineapple", "raspberry"][0m
+[33m[tester::#FS1] [client] [0m[36m  ],[0m
+[33m[tester::#FS1] [client] [0m[36m  ["0-3", ["pear", "apple"]][0m
+[33m[tester::#FS1] [client] [0m[36m][0m
+[33m[tester::#FS1] [client] [0m[92mReceived [[0m
+[33m[tester::#FS1] [client] [0m[92m  [[0m
+[33m[tester::#FS1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#FS1] [client] [0m[92m    ["pineapple", "raspberry"][0m
+[33m[tester::#FS1] [client] [0m[92m  ],[0m
+[33m[tester::#FS1] [client] [0m[92m  ["0-3", ["pear", "apple"]][0m
+[33m[tester::#FS1] [client] [0m[92m][0m
 [33m[tester::#FS1] [0m[92mTest passed.[0m
 [33m[tester::#FS1] [0m[36mTerminating program[0m
 [33m[tester::#FS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YP1] [0m[94mRunning tests for Stage #YP1 (yp1)[0m
 [33m[tester::#YP1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YP1] [0m[94mclient: $ redis-cli XADD banana 0-1 orange blueberry[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$6\r\norange\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-1"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD banana 0-2 grape pineapple[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-2\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-2"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD banana 0-3 raspberry mango[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-3\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-3"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD banana 0-4 grape orange[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-4\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-4\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-4"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-4"[0m
-[33m[tester::#YP1] [0m[94mclient: > XRANGE banana - 0-3[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$6\r\nbanana\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$6\r\norange\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-1",[0m
-[33m[tester::#YP1] [0m[36m    ["orange", "blueberry"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-2",[0m
-[33m[tester::#YP1] [0m[36m    ["grape", "pineapple"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-3",[0m
-[33m[tester::#YP1] [0m[36m    ["raspberry", "mango"][0m
-[33m[tester::#YP1] [0m[36m  ][0m
-[33m[tester::#YP1] [0m[36m][0m
-[33m[tester::#YP1] [0m[36m[0m
-[33m[tester::#YP1] [0m[92mReceived [[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-1",[0m
-[33m[tester::#YP1] [0m[92m    ["orange", "blueberry"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-2",[0m
-[33m[tester::#YP1] [0m[92m    ["grape", "pineapple"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-3",[0m
-[33m[tester::#YP1] [0m[92m    ["raspberry", "mango"][0m
-[33m[tester::#YP1] [0m[92m  ][0m
-[33m[tester::#YP1] [0m[92m][0m
-[33m[tester::#YP1] [0m[92m[0m
+[33m[tester::#YP1] [client] [0m[94m$ redis-cli XADD banana 0-1 orange blueberry[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$6\r\norange\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD banana 0-2 grape pineapple[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-2\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD banana 0-3 raspberry mango[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-3\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD banana 0-4 grape orange[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-4\r\n$5\r\ngrape\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-4\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-4"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-4"[0m
+[33m[tester::#YP1] [client] [0m[94m> XRANGE banana - 0-3[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$6\r\nbanana\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$6\r\norange\r\n$9\r\nblueberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\ngrape\r\n$9\r\npineapple\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["orange", "blueberry"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["grape", "pineapple"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-3",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["raspberry", "mango"][0m
+[33m[tester::#YP1] [client] [0m[36m  ][0m
+[33m[tester::#YP1] [client] [0m[36m][0m
+[33m[tester::#YP1] [client] [0m[92mReceived [[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["orange", "blueberry"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["grape", "pineapple"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-3",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["raspberry", "mango"][0m
+[33m[tester::#YP1] [client] [0m[92m  ][0m
+[33m[tester::#YP1] [client] [0m[92m][0m
 [33m[tester::#YP1] [0m[92mTest passed.[0m
 [33m[tester::#YP1] [0m[36mTerminating program[0m
 [33m[tester::#YP1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZX1] [0m[94mRunning tests for Stage #ZX1 (zx1)[0m
 [33m[tester::#ZX1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZX1] [0m[94mclient: $ redis-cli XADD blueberry 0-1 banana mango[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$6\r\nbanana\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-1"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD blueberry 0-2 orange raspberry[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$6\r\norange\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-2"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD blueberry 0-3 strawberry grape[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-3\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-3"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XRANGE blueberry 0-2 0-3[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$3\r\n0-3\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "*2\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$6\r\norange\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-2",[0m
-[33m[tester::#ZX1] [0m[36m    ["orange", "raspberry"][0m
-[33m[tester::#ZX1] [0m[36m  ],[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-3",[0m
-[33m[tester::#ZX1] [0m[36m    ["strawberry", "grape"][0m
-[33m[tester::#ZX1] [0m[36m  ][0m
-[33m[tester::#ZX1] [0m[36m][0m
-[33m[tester::#ZX1] [0m[36m[0m
-[33m[tester::#ZX1] [0m[92mReceived [[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-2",[0m
-[33m[tester::#ZX1] [0m[92m    ["orange", "raspberry"][0m
-[33m[tester::#ZX1] [0m[92m  ],[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-3",[0m
-[33m[tester::#ZX1] [0m[92m    ["strawberry", "grape"][0m
-[33m[tester::#ZX1] [0m[92m  ][0m
-[33m[tester::#ZX1] [0m[92m][0m
-[33m[tester::#ZX1] [0m[92m[0m
+[33m[tester::#ZX1] [client] [0m[94m$ redis-cli XADD blueberry 0-1 banana mango[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$6\r\nbanana\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD blueberry 0-2 orange raspberry[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$6\r\norange\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD blueberry 0-3 strawberry grape[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-3\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XRANGE blueberry 0-2 0-3[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$3\r\n0-3\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "*2\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$6\r\norange\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["orange", "raspberry"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ],[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["strawberry", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ][0m
+[33m[tester::#ZX1] [client] [0m[36m][0m
+[33m[tester::#ZX1] [client] [0m[92mReceived [[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["orange", "raspberry"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ],[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["strawberry", "grape"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ][0m
+[33m[tester::#ZX1] [client] [0m[92m][0m
 [33m[tester::#ZX1] [0m[92mTest passed.[0m
 [33m[tester::#ZX1] [0m[36mTerminating program[0m
 [33m[tester::#ZX1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XU6] [0m[94mRunning tests for Stage #XU6 (xu6)[0m
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD raspberry * foo bar[0m
-[33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946676291-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946676291-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751946676291-0"[0m
+[33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD raspberry * foo bar[0m
+[33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752030946275-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752030946275-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1752030946275-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -389,89 +374,89 @@ Debug = true
 
 [33m[tester::#YH3] [0m[94mRunning tests for Stage #YH3 (yh3)[0m
 [33m[tester::#YH3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YH3] [0m[94mclient: $ redis-cli XADD raspberry 0-* pineapple banana[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-*\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "0-1"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD raspberry 1-* pineapple banana[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-0\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-0"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-0"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD raspberry 1-* banana blueberry[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-1"[0m
+[33m[tester::#YH3] [client] [0m[94m$ redis-cli XADD raspberry 0-* pineapple banana[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-*\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD raspberry 1-* pineapple banana[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-0\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-0"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-0"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD raspberry 1-* banana blueberry[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n1-*\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-1"[0m
 [33m[tester::#YH3] [0m[92mTest passed.[0m
 [33m[tester::#YH3] [0m[36mTerminating program[0m
 [33m[tester::#YH3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HQ8] [0m[94mRunning tests for Stage #HQ8 (hq8)[0m
 [33m[tester::#HQ8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HQ8] [0m[94mclient: $ redis-cli XADD pear 1-1 pear apple[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-1\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-1"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pear 1-2 blueberry raspberry[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-2\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-2\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-2"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-2"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pear 1-2 banana strawberry[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-2\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pear 0-3 orange pineapple[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-3\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pear 0-0 grape mango[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-0\r\n$5\r\ngrape\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[94m$ redis-cli XADD pear 1-1 pear apple[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-1\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pear 1-2 blueberry raspberry[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-2\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-2\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pear 1-2 banana strawberry[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-2\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pear 0-3 orange pineapple[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-3\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pear 0-0 grape mango[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-0\r\n$5\r\ngrape\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
 [33m[tester::#HQ8] [0m[92mTest passed.[0m
 [33m[tester::#HQ8] [0m[36mTerminating program[0m
 [33m[tester::#HQ8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF6] [0m[94mRunning tests for Stage #CF6 (cf6)[0m
 [33m[tester::#CF6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CF6] [0m[94mclient: $ redis-cli XADD grape 0-1 foo bar[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#CF6] [0m[92mReceived "0-1"[0m
-[33m[tester::#CF6] [0m[94mclient: > TYPE grape[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "+stream\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP simple string: "stream"[0m
-[33m[tester::#CF6] [0m[92mReceived "stream"[0m
+[33m[tester::#CF6] [client] [0m[94m$ redis-cli XADD grape 0-1 foo bar[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\ngrape\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#CF6] [client] [0m[94m> TYPE grape[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "+stream\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP simple string: "stream"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "stream"[0m
 [33m[tester::#CF6] [0m[92mTest passed.[0m
 [33m[tester::#CF6] [0m[36mTerminating program[0m
 [33m[tester::#CF6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CC3] [0m[94mRunning tests for Stage #CC3 (cc3)[0m
 [33m[tester::#CC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CC3] [0m[94mclient: $ redis-cli SET strawberry mango[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CC3] [0m[92mReceived "OK"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE strawberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+string\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "string"[0m
-[33m[tester::#CC3] [0m[92mReceived "string"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE missing_key_mango[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$17\r\nmissing_key_mango\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+none\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "none"[0m
-[33m[tester::#CC3] [0m[92mReceived "none"[0m
+[33m[tester::#CC3] [client] [0m[94m$ redis-cli SET strawberry mango[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE strawberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+string\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "string"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "string"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE missing_key_mango[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$17\r\nmissing_key_mango\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+none\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "none"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "none"[0m
 [33m[tester::#CC3] [0m[92mTest passed.[0m
 [33m[tester::#CC3] [0m[36mTerminating program[0m
 [33m[tester::#CC3] [0m[36mProgram terminated successfully[0m
@@ -485,253 +470,217 @@ Debug = true
 [33m[tester::#NA2] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#NA2] [setup] [0m[94m4. replica@6383 (Listening port = 6383)[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6380[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime´\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4\x8b\x83\xa3\xa47+\xec"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe2\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(267238dfcf8ecfa5b306624eb88e7122c5a46f11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06\xb1|U\x95o\xdb!"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\uef8c\xe9BZ'."[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe3\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(267238dfcf8ecfa5b306624eb88e7122c5a46f11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\x84s\x1fs\x02\xd7\xe3"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeblos\xdenI\x8e"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe3\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(267238dfcf8ecfa5b306624eb88e7122c5a46f11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffIV\x90\x85\xef6\xb9C"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC d9b3568e1bef3080231f1f72c8a44efceb1a1ff6 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 267238dfcf8ecfa5b306624eb88e7122c5a46f11 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeµ\x95lh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9b3568e1bef3080231f1f72c8a44efceb1a1ff6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82y[\xbdf4 \xeb"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe3\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(267238dfcf8ecfa5b306624eb88e7122c5a46f11\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff C\xa4KWl\xd0&"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 1 500[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 1 500[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 54[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 54[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 1[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#NA2] [test] [0m[92mPassed first WAIT test.[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 4 2000[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 4 2000[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2104 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -744,103 +693,103 @@ Debug = true
 [33m[tester::#TU8] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#TU8] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6380[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf9f\xbb\xe6\xb2q\xf3\xe7"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a321d5326e0befe3cb486139473f4abd3ce40aef\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab\xb7\x03ޔH\xe9\x15"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffF\xa6\xecȯ\xad\xa9\xfb"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a321d5326e0befe3cb486139473f4abd3ce40aef\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14wT\xf0\x89\x94\xb3\t"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC b179032a1557f2903adf4962b7391b7865812327 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC a321d5326e0befe3cb486139473f4abd3ce40aef 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime·\x95lh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b179032a1557f2903adf4962b7391b7865812327\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffCt\x0fR3\x99\xc7["[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a321d5326e0befe3cb486139473f4abd3ce40aef\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x11\xa5\xb7j\x15\xa0ݩ"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 3[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 4 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 3[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 5 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 3[0m
+[33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 3[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 4 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 3[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 5 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 3[0m
 [33m[tester::#TU8] [0m[92mTest passed.[0m
 [33m[tester::#TU8] [0m[36mTerminating program[0m
 [33m[tester::#TU8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MY8] [0m[94mRunning tests for Stage #MY8 (my8)[0m
 [33m[tester::#MY8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#MY8] [0m[94mclient: $ redis-cli WAIT 0 60000[0m
-[33m[tester::#MY8] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received bytes: ":0\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received RESP integer: 0[0m
-[33m[tester::#MY8] [0m[92mReceived 0[0m
+[33m[tester::#MY8] [client] [0m[94m$ redis-cli WAIT 0 60000[0m
+[33m[tester::#MY8] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived bytes: ":0\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived RESP integer: 0[0m
+[33m[tester::#MY8] [client] [0m[92mReceived 0[0m
 [33m[tester::#MY8] [0m[92mTest passed.[0m
 [33m[tester::#MY8] [0m[36mTerminating program[0m
 [33m[tester::#MY8] [0m[36mProgram terminated successfully[0m
@@ -848,92 +797,78 @@ Debug = true
 [33m[tester::#YD3] [0m[94mRunning tests for Stage #YD3 (yd3)[0m
 [33m[tester::#YD3] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YD3] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YD3] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > PING[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET blueberry apple[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET raspberry mango[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n166\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "166"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "166"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> PING[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET blueberry apple[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET raspberry mango[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n166\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "166"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "166"][0m
 [33m[tester::#YD3] [0m[92mTest passed.[0m
 [33m[tester::#YD3] [0m[36mTerminating program[0m
 [33m[tester::#YD3] [0m[36mProgram terminated successfully[0m
@@ -941,72 +876,62 @@ Debug = true
 [33m[tester::#XV6] [0m[94mRunning tests for Stage #XV6 (xv6)[0m
 [33m[tester::#XV6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#XV6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#XV6] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#XV6] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[36m[0m
-[33m[tester::#XV6] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[92m[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#XV6] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#XV6] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#XV6] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
 [33m[tester::#XV6] [0m[92mTest passed.[0m
 [33m[tester::#XV6] [0m[36mTerminating program[0m
 [33m[tester::#XV6] [0m[36mProgram terminated successfully[0m
@@ -1014,89 +939,81 @@ Debug = true
 [33m[tester::#YG4] [0m[94mRunning tests for Stage #YG4 (yg4)[0m
 [33m[tester::#YG4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YG4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YG4] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET foo 123[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET bar 456[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET baz 789[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [0m[94mclient: $ redis-cli GET foo[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "123"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "123"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key bar[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET bar[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "456"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET bar[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "456"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key baz[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET baz[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "789"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET baz[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "789"[0m
 [33m[tester::#YG4] [0m[92mTest passed.[0m
 [33m[tester::#YG4] [0m[36mTerminating program[0m
 [33m[tester::#YG4] [0m[36mProgram terminated successfully[0m
@@ -1108,252 +1025,224 @@ Debug = true
 [33m[tester::#HD5] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#HD5] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6380[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xab\xe1X\xa4j\x1f\xe2\r"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cafeb97a8efad464faca7b1c3abee318cf22faee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffe\xc3\x19E\xf7\xb9E\xca"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1b\x87k\xeaxq\xef\xed"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7\xdemh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cafeb97a8efad464faca7b1c3abee318cf22faee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffե*\v\xe5\xd7H*"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC ee450e6ddf73f56eff9141844dbc3e6227f7f5ee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC cafeb97a8efad464faca7b1c3abee318cf22faee 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime¹\x95lh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ee450e6ddf73f56eff9141844dbc3e6227f7f5ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88Z\xe3IVӁ\x88"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe7\xdemh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cafeb97a8efad464faca7b1c3abee318cf22faee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffFx\xa2\xa8\xcbu&O"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 1/3: replica@6380[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 2/3: replica@6381[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 3/3: replica@6382[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [0m[92mTest passed.[0m
 [33m[tester::#HD5] [0m[36mTerminating program[0m
 [33m[tester::#HD5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZN8] [0m[94mRunning tests for Stage #ZN8 (zn8)[0m
 [33m[tester::#ZN8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: $ redis-cli PING[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF listening-port 6380[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF capa psync2[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC 50f4faf7255f08cff8ada2f200426b29daf6168d 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 015b4d15641c38882b9836d616c31c499be40851 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 015b4d15641c38882b9836d616c31c499be40851 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 015b4d15641c38882b9836d616c31c499be40851 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeº\x95lh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(50f4faf7255f08cff8ada2f200426b29daf6168d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3<\xcb\xdb>\xfb\x83\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(015b4d15641c38882b9836d616c31c499be40851\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdbêq&B)R"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [test] [0m[92mSent 3 SET commands to master successfully.[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#ZN8] [0m[92mTest passed.[0m
 [33m[tester::#ZN8] [0m[36mTerminating program[0m
 [33m[tester::#ZN8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF8] [0m[94mRunning tests for Stage #CF8 (cf8)[0m
 [33m[tester::#CF8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#CF8] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#CF8] [0m[92mReceived "PONG"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06 0"[0m
+[33m[tester::#CF8] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 598f9eacabc009abb858c15f9b34206a86d66b24 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 598f9eacabc009abb858c15f9b34206a86d66b24 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 598f9eacabc009abb858c15f9b34206a86d66b24 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctimeº\x95lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d937ea2a816c9b9ba1c8e6f47f77e7f1ac3e9a06\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\xe8\xf3ߌU\xb7\x1f"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(598f9eacabc009abb858c15f9b34206a86d66b24\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b;\x05\xbaTQA?"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1361,47 +1250,47 @@ Debug = true
 
 [33m[tester::#VM3] [0m[94mRunning tests for Stage #VM3 (vm3)[0m
 [33m[tester::#VM3] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#VM3] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#VM3] [0m[92mReceived "PONG"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 0070e60571a01e007b3815795c0e99655783cb12 0"[0m
+[33m[tester::#VM3] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC be60ad3bbe3bf65a2df433d32da0997e98b78a13 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC be60ad3bbe3bf65a2df433d32da0997e98b78a13 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC be60ad3bbe3bf65a2df433d32da0997e98b78a13 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FJ0] [0m[94mRunning tests for Stage #FJ0 (fj0)[0m
 [33m[tester::#FJ0] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#FJ0] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#FJ0] [0m[92mReceived "PONG"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#FJ0] [0m[92mTest passed.[0m
 [33m[tester::#FJ0] [0m[36mTerminating program[0m
 [33m[tester::#FJ0] [0m[36mProgram terminated successfully[0m
@@ -1409,62 +1298,54 @@ Debug = true
 [33m[tester::#JU6] [0m[94mRunning tests for Stage #JU6 (ju6)[0m
 [33m[tester::#JU6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#JU6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PING"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "listening-port",[0m
-[33m[tester::#JU6] [0m[36m  "6380"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "listening-port",[0m
-[33m[tester::#JU6] [0m[92m  "6380"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "eof",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "psync2",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "eof",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "psync2",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[36m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[92m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
 [33m[tester::#JU6] [0m[92mTest passed.[0m
 [33m[tester::#JU6] [0m[36mTerminating program[0m
 [33m[tester::#JU6] [0m[36mProgram terminated successfully[0m
@@ -1472,54 +1353,48 @@ Debug = true
 [33m[tester::#EH4] [0m[94mRunning tests for Stage #EH4 (eh4)[0m
 [33m[tester::#EH4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#EH4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived ["PING"][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "listening-port",[0m
-[33m[tester::#EH4] [0m[36m  "6380"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "listening-port",[0m
-[33m[tester::#EH4] [0m[92m  "6380"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "eof",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "psync2",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "eof",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "psync2",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#EH4] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#EH4] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[36m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[92m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
 [33m[tester::#EH4] [0m[92mTest passed.[0m
 [33m[tester::#EH4] [0m[36mTerminating program[0m
 [33m[tester::#EH4] [0m[36mProgram terminated successfully[0m
@@ -1527,25 +1402,23 @@ Debug = true
 [33m[tester::#GL7] [0m[94mRunning tests for Stage #GL7 (gl7)[0m
 [33m[tester::#GL7] [0m[94mMaster is running on port 6379.[0m
 [33m[tester::#GL7] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#GL7] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#GL7] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#GL7] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#GL7] [0m[36m[0m
-[33m[tester::#GL7] [0m[92mReceived ["PING"][0m
-[33m[tester::#GL7] [0m[92m[0m
-[33m[tester::#GL7] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#GL7] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
+[33m[tester::#GL7] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#GL7] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#GL7] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#GL7] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#GL7] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#GL7] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
 [33m[tester::#GL7] [0m[92mTest passed.[0m
 [33m[tester::#GL7] [0m[36mTerminating program[0m
 [33m[tester::#GL7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XC1] [0m[94mRunning tests for Stage #XC1 (xc1)[0m
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cec2765a3d2986b04e4810b69aac5f743500f64e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d807039bedff9a95af0e5f9e1f57a47d44593517\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d807039bedff9a95af0e5f9e1f57a47d44593517\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:d807039bedff9a95af0e5f9e1f57a47d44593517\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1555,11 +1428,11 @@ Debug = true
 [33m[tester::#HC6] [0m[94mRunning tests for Stage #HC6 (hc6)[0m
 [33m[tester::#HC6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#HC6] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#HC6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -1567,11 +1440,11 @@ Debug = true
 
 [33m[tester::#YE5] [0m[94mRunning tests for Stage #YE5 (ye5)[0m
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5574f6c7fb6b4edb5e88a9e1d61c6c915782ab7b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:162664450410aef39a5e6df11143018622d7a521\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:162664450410aef39a5e6df11143018622d7a521\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:162664450410aef39a5e6df11143018622d7a521\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1601,21 +1474,21 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | bc 46 59                                        | .FY[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1600 --dbfilename apple.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET raspberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\nbanana\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "banana"[0m
-[33m[tester::#SM4] [0m[92mReceived "banana"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET orange[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET mango[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#SM4] [0m[92mReceived "orange"[0m
+[33m[tester::#SM4] [client] [0m[94m$ redis-cli GET raspberry[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "banana"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "banana"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET orange[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET mango[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "orange"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
@@ -1625,30 +1498,30 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 00 00 06 62 | er.7.2.0.......b[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 00 00 06 62 | s-bits.@.......b[0m
 [33m[tester::#DQ3] [0m[36m0030 | 61 6e 61 6e 61 05 61 70 70 6c 65 00 04 70 65 61 | anana.apple..pea[0m
 [33m[tester::#DQ3] [0m[36m0040 | 72 0a 73 74 72 61 77 62 65 72 72 79 00 09 62 6c | r.strawberry..bl[0m
 [33m[tester::#DQ3] [0m[36m0050 | 75 65 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 | ueberry.blueberr[0m
-[33m[tester::#DQ3] [0m[36m0060 | 79 ff 6e 1a 43 ca 49 58 57 72                   | y.n.C.IXWr[0m
+[33m[tester::#DQ3] [0m[36m0060 | 79 ff 8d bc a5 75 40 e0 5f 22                   | y....u@._"[0m
 [33m[tester::#DQ3] [0m[36m[0m
 [33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9407 --dbfilename strawberry.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET banana[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#DQ3] [0m[92mReceived "apple"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET pear[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET blueberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "blueberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "blueberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET banana[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "apple"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET pear[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET blueberry[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
@@ -1670,25 +1543,23 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0090 | 6e 99 43 a8 45                                  | n.C.E[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2389 --dbfilename pineapple.rdb[0m
-[33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*5\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "pineapple",[0m
-[33m[tester::#JW4] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [0m[36m  "strawberry",[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "blueberry"[0m
-[33m[tester::#JW4] [0m[36m][0m
-[33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "pineapple",[0m
-[33m[tester::#JW4] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [0m[92m  "strawberry",[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "blueberry"[0m
-[33m[tester::#JW4] [0m[92m][0m
-[33m[tester::#JW4] [0m[92m[0m
+[33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\nblueberry\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[36m][0m
+[33m[tester::#JW4] [client] [0m[92mReceived [[0m
+[33m[tester::#JW4] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -1705,11 +1576,11 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0040 | 72 79 ff f1 2b db 4b ca 51 08 d5                | ry..+.K.Q..[0m
 [33m[tester::#GC6] [0m[36m[0m
 [33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET pineapple[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#GC6] [0m[92mReceived "raspberry"[0m
+[33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pineapple[0m
+[33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#GC6] [client] [0m[92mReceived "raspberry"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
@@ -1719,58 +1590,54 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 04 70 | er.7.2.0.......p[0m
-[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff d6 | ear.strawberry..[0m
-[33m[tester::#JZ6] [0m[36m0040 | 5f e2 14 2c 5b 67 c6                            | _..,[g.[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff ac | ear.strawberry..[0m
+[33m[tester::#JZ6] [0m[36m0040 | 16 e9 97 c8 3c d1 28                            | ....<.([0m
 [33m[tester::#JZ6] [0m[36m[0m
 [33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3687 --dbfilename banana.rdb[0m
-[33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["pear"][0m
-[33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["pear"][0m
-[33m[tester::#JZ6] [0m[92m[0m
+[33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$4\r\npear\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived RESP array: ["pear"][0m
+[33m[tester::#JZ6] [client] [0m[92mReceived ["pear"][0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
 [33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
-[33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
-[33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-1438\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-1438"][0m
-[33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-1438"][0m
-[33m[tester::#ZG5] [0m[92m[0m
+[33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
+[33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-1438\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-1438"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-1438"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET banana raspberry px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:25.653[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:36:25.653 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET banana[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "raspberry"[0m
-[33m[tester::#YZ1] [0m[92mReceived "raspberry"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET banana raspberry px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:00:55.350[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:00:55.351 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "raspberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:36:25.756 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET banana[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 09:00:55.454 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -1778,89 +1645,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key orange to pineapple[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET orange pineapple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET orange pineapple[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key orange[0m
-[33m[tester::#LA7] [0m[94m> GET orange[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
-[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET orange[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "pineapple"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO grape[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "grape"[0m
-[33m[tester::#QQ0] [0m[92mReceived "grape"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO grape[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -1868,11 +1735,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -2,781 +2,754 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [0m[94mclient-1: $ redis-cli SET blueberry 80[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: ":1\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP integer: 1[0m
-[33m[tester::#JF8] [0m[92mReceived 1[0m
-[33m[tester::#JF8] [0m[94mclient-2: $ redis-cli SET blueberry 80[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: ":2\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP integer: 2[0m
-[33m[tester::#JF8] [0m[92mReceived 2[0m
-[33m[tester::#JF8] [0m[94mclient-3: $ redis-cli SET blueberry 80[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: ":3\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP integer: 3[0m
-[33m[tester::#JF8] [0m[92mReceived 3[0m
-[33m[tester::#JF8] [0m[94mclient-1: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-1: > INCR blueberry[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-2: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-2: > INCR blueberry[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-3: > MULTI[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+OK\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "OK"[0m
-[33m[tester::#JF8] [0m[92mReceived "OK"[0m
-[33m[tester::#JF8] [0m[36mSending command: #1/#2[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR apple[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[36mSending command: #2/#2[0m
-[33m[tester::#JF8] [0m[94mclient-3: > INCR blueberry[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#JF8] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#JF8] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received bytes: "*2\r\n:4\r\n:81\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-1: Received RESP array: [4, 81][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [4, 81][0m
-[33m[tester::#JF8] [0m[92m[0m
-[33m[tester::#JF8] [0m[94mclient-2: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received bytes: "*2\r\n:5\r\n:82\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-2: Received RESP array: [5, 82][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [5, 82][0m
-[33m[tester::#JF8] [0m[92m[0m
-[33m[tester::#JF8] [0m[94mclient-3: > EXEC[0m
-[33m[tester::#JF8] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received bytes: "*2\r\n:6\r\n:83\r\n"[0m
-[33m[tester::#JF8] [0m[36mclient-3: Received RESP array: [6, 83][0m
-[33m[tester::#JF8] [0m[36m[0m
-[33m[tester::#JF8] [0m[92mReceived [6, 83][0m
-[33m[tester::#JF8] [0m[92m[0m
+[33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET blueberry 80[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived 1[0m
+[33m[tester::#JF8] [client-2] [0m[94m$ redis-cli SET blueberry 80[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived 2[0m
+[33m[tester::#JF8] [client-3] [0m[94m$ redis-cli SET blueberry 80[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived 3[0m
+[33m[tester::#JF8] [client-1] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-1] [0m[94m> INCR blueberry[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-2] [0m[94m> INCR blueberry[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[94m> MULTI[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "OK"[0m
+[33m[tester::#JF8] [0m[36mSending command: 1/2[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR apple[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [0m[36mSending command: 2/2[0m
+[33m[tester::#JF8] [client-3] [0m[94m> INCR blueberry[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#JF8] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "*2\r\n:4\r\n:81\r\n"[0m
+[33m[tester::#JF8] [client-1] [0m[36mReceived RESP array: [4, 81][0m
+[33m[tester::#JF8] [client-1] [0m[92mReceived [4, 81][0m
+[33m[tester::#JF8] [client-2] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived bytes: "*2\r\n:5\r\n:82\r\n"[0m
+[33m[tester::#JF8] [client-2] [0m[36mReceived RESP array: [5, 82][0m
+[33m[tester::#JF8] [client-2] [0m[92mReceived [5, 82][0m
+[33m[tester::#JF8] [client-3] [0m[94m> EXEC[0m
+[33m[tester::#JF8] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived bytes: "*2\r\n:6\r\n:83\r\n"[0m
+[33m[tester::#JF8] [client-3] [0m[36mReceived RESP array: [6, 83][0m
+[33m[tester::#JF8] [client-3] [0m[92mReceived [6, 83][0m
 [33m[tester::#JF8] [0m[92mTest passed.[0m
 [33m[tester::#JF8] [0m[36mTerminating program[0m
 [33m[tester::#JF8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [0m[94mclient-1: $ redis-cli SET pineapple pear[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > SET grape 92[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$2\r\n92\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > MULTI[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#SG9] [0m[92mReceived "OK"[0m
-[33m[tester::#SG9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#SG9] [0m[94mclient-1: > INCR pineapple[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#SG9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#SG9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#SG9] [0m[94mclient-1: > INCR grape[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#SG9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#SG9] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#SG9] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received bytes: "*2\r\n-ERR value is not an integer or out of range\r\n:93\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#SG9] [0m[36m  "ERR value is not an integer or out of range",[0m
-[33m[tester::#SG9] [0m[36m  93[0m
-[33m[tester::#SG9] [0m[36m][0m
-[33m[tester::#SG9] [0m[36m[0m
-[33m[tester::#SG9] [0m[92mReceived [[0m
-[33m[tester::#SG9] [0m[92m  "ERR value is not an integer or out of range",[0m
-[33m[tester::#SG9] [0m[92m  93[0m
-[33m[tester::#SG9] [0m[92m][0m
-[33m[tester::#SG9] [0m[92m[0m
-[33m[tester::#SG9] [0m[94mclient-2: $ redis-cli GET grape[0m
-[33m[tester::#SG9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received bytes: "$2\r\n93\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received RESP bulk string: "93"[0m
-[33m[tester::#SG9] [0m[92mReceived "93"[0m
-[33m[tester::#SG9] [0m[94mclient-2: > GET pineapple[0m
-[33m[tester::#SG9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#SG9] [0m[36mclient-2: Received RESP bulk string: "pear"[0m
-[33m[tester::#SG9] [0m[92mReceived "pear"[0m
+[33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pineapple pear[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> SET grape 92[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$2\r\n92\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> MULTI[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#SG9] [0m[36mSending command: 1/2[0m
+[33m[tester::#SG9] [client-1] [0m[94m> INCR pineapple[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#SG9] [0m[36mSending command: 2/2[0m
+[33m[tester::#SG9] [client-1] [0m[94m> INCR grape[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#SG9] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "*2\r\n-ERR value is not an integer or out of range\r\n:93\r\n"[0m
+[33m[tester::#SG9] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#SG9] [client-1] [0m[36m  "ERR value is not an integer or out of range",[0m
+[33m[tester::#SG9] [client-1] [0m[36m  93[0m
+[33m[tester::#SG9] [client-1] [0m[36m][0m
+[33m[tester::#SG9] [client-1] [0m[92mReceived [[0m
+[33m[tester::#SG9] [client-1] [0m[92m  "ERR value is not an integer or out of range",[0m
+[33m[tester::#SG9] [client-1] [0m[92m  93[0m
+[33m[tester::#SG9] [client-1] [0m[92m][0m
+[33m[tester::#SG9] [client-2] [0m[94m$ redis-cli GET grape[0m
+[33m[tester::#SG9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived bytes: "$2\r\n93\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived RESP bulk string: "93"[0m
+[33m[tester::#SG9] [client-2] [0m[92mReceived "93"[0m
+[33m[tester::#SG9] [client-2] [0m[94m> GET pineapple[0m
+[33m[tester::#SG9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#SG9] [client-2] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#SG9] [client-2] [0m[92mReceived "pear"[0m
 [33m[tester::#SG9] [0m[92mTest passed.[0m
 [33m[tester::#SG9] [0m[36mTerminating program[0m
 [33m[tester::#SG9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RL9] [0m[94mRunning tests for Stage #RL9 (rl9)[0m
 [33m[tester::#RL9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RL9] [0m[94mclient: $ redis-cli SET grape 35[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$2\r\n35\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[94mclient: > MULTI[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#RL9] [0m[94mclient: > SET raspberry 96[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$2\r\n96\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RL9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RL9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#RL9] [0m[94mclient: > INCR raspberry[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RL9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RL9] [0m[94mclient: > DISCARD[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#RL9] [0m[92mReceived "OK"[0m
-[33m[tester::#RL9] [0m[94mclient: > GET raspberry[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#RL9] [0m[94mclient: > GET grape[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "$2\r\n35\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP bulk string: "35"[0m
-[33m[tester::#RL9] [0m[92mReceived "35"[0m
-[33m[tester::#RL9] [0m[94mclient: > DISCARD[0m
-[33m[tester::#RL9] [0m[36mclient: Sent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received bytes: "-ERR DISCARD without MULTI\r\n"[0m
-[33m[tester::#RL9] [0m[36mclient: Received RESP error: "ERR: ERR DISCARD without MULTI"[0m
-[33m[tester::#RL9] [0m[92mReceived "ERR: ERR DISCARD without MULTI"[0m
+[33m[tester::#RL9] [client] [0m[94m$ redis-cli SET grape 35[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$2\r\n35\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [client] [0m[94m> MULTI[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [0m[36mSending command: 1/2[0m
+[33m[tester::#RL9] [client] [0m[94m> SET raspberry 96[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nraspberry\r\n$2\r\n96\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RL9] [0m[36mSending command: 2/2[0m
+[33m[tester::#RL9] [client] [0m[94m> INCR raspberry[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RL9] [client] [0m[94m> DISCARD[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#RL9] [client] [0m[94m> GET raspberry[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#RL9] [client] [0m[94m> GET grape[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "$2\r\n35\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP bulk string: "35"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "35"[0m
+[33m[tester::#RL9] [client] [0m[94m> DISCARD[0m
+[33m[tester::#RL9] [client] [0m[36mSent bytes: "*1\r\n$7\r\nDISCARD\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived bytes: "-ERR DISCARD without MULTI\r\n"[0m
+[33m[tester::#RL9] [client] [0m[36mReceived RESP error: "ERR: ERR DISCARD without MULTI"[0m
+[33m[tester::#RL9] [client] [0m[92mReceived "ERR: ERR DISCARD without MULTI"[0m
 [33m[tester::#RL9] [0m[92mTest passed.[0m
 [33m[tester::#RL9] [0m[36mTerminating program[0m
 [33m[tester::#RL9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [0m[94mclient-1: $ redis-cli MULTI[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#FY6] [0m[92mReceived "OK"[0m
-[33m[tester::#FY6] [0m[36mSending command: #1/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > SET blueberry 50[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n50\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #2/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > INCR blueberry[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #3/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > INCR orange[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\norange\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[36mSending command: #4/#4[0m
-[33m[tester::#FY6] [0m[94mclient-1: > GET orange[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#FY6] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#FY6] [0m[94mclient-1: > EXEC[0m
-[33m[tester::#FY6] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received bytes: "*4\r\n+OK\r\n:51\r\n:1\r\n$1\r\n1\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-1: Received RESP array: ["OK", 51, 1, "1"][0m
-[33m[tester::#FY6] [0m[36m[0m
-[33m[tester::#FY6] [0m[92mReceived ["OK", 51, 1, "1"][0m
-[33m[tester::#FY6] [0m[92m[0m
-[33m[tester::#FY6] [0m[94mclient-2: $ redis-cli GET blueberry[0m
-[33m[tester::#FY6] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-2: Received bytes: "$2\r\n51\r\n"[0m
-[33m[tester::#FY6] [0m[36mclient-2: Received RESP bulk string: "51"[0m
-[33m[tester::#FY6] [0m[92mReceived "51"[0m
+[33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#FY6] [0m[36mSending command: 1/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> SET blueberry 50[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n50\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 2/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> INCR blueberry[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 3/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> INCR orange[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\norange\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [0m[36mSending command: 4/4[0m
+[33m[tester::#FY6] [client-1] [0m[94m> GET orange[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#FY6] [client-1] [0m[94m> EXEC[0m
+[33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "*4\r\n+OK\r\n:51\r\n:1\r\n$1\r\n1\r\n"[0m
+[33m[tester::#FY6] [client-1] [0m[36mReceived RESP array: ["OK", 51, 1, "1"][0m
+[33m[tester::#FY6] [client-1] [0m[92mReceived ["OK", 51, 1, "1"][0m
+[33m[tester::#FY6] [client-2] [0m[94m$ redis-cli GET blueberry[0m
+[33m[tester::#FY6] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#FY6] [client-2] [0m[36mReceived bytes: "$2\r\n51\r\n"[0m
+[33m[tester::#FY6] [client-2] [0m[36mReceived RESP bulk string: "51"[0m
+[33m[tester::#FY6] [client-2] [0m[92mReceived "51"[0m
 [33m[tester::#FY6] [0m[92mTest passed.[0m
 [33m[tester::#FY6] [0m[36mTerminating program[0m
 [33m[tester::#FY6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [0m[94mclient-1: $ redis-cli MULTI[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+OK\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "OK"[0m
-[33m[tester::#RS9] [0m[92mReceived "OK"[0m
-[33m[tester::#RS9] [0m[36mSending command: #1/#2[0m
-[33m[tester::#RS9] [0m[94mclient-1: > SET blueberry 73[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n73\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RS9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RS9] [0m[36mSending command: #2/#2[0m
-[33m[tester::#RS9] [0m[94mclient-1: > INCR blueberry[0m
-[33m[tester::#RS9] [0m[36mclient-1: Sent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received bytes: "+QUEUED\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-1: Received RESP simple string: "QUEUED"[0m
-[33m[tester::#RS9] [0m[92mReceived "QUEUED"[0m
-[33m[tester::#RS9] [0m[94mclient-2: $ redis-cli GET blueberry[0m
-[33m[tester::#RS9] [0m[36mclient-2: Sent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-2: Received bytes: "$-1\r\n"[0m
-[33m[tester::#RS9] [0m[36mclient-2: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#RS9] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "OK"[0m
+[33m[tester::#RS9] [0m[36mSending command: 1/2[0m
+[33m[tester::#RS9] [client-1] [0m[94m> SET blueberry 73[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n73\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RS9] [0m[36mSending command: 2/2[0m
+[33m[tester::#RS9] [client-1] [0m[94m> INCR blueberry[0m
+[33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+QUEUED\r\n"[0m
+[33m[tester::#RS9] [client-1] [0m[36mReceived RESP simple string: "QUEUED"[0m
+[33m[tester::#RS9] [client-1] [0m[92mReceived "QUEUED"[0m
+[33m[tester::#RS9] [client-2] [0m[94m$ redis-cli GET blueberry[0m
+[33m[tester::#RS9] [client-2] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#RS9] [client-2] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#RS9] [0m[92mTest passed.[0m
 [33m[tester::#RS9] [0m[36mTerminating program[0m
 [33m[tester::#RS9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WE1] [0m[94mRunning tests for Stage #WE1 (we1)[0m
 [33m[tester::#WE1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WE1] [0m[94mclient: $ redis-cli MULTI[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#WE1] [0m[92mReceived "OK"[0m
-[33m[tester::#WE1] [0m[94mclient: > EXEC[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "*0\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP array: [][0m
-[33m[tester::#WE1] [0m[36m[0m
-[33m[tester::#WE1] [0m[92mReceived [][0m
-[33m[tester::#WE1] [0m[92m[0m
-[33m[tester::#WE1] [0m[94mclient: > EXEC[0m
-[33m[tester::#WE1] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received bytes: "-ERR EXEC without MULTI\r\n"[0m
-[33m[tester::#WE1] [0m[36mclient: Received RESP error: "ERR: ERR EXEC without MULTI"[0m
-[33m[tester::#WE1] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#WE1] [client] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#WE1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#WE1] [client] [0m[94m> EXEC[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "*0\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP array: [][0m
+[33m[tester::#WE1] [client] [0m[92mReceived [][0m
+[33m[tester::#WE1] [client] [0m[94m> EXEC[0m
+[33m[tester::#WE1] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived bytes: "-ERR EXEC without MULTI\r\n"[0m
+[33m[tester::#WE1] [client] [0m[36mReceived RESP error: "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#WE1] [client] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
 [33m[tester::#WE1] [0m[92mTest passed.[0m
 [33m[tester::#WE1] [0m[36mTerminating program[0m
 [33m[tester::#WE1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#LO4] [0m[94mRunning tests for Stage #LO4 (lo4)[0m
 [33m[tester::#LO4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LO4] [0m[94mclient: $ redis-cli EXEC[0m
-[33m[tester::#LO4] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
-[33m[tester::#LO4] [0m[36mclient: Received bytes: "-ERR EXEC without MULTI\r\n"[0m
-[33m[tester::#LO4] [0m[36mclient: Received RESP error: "ERR: ERR EXEC without MULTI"[0m
-[33m[tester::#LO4] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#LO4] [client] [0m[94m$ redis-cli EXEC[0m
+[33m[tester::#LO4] [client] [0m[36mSent bytes: "*1\r\n$4\r\nEXEC\r\n"[0m
+[33m[tester::#LO4] [client] [0m[36mReceived bytes: "-ERR EXEC without MULTI\r\n"[0m
+[33m[tester::#LO4] [client] [0m[36mReceived RESP error: "ERR: ERR EXEC without MULTI"[0m
+[33m[tester::#LO4] [client] [0m[92mReceived "ERR: ERR EXEC without MULTI"[0m
 [33m[tester::#LO4] [0m[92mTest passed.[0m
 [33m[tester::#LO4] [0m[36mTerminating program[0m
 [33m[tester::#LO4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#PN0] [0m[94mRunning tests for Stage #PN0 (pn0)[0m
 [33m[tester::#PN0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#PN0] [0m[94mclient: $ redis-cli MULTI[0m
-[33m[tester::#PN0] [0m[36mclient: Sent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
-[33m[tester::#PN0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#PN0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#PN0] [0m[92mReceived "OK"[0m
+[33m[tester::#PN0] [client] [0m[94m$ redis-cli MULTI[0m
+[33m[tester::#PN0] [client] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
+[33m[tester::#PN0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#PN0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#PN0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#PN0] [0m[92mTest passed.[0m
 [33m[tester::#PN0] [0m[36mTerminating program[0m
 [33m[tester::#PN0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MK1] [0m[94mRunning tests for Stage #MK1 (mk1)[0m
 [33m[tester::#MK1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#MK1] [0m[94mclient: $ redis-cli SET banana apple[0m
-[33m[tester::#MK1] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$5\r\napple\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#MK1] [0m[92mReceived "OK"[0m
-[33m[tester::#MK1] [0m[94mclient: > INCR banana[0m
-[33m[tester::#MK1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received bytes: "-ERR value is not an integer or out of range\r\n"[0m
-[33m[tester::#MK1] [0m[36mclient: Received RESP error: "ERR: ERR value is not an integer or out of range"[0m
-[33m[tester::#MK1] [0m[92mReceived "ERR: ERR value is not an integer or out of range"[0m
+[33m[tester::#MK1] [client] [0m[94m$ redis-cli SET banana apple[0m
+[33m[tester::#MK1] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$5\r\napple\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#MK1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#MK1] [client] [0m[94m> INCR banana[0m
+[33m[tester::#MK1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived bytes: "-ERR value is not an integer or out of range\r\n"[0m
+[33m[tester::#MK1] [client] [0m[36mReceived RESP error: "ERR: ERR value is not an integer or out of range"[0m
+[33m[tester::#MK1] [client] [0m[92mReceived "ERR: ERR value is not an integer or out of range"[0m
 [33m[tester::#MK1] [0m[92mTest passed.[0m
 [33m[tester::#MK1] [0m[36mTerminating program[0m
 [33m[tester::#MK1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#LZ8] [0m[94mRunning tests for Stage #LZ8 (lz8)[0m
 [33m[tester::#LZ8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LZ8] [0m[94mclient: $ redis-cli INCR pear[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$4\r\npear\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP integer: 1[0m
-[33m[tester::#LZ8] [0m[92mReceived 1[0m
-[33m[tester::#LZ8] [0m[94mclient: > INCR pear[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$4\r\npear\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: ":2\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP integer: 2[0m
-[33m[tester::#LZ8] [0m[92mReceived 2[0m
-[33m[tester::#LZ8] [0m[94mclient: > GET pear[0m
-[33m[tester::#LZ8] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received bytes: "$1\r\n2\r\n"[0m
-[33m[tester::#LZ8] [0m[36mclient: Received RESP bulk string: "2"[0m
-[33m[tester::#LZ8] [0m[92mReceived "2"[0m
+[33m[tester::#LZ8] [client] [0m[94m$ redis-cli INCR pear[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP integer: 1[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived 1[0m
+[33m[tester::#LZ8] [client] [0m[94m> INCR pear[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: ":2\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP integer: 2[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived 2[0m
+[33m[tester::#LZ8] [client] [0m[94m> GET pear[0m
+[33m[tester::#LZ8] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived bytes: "$1\r\n2\r\n"[0m
+[33m[tester::#LZ8] [client] [0m[36mReceived RESP bulk string: "2"[0m
+[33m[tester::#LZ8] [client] [0m[92mReceived "2"[0m
 [33m[tester::#LZ8] [0m[92mTest passed.[0m
 [33m[tester::#LZ8] [0m[36mTerminating program[0m
 [33m[tester::#LZ8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#SI4] [0m[94mRunning tests for Stage #SI4 (si4)[0m
 [33m[tester::#SI4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SI4] [0m[94mclient: $ redis-cli SET apple 35[0m
-[33m[tester::#SI4] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n35\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#SI4] [0m[92mReceived "OK"[0m
-[33m[tester::#SI4] [0m[94mclient: > INCR apple[0m
-[33m[tester::#SI4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received bytes: ":36\r\n"[0m
-[33m[tester::#SI4] [0m[36mclient: Received RESP integer: 36[0m
-[33m[tester::#SI4] [0m[92mReceived 36[0m
+[33m[tester::#SI4] [client] [0m[94m$ redis-cli SET apple 35[0m
+[33m[tester::#SI4] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n35\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#SI4] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#SI4] [client] [0m[94m> INCR apple[0m
+[33m[tester::#SI4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINCR\r\n$5\r\napple\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived bytes: ":36\r\n"[0m
+[33m[tester::#SI4] [client] [0m[36mReceived RESP integer: 36[0m
+[33m[tester::#SI4] [client] [0m[92mReceived 36[0m
 [33m[tester::#SI4] [0m[92mTest passed.[0m
 [33m[tester::#SI4] [0m[36mTerminating program[0m
 [33m[tester::#SI4] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XU1] [0m[94mRunning tests for Stage #XU1 (xu1)[0m
 [33m[tester::#XU1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU1] [0m[94mredis-cli: $ redis-cli XADD apple 0-1 temperature 10[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP bulk string: "0-1"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-1"[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 0 streams apple $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$5\r\napple\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[94mother-redis-cli: $ redis-cli XADD apple 0-2 temperature 10[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#XU1] [0m[36mother-redis-cli: Received RESP bulk string: "0-2"[0m
-[33m[tester::#XU1] [0m[92mReceived "0-2"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*1\r\n*2\r\n$5\r\napple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP array: [[0m
-[33m[tester::#XU1] [0m[36m  [[0m
-[33m[tester::#XU1] [0m[36m    "apple",[0m
-[33m[tester::#XU1] [0m[36m    [[0m
-[33m[tester::#XU1] [0m[36m      [[0m
-[33m[tester::#XU1] [0m[36m        "0-2",[0m
-[33m[tester::#XU1] [0m[36m        ["temperature", "10"][0m
-[33m[tester::#XU1] [0m[36m      ][0m
-[33m[tester::#XU1] [0m[36m    ][0m
-[33m[tester::#XU1] [0m[36m  ][0m
-[33m[tester::#XU1] [0m[36m][0m
-[33m[tester::#XU1] [0m[36m[0m
-[33m[tester::#XU1] [0m[92mReceived [[0m
-[33m[tester::#XU1] [0m[92m  [[0m
-[33m[tester::#XU1] [0m[92m    "apple",[0m
-[33m[tester::#XU1] [0m[92m    [[0m
-[33m[tester::#XU1] [0m[92m      [[0m
-[33m[tester::#XU1] [0m[92m        "0-2",[0m
-[33m[tester::#XU1] [0m[92m        ["temperature", "10"][0m
-[33m[tester::#XU1] [0m[92m      ][0m
-[33m[tester::#XU1] [0m[92m    ][0m
-[33m[tester::#XU1] [0m[92m  ][0m
-[33m[tester::#XU1] [0m[92m][0m
-[33m[tester::#XU1] [0m[92m[0m
-[33m[tester::#XU1] [0m[94mredis-cli: > XREAD block 1000 streams apple $[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$5\r\napple\r\n$1\r\n$\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received bytes: "*-1\r\n"[0m
-[33m[tester::#XU1] [0m[36mredis-cli: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#XU1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94m$ redis-cli XADD apple 0-1 temperature 10[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 0 streams apple $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$5\r\napple\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[94mSleeping for 1000 ms[0m
+[33m[tester::#XU1] [client-2] [0m[94m$ redis-cli XADD apple 0-2 temperature 10[0m
+[33m[tester::#XU1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#XU1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#XU1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$5\r\napple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XU1] [client-1] [0m[36m  [[0m
+[33m[tester::#XU1] [client-1] [0m[36m    "apple",[0m
+[33m[tester::#XU1] [client-1] [0m[36m    [[0m
+[33m[tester::#XU1] [client-1] [0m[36m      [[0m
+[33m[tester::#XU1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[36m        ["temperature", "10"][0m
+[33m[tester::#XU1] [client-1] [0m[36m      ][0m
+[33m[tester::#XU1] [client-1] [0m[36m    ][0m
+[33m[tester::#XU1] [client-1] [0m[36m  ][0m
+[33m[tester::#XU1] [client-1] [0m[36m][0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#XU1] [client-1] [0m[92m  [[0m
+[33m[tester::#XU1] [client-1] [0m[92m    "apple",[0m
+[33m[tester::#XU1] [client-1] [0m[92m    [[0m
+[33m[tester::#XU1] [client-1] [0m[92m      [[0m
+[33m[tester::#XU1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#XU1] [client-1] [0m[92m        ["temperature", "10"][0m
+[33m[tester::#XU1] [client-1] [0m[92m      ][0m
+[33m[tester::#XU1] [client-1] [0m[92m    ][0m
+[33m[tester::#XU1] [client-1] [0m[92m  ][0m
+[33m[tester::#XU1] [client-1] [0m[92m][0m
+[33m[tester::#XU1] [client-1] [0m[94m> XREAD block 1000 streams apple $[0m
+[33m[tester::#XU1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$5\r\napple\r\n$1\r\n$\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#XU1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#XU1] [0m[92mTest passed.[0m
 [33m[tester::#XU1] [0m[36mTerminating program[0m
 [33m[tester::#XU1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HW1] [0m[94mRunning tests for Stage #HW1 (hw1)[0m
 [33m[tester::#HW1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HW1] [0m[94mclient-1: $ redis-cli XADD blueberry 0-1 temperature 54[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n54\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-1"[0m
-[33m[tester::#HW1] [0m[94mclient-1: > XREAD block 0 streams blueberry 0-1[0m
-[33m[tester::#HW1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#HW1] [0m[94mclient-2: $ redis-cli XADD blueberry 0-2 temperature 2[0m
-[33m[tester::#HW1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$1\r\n2\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#HW1] [0m[92mReceived "0-2"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n2\r\n"[0m
-[33m[tester::#HW1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#HW1] [0m[36m  [[0m
-[33m[tester::#HW1] [0m[36m    "blueberry",[0m
-[33m[tester::#HW1] [0m[36m    [[0m
-[33m[tester::#HW1] [0m[36m      [[0m
-[33m[tester::#HW1] [0m[36m        "0-2",[0m
-[33m[tester::#HW1] [0m[36m        ["temperature", "2"][0m
-[33m[tester::#HW1] [0m[36m      ][0m
-[33m[tester::#HW1] [0m[36m    ][0m
-[33m[tester::#HW1] [0m[36m  ][0m
-[33m[tester::#HW1] [0m[36m][0m
-[33m[tester::#HW1] [0m[36m[0m
-[33m[tester::#HW1] [0m[92mReceived [[0m
-[33m[tester::#HW1] [0m[92m  [[0m
-[33m[tester::#HW1] [0m[92m    "blueberry",[0m
-[33m[tester::#HW1] [0m[92m    [[0m
-[33m[tester::#HW1] [0m[92m      [[0m
-[33m[tester::#HW1] [0m[92m        "0-2",[0m
-[33m[tester::#HW1] [0m[92m        ["temperature", "2"][0m
-[33m[tester::#HW1] [0m[92m      ][0m
-[33m[tester::#HW1] [0m[92m    ][0m
-[33m[tester::#HW1] [0m[92m  ][0m
-[33m[tester::#HW1] [0m[92m][0m
-[33m[tester::#HW1] [0m[92m[0m
+[33m[tester::#HW1] [client-1] [0m[94m$ redis-cli XADD blueberry 0-1 temperature 54[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n54\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#HW1] [client-1] [0m[94m> XREAD block 0 streams blueberry 0-1[0m
+[33m[tester::#HW1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$1\r\n0\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[94m$ redis-cli XADD blueberry 0-2 temperature 2[0m
+[33m[tester::#HW1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$1\r\n2\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#HW1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#HW1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n2\r\n"[0m
+[33m[tester::#HW1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#HW1] [client-1] [0m[36m  [[0m
+[33m[tester::#HW1] [client-1] [0m[36m    "blueberry",[0m
+[33m[tester::#HW1] [client-1] [0m[36m    [[0m
+[33m[tester::#HW1] [client-1] [0m[36m      [[0m
+[33m[tester::#HW1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[36m        ["temperature", "2"][0m
+[33m[tester::#HW1] [client-1] [0m[36m      ][0m
+[33m[tester::#HW1] [client-1] [0m[36m    ][0m
+[33m[tester::#HW1] [client-1] [0m[36m  ][0m
+[33m[tester::#HW1] [client-1] [0m[36m][0m
+[33m[tester::#HW1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#HW1] [client-1] [0m[92m  [[0m
+[33m[tester::#HW1] [client-1] [0m[92m    "blueberry",[0m
+[33m[tester::#HW1] [client-1] [0m[92m    [[0m
+[33m[tester::#HW1] [client-1] [0m[92m      [[0m
+[33m[tester::#HW1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#HW1] [client-1] [0m[92m        ["temperature", "2"][0m
+[33m[tester::#HW1] [client-1] [0m[92m      ][0m
+[33m[tester::#HW1] [client-1] [0m[92m    ][0m
+[33m[tester::#HW1] [client-1] [0m[92m  ][0m
+[33m[tester::#HW1] [client-1] [0m[92m][0m
 [33m[tester::#HW1] [0m[92mTest passed.[0m
 [33m[tester::#HW1] [0m[36mTerminating program[0m
 [33m[tester::#HW1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#BS1] [0m[94mRunning tests for Stage #BS1 (bs1)[0m
 [33m[tester::#BS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#BS1] [0m[94mclient-1: $ redis-cli XADD pineapple 0-1 temperature 10[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP bulk string: "0-1"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#BS1] [0m[94mWaiting for 500ms[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams pineapple 0-1[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#BS1] [0m[94mclient-2: $ redis-cli XADD pineapple 0-2 temperature 99[0m
-[33m[tester::#BS1] [0m[36mclient-2: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-2: Received RESP bulk string: "0-2"[0m
-[33m[tester::#BS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*1\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP array: [[0m
-[33m[tester::#BS1] [0m[36m  [[0m
-[33m[tester::#BS1] [0m[36m    "pineapple",[0m
-[33m[tester::#BS1] [0m[36m    [[0m
-[33m[tester::#BS1] [0m[36m      [[0m
-[33m[tester::#BS1] [0m[36m        "0-2",[0m
-[33m[tester::#BS1] [0m[36m        ["temperature", "99"][0m
-[33m[tester::#BS1] [0m[36m      ][0m
-[33m[tester::#BS1] [0m[36m    ][0m
-[33m[tester::#BS1] [0m[36m  ][0m
-[33m[tester::#BS1] [0m[36m][0m
-[33m[tester::#BS1] [0m[36m[0m
-[33m[tester::#BS1] [0m[92mReceived [[0m
-[33m[tester::#BS1] [0m[92m  [[0m
-[33m[tester::#BS1] [0m[92m    "pineapple",[0m
-[33m[tester::#BS1] [0m[92m    [[0m
-[33m[tester::#BS1] [0m[92m      [[0m
-[33m[tester::#BS1] [0m[92m        "0-2",[0m
-[33m[tester::#BS1] [0m[92m        ["temperature", "99"][0m
-[33m[tester::#BS1] [0m[92m      ][0m
-[33m[tester::#BS1] [0m[92m    ][0m
-[33m[tester::#BS1] [0m[92m  ][0m
-[33m[tester::#BS1] [0m[92m][0m
-[33m[tester::#BS1] [0m[92m[0m
-[33m[tester::#BS1] [0m[94mclient-1: > XREAD block 1000 streams pineapple 0-2[0m
-[33m[tester::#BS1] [0m[36mclient-1: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received bytes: "*-1\r\n"[0m
-[33m[tester::#BS1] [0m[36mclient-1: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#BS1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94m$ redis-cli XADD pineapple 0-1 temperature 10[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n10\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "0-1"[0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams pineapple 0-1[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[94mWaiting for 500 ms[0m
+[33m[tester::#BS1] [client-2] [0m[94m$ redis-cli XADD pineapple 0-2 temperature 99[0m
+[33m[tester::#BS1] [client-2] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-2] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#BS1] [client-2] [0m[92mReceived "0-2"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\npineapple\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n99\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP array: [[0m
+[33m[tester::#BS1] [client-1] [0m[36m  [[0m
+[33m[tester::#BS1] [client-1] [0m[36m    "pineapple",[0m
+[33m[tester::#BS1] [client-1] [0m[36m    [[0m
+[33m[tester::#BS1] [client-1] [0m[36m      [[0m
+[33m[tester::#BS1] [client-1] [0m[36m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[36m        ["temperature", "99"][0m
+[33m[tester::#BS1] [client-1] [0m[36m      ][0m
+[33m[tester::#BS1] [client-1] [0m[36m    ][0m
+[33m[tester::#BS1] [client-1] [0m[36m  ][0m
+[33m[tester::#BS1] [client-1] [0m[36m][0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived [[0m
+[33m[tester::#BS1] [client-1] [0m[92m  [[0m
+[33m[tester::#BS1] [client-1] [0m[92m    "pineapple",[0m
+[33m[tester::#BS1] [client-1] [0m[92m    [[0m
+[33m[tester::#BS1] [client-1] [0m[92m      [[0m
+[33m[tester::#BS1] [client-1] [0m[92m        "0-2",[0m
+[33m[tester::#BS1] [client-1] [0m[92m        ["temperature", "99"][0m
+[33m[tester::#BS1] [client-1] [0m[92m      ][0m
+[33m[tester::#BS1] [client-1] [0m[92m    ][0m
+[33m[tester::#BS1] [client-1] [0m[92m  ][0m
+[33m[tester::#BS1] [client-1] [0m[92m][0m
+[33m[tester::#BS1] [client-1] [0m[94m> XREAD block 1000 streams pineapple 0-2[0m
+[33m[tester::#BS1] [client-1] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$5\r\nblock\r\n$4\r\n1000\r\n$7\r\nstreams\r\n$9\r\npineapple\r\n$3\r\n0-2\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived bytes: "*-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#BS1] [client-1] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#BS1] [0m[92mTest passed.[0m
 [33m[tester::#BS1] [0m[36mTerminating program[0m
 [33m[tester::#BS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#RU9] [0m[94mRunning tests for Stage #RU9 (ru9)[0m
 [33m[tester::#RU9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RU9] [0m[94mclient: $ redis-cli XADD pear 0-1 temperature 0[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-1"[0m
-[33m[tester::#RU9] [0m[94mclient: > XADD raspberry 0-2 humidity 1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#RU9] [0m[92mReceived "0-2"[0m
-[33m[tester::#RU9] [0m[94mclient: > XREAD streams pear raspberry 0-0 0-1[0m
-[33m[tester::#RU9] [0m[36mclient: Sent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received bytes: "*2\r\n*2\r\n$4\r\npear\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$9\r\nraspberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
-[33m[tester::#RU9] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "pear",[0m
-[33m[tester::#RU9] [0m[36m    [[0m
-[33m[tester::#RU9] [0m[36m      [[0m
-[33m[tester::#RU9] [0m[36m        "0-1",[0m
-[33m[tester::#RU9] [0m[36m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[36m      ][0m
-[33m[tester::#RU9] [0m[36m    ][0m
-[33m[tester::#RU9] [0m[36m  ],[0m
-[33m[tester::#RU9] [0m[36m  [[0m
-[33m[tester::#RU9] [0m[36m    "raspberry",[0m
-[33m[tester::#RU9] [0m[36m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[36m  ][0m
-[33m[tester::#RU9] [0m[36m][0m
-[33m[tester::#RU9] [0m[36m[0m
-[33m[tester::#RU9] [0m[92mReceived [[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "pear",[0m
-[33m[tester::#RU9] [0m[92m    [[0m
-[33m[tester::#RU9] [0m[92m      [[0m
-[33m[tester::#RU9] [0m[92m        "0-1",[0m
-[33m[tester::#RU9] [0m[92m        ["temperature", "0"][0m
-[33m[tester::#RU9] [0m[92m      ][0m
-[33m[tester::#RU9] [0m[92m    ][0m
-[33m[tester::#RU9] [0m[92m  ],[0m
-[33m[tester::#RU9] [0m[92m  [[0m
-[33m[tester::#RU9] [0m[92m    "raspberry",[0m
-[33m[tester::#RU9] [0m[92m    [["0-2", ["humidity", "1"]]][0m
-[33m[tester::#RU9] [0m[92m  ][0m
-[33m[tester::#RU9] [0m[92m][0m
-[33m[tester::#RU9] [0m[92m[0m
+[33m[tester::#RU9] [client] [0m[94m$ redis-cli XADD pear 0-1 temperature 0[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$1\r\n0\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#RU9] [client] [0m[94m> XADD raspberry 0-2 humidity 1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#RU9] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#RU9] [client] [0m[94m> XREAD streams pear raspberry 0-0 0-1[0m
+[33m[tester::#RU9] [client] [0m[36mSent bytes: "*6\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$3\r\n0-0\r\n$3\r\n0-1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived bytes: "*2\r\n*2\r\n$4\r\npear\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$1\r\n0\r\n*2\r\n$9\r\nraspberry\r\n*1\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$8\r\nhumidity\r\n$1\r\n1\r\n"[0m
+[33m[tester::#RU9] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "pear",[0m
+[33m[tester::#RU9] [client] [0m[36m    [[0m
+[33m[tester::#RU9] [client] [0m[36m      [[0m
+[33m[tester::#RU9] [client] [0m[36m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[36m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[36m      ][0m
+[33m[tester::#RU9] [client] [0m[36m    ][0m
+[33m[tester::#RU9] [client] [0m[36m  ],[0m
+[33m[tester::#RU9] [client] [0m[36m  [[0m
+[33m[tester::#RU9] [client] [0m[36m    "raspberry",[0m
+[33m[tester::#RU9] [client] [0m[36m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[36m  ][0m
+[33m[tester::#RU9] [client] [0m[36m][0m
+[33m[tester::#RU9] [client] [0m[92mReceived [[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "pear",[0m
+[33m[tester::#RU9] [client] [0m[92m    [[0m
+[33m[tester::#RU9] [client] [0m[92m      [[0m
+[33m[tester::#RU9] [client] [0m[92m        "0-1",[0m
+[33m[tester::#RU9] [client] [0m[92m        ["temperature", "0"][0m
+[33m[tester::#RU9] [client] [0m[92m      ][0m
+[33m[tester::#RU9] [client] [0m[92m    ][0m
+[33m[tester::#RU9] [client] [0m[92m  ],[0m
+[33m[tester::#RU9] [client] [0m[92m  [[0m
+[33m[tester::#RU9] [client] [0m[92m    "raspberry",[0m
+[33m[tester::#RU9] [client] [0m[92m    [["0-2", ["humidity", "1"]]][0m
+[33m[tester::#RU9] [client] [0m[92m  ][0m
+[33m[tester::#RU9] [client] [0m[92m][0m
 [33m[tester::#RU9] [0m[92mTest passed.[0m
 [33m[tester::#RU9] [0m[36mTerminating program[0m
 [33m[tester::#RU9] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#UM0] [0m[94mRunning tests for Stage #UM0 (um0)[0m
 [33m[tester::#UM0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#UM0] [0m[94mclient: $ redis-cli XADD blueberry 0-1 temperature 38[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n38\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#UM0] [0m[92mReceived "0-1"[0m
-[33m[tester::#UM0] [0m[94mclient: > XREAD streams blueberry 0-0[0m
-[33m[tester::#UM0] [0m[36mclient: Sent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-0\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n38\r\n"[0m
-[33m[tester::#UM0] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#UM0] [0m[36m  [[0m
-[33m[tester::#UM0] [0m[36m    "blueberry",[0m
-[33m[tester::#UM0] [0m[36m    [[0m
-[33m[tester::#UM0] [0m[36m      [[0m
-[33m[tester::#UM0] [0m[36m        "0-1",[0m
-[33m[tester::#UM0] [0m[36m        ["temperature", "38"][0m
-[33m[tester::#UM0] [0m[36m      ][0m
-[33m[tester::#UM0] [0m[36m    ][0m
-[33m[tester::#UM0] [0m[36m  ][0m
-[33m[tester::#UM0] [0m[36m][0m
-[33m[tester::#UM0] [0m[36m[0m
-[33m[tester::#UM0] [0m[92mReceived [[0m
-[33m[tester::#UM0] [0m[92m  [[0m
-[33m[tester::#UM0] [0m[92m    "blueberry",[0m
-[33m[tester::#UM0] [0m[92m    [[0m
-[33m[tester::#UM0] [0m[92m      [[0m
-[33m[tester::#UM0] [0m[92m        "0-1",[0m
-[33m[tester::#UM0] [0m[92m        ["temperature", "38"][0m
-[33m[tester::#UM0] [0m[92m      ][0m
-[33m[tester::#UM0] [0m[92m    ][0m
-[33m[tester::#UM0] [0m[92m  ][0m
-[33m[tester::#UM0] [0m[92m][0m
-[33m[tester::#UM0] [0m[92m[0m
+[33m[tester::#UM0] [client] [0m[94m$ redis-cli XADD blueberry 0-1 temperature 38[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$3\r\n0-1\r\n$11\r\ntemperature\r\n$2\r\n38\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#UM0] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#UM0] [client] [0m[94m> XREAD streams blueberry 0-0[0m
+[33m[tester::#UM0] [client] [0m[36mSent bytes: "*4\r\n$5\r\nXREAD\r\n$7\r\nstreams\r\n$9\r\nblueberry\r\n$3\r\n0-0\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived bytes: "*1\r\n*2\r\n$9\r\nblueberry\r\n*1\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$11\r\ntemperature\r\n$2\r\n38\r\n"[0m
+[33m[tester::#UM0] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#UM0] [client] [0m[36m  [[0m
+[33m[tester::#UM0] [client] [0m[36m    "blueberry",[0m
+[33m[tester::#UM0] [client] [0m[36m    [[0m
+[33m[tester::#UM0] [client] [0m[36m      [[0m
+[33m[tester::#UM0] [client] [0m[36m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[36m        ["temperature", "38"][0m
+[33m[tester::#UM0] [client] [0m[36m      ][0m
+[33m[tester::#UM0] [client] [0m[36m    ][0m
+[33m[tester::#UM0] [client] [0m[36m  ][0m
+[33m[tester::#UM0] [client] [0m[36m][0m
+[33m[tester::#UM0] [client] [0m[92mReceived [[0m
+[33m[tester::#UM0] [client] [0m[92m  [[0m
+[33m[tester::#UM0] [client] [0m[92m    "blueberry",[0m
+[33m[tester::#UM0] [client] [0m[92m    [[0m
+[33m[tester::#UM0] [client] [0m[92m      [[0m
+[33m[tester::#UM0] [client] [0m[92m        "0-1",[0m
+[33m[tester::#UM0] [client] [0m[92m        ["temperature", "38"][0m
+[33m[tester::#UM0] [client] [0m[92m      ][0m
+[33m[tester::#UM0] [client] [0m[92m    ][0m
+[33m[tester::#UM0] [client] [0m[92m  ][0m
+[33m[tester::#UM0] [client] [0m[92m][0m
 [33m[tester::#UM0] [0m[92mTest passed.[0m
 [33m[tester::#UM0] [0m[36mTerminating program[0m
 [33m[tester::#UM0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FS1] [0m[94mRunning tests for Stage #FS1 (fs1)[0m
 [33m[tester::#FS1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FS1] [0m[94mclient: $ redis-cli XADD banana 0-1 raspberry mango[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-1"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD banana 0-2 raspberry banana[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-2\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-2"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD banana 0-3 mango pear[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-3\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-3"[0m
-[33m[tester::#FS1] [0m[94mclient: > XADD banana 0-4 apple pear[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-4\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "$3\r\n0-4\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP bulk string: "0-4"[0m
-[33m[tester::#FS1] [0m[92mReceived "0-4"[0m
-[33m[tester::#FS1] [0m[94mclient: > XRANGE banana 0-1 +[0m
-[33m[tester::#FS1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$1\r\n+\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received bytes: "*4\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$5\r\nmango\r\n$4\r\npear\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
-[33m[tester::#FS1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#FS1] [0m[36m  [[0m
-[33m[tester::#FS1] [0m[36m    "0-1",[0m
-[33m[tester::#FS1] [0m[36m    ["raspberry", "mango"][0m
-[33m[tester::#FS1] [0m[36m  ],[0m
-[33m[tester::#FS1] [0m[36m  [[0m
-[33m[tester::#FS1] [0m[36m    "0-2",[0m
-[33m[tester::#FS1] [0m[36m    ["raspberry", "banana"][0m
-[33m[tester::#FS1] [0m[36m  ],[0m
-[33m[tester::#FS1] [0m[36m  ["0-3", ["mango", "pear"]],[0m
-[33m[tester::#FS1] [0m[36m  ["0-4", ["apple", "pear"]][0m
-[33m[tester::#FS1] [0m[36m][0m
-[33m[tester::#FS1] [0m[36m[0m
-[33m[tester::#FS1] [0m[92mReceived [[0m
-[33m[tester::#FS1] [0m[92m  [[0m
-[33m[tester::#FS1] [0m[92m    "0-1",[0m
-[33m[tester::#FS1] [0m[92m    ["raspberry", "mango"][0m
-[33m[tester::#FS1] [0m[92m  ],[0m
-[33m[tester::#FS1] [0m[92m  [[0m
-[33m[tester::#FS1] [0m[92m    "0-2",[0m
-[33m[tester::#FS1] [0m[92m    ["raspberry", "banana"][0m
-[33m[tester::#FS1] [0m[92m  ],[0m
-[33m[tester::#FS1] [0m[92m  ["0-3", ["mango", "pear"]],[0m
-[33m[tester::#FS1] [0m[92m  ["0-4", ["apple", "pear"]][0m
-[33m[tester::#FS1] [0m[92m][0m
-[33m[tester::#FS1] [0m[92m[0m
+[33m[tester::#FS1] [client] [0m[94m$ redis-cli XADD banana 0-1 raspberry mango[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD banana 0-2 raspberry banana[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-2\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD banana 0-3 mango pear[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-3\r\n$5\r\nmango\r\n$4\r\npear\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#FS1] [client] [0m[94m> XADD banana 0-4 apple pear[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-4\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "$3\r\n0-4\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP bulk string: "0-4"[0m
+[33m[tester::#FS1] [client] [0m[92mReceived "0-4"[0m
+[33m[tester::#FS1] [client] [0m[94m> XRANGE banana 0-1 +[0m
+[33m[tester::#FS1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$1\r\n+\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived bytes: "*4\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$9\r\nraspberry\r\n$5\r\nmango\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$5\r\nmango\r\n$4\r\npear\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$5\r\napple\r\n$4\r\npear\r\n"[0m
+[33m[tester::#FS1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#FS1] [client] [0m[36m  [[0m
+[33m[tester::#FS1] [client] [0m[36m    "0-1",[0m
+[33m[tester::#FS1] [client] [0m[36m    ["raspberry", "mango"][0m
+[33m[tester::#FS1] [client] [0m[36m  ],[0m
+[33m[tester::#FS1] [client] [0m[36m  [[0m
+[33m[tester::#FS1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#FS1] [client] [0m[36m    ["raspberry", "banana"][0m
+[33m[tester::#FS1] [client] [0m[36m  ],[0m
+[33m[tester::#FS1] [client] [0m[36m  ["0-3", ["mango", "pear"]],[0m
+[33m[tester::#FS1] [client] [0m[36m  ["0-4", ["apple", "pear"]][0m
+[33m[tester::#FS1] [client] [0m[36m][0m
+[33m[tester::#FS1] [client] [0m[92mReceived [[0m
+[33m[tester::#FS1] [client] [0m[92m  [[0m
+[33m[tester::#FS1] [client] [0m[92m    "0-1",[0m
+[33m[tester::#FS1] [client] [0m[92m    ["raspberry", "mango"][0m
+[33m[tester::#FS1] [client] [0m[92m  ],[0m
+[33m[tester::#FS1] [client] [0m[92m  [[0m
+[33m[tester::#FS1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#FS1] [client] [0m[92m    ["raspberry", "banana"][0m
+[33m[tester::#FS1] [client] [0m[92m  ],[0m
+[33m[tester::#FS1] [client] [0m[92m  ["0-3", ["mango", "pear"]],[0m
+[33m[tester::#FS1] [client] [0m[92m  ["0-4", ["apple", "pear"]][0m
+[33m[tester::#FS1] [client] [0m[92m][0m
 [33m[tester::#FS1] [0m[92mTest passed.[0m
 [33m[tester::#FS1] [0m[36mTerminating program[0m
 [33m[tester::#FS1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YP1] [0m[94mRunning tests for Stage #YP1 (yp1)[0m
 [33m[tester::#YP1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YP1] [0m[94mclient: $ redis-cli XADD raspberry 0-1 banana raspberry[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-1\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-1"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD raspberry 0-2 strawberry pineapple[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-2"[0m
-[33m[tester::#YP1] [0m[94mclient: > XADD raspberry 0-3 grape pear[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-3\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#YP1] [0m[92mReceived "0-3"[0m
-[33m[tester::#YP1] [0m[94mclient: > XRANGE raspberry - 0-3[0m
-[33m[tester::#YP1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nraspberry\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
-[33m[tester::#YP1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-1",[0m
-[33m[tester::#YP1] [0m[36m    ["banana", "raspberry"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  [[0m
-[33m[tester::#YP1] [0m[36m    "0-2",[0m
-[33m[tester::#YP1] [0m[36m    ["strawberry", "pineapple"][0m
-[33m[tester::#YP1] [0m[36m  ],[0m
-[33m[tester::#YP1] [0m[36m  ["0-3", ["grape", "pear"]][0m
-[33m[tester::#YP1] [0m[36m][0m
-[33m[tester::#YP1] [0m[36m[0m
-[33m[tester::#YP1] [0m[92mReceived [[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-1",[0m
-[33m[tester::#YP1] [0m[92m    ["banana", "raspberry"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  [[0m
-[33m[tester::#YP1] [0m[92m    "0-2",[0m
-[33m[tester::#YP1] [0m[92m    ["strawberry", "pineapple"][0m
-[33m[tester::#YP1] [0m[92m  ],[0m
-[33m[tester::#YP1] [0m[92m  ["0-3", ["grape", "pear"]][0m
-[33m[tester::#YP1] [0m[92m][0m
-[33m[tester::#YP1] [0m[92m[0m
+[33m[tester::#YP1] [client] [0m[94m$ redis-cli XADD raspberry 0-1 banana raspberry[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-1\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD raspberry 0-2 strawberry pineapple[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-2\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#YP1] [client] [0m[94m> XADD raspberry 0-3 grape pear[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$3\r\n0-3\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#YP1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#YP1] [client] [0m[94m> XRANGE raspberry - 0-3[0m
+[33m[tester::#YP1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$9\r\nraspberry\r\n$1\r\n-\r\n$3\r\n0-3\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived bytes: "*3\r\n*2\r\n$3\r\n0-1\r\n*2\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
+[33m[tester::#YP1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["banana", "raspberry"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  [[0m
+[33m[tester::#YP1] [client] [0m[36m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[36m    ["strawberry", "pineapple"][0m
+[33m[tester::#YP1] [client] [0m[36m  ],[0m
+[33m[tester::#YP1] [client] [0m[36m  ["0-3", ["grape", "pear"]][0m
+[33m[tester::#YP1] [client] [0m[36m][0m
+[33m[tester::#YP1] [client] [0m[92mReceived [[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-1",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["banana", "raspberry"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  [[0m
+[33m[tester::#YP1] [client] [0m[92m    "0-2",[0m
+[33m[tester::#YP1] [client] [0m[92m    ["strawberry", "pineapple"][0m
+[33m[tester::#YP1] [client] [0m[92m  ],[0m
+[33m[tester::#YP1] [client] [0m[92m  ["0-3", ["grape", "pear"]][0m
+[33m[tester::#YP1] [client] [0m[92m][0m
 [33m[tester::#YP1] [0m[92mTest passed.[0m
 [33m[tester::#YP1] [0m[36mTerminating program[0m
 [33m[tester::#YP1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZX1] [0m[94mRunning tests for Stage #ZX1 (zx1)[0m
 [33m[tester::#ZX1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZX1] [0m[94mclient: $ redis-cli XADD mango 0-1 mango banana[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-1\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-1"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD mango 0-2 apple mango[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$5\r\napple\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-2\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-2"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-2"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD mango 0-3 orange strawberry[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-3\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-3\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-3"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-3"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XADD mango 0-4 raspberry orange[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-4\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "$3\r\n0-4\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP bulk string: "0-4"[0m
-[33m[tester::#ZX1] [0m[92mReceived "0-4"[0m
-[33m[tester::#ZX1] [0m[94mclient: > XRANGE mango 0-2 0-4[0m
-[33m[tester::#ZX1] [0m[36mclient: Sent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$3\r\n0-4\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received bytes: "*3\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\napple\r\n$5\r\nmango\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
-[33m[tester::#ZX1] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#ZX1] [0m[36m  ["0-2", ["apple", "mango"]],[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-3",[0m
-[33m[tester::#ZX1] [0m[36m    ["orange", "strawberry"][0m
-[33m[tester::#ZX1] [0m[36m  ],[0m
-[33m[tester::#ZX1] [0m[36m  [[0m
-[33m[tester::#ZX1] [0m[36m    "0-4",[0m
-[33m[tester::#ZX1] [0m[36m    ["raspberry", "orange"][0m
-[33m[tester::#ZX1] [0m[36m  ][0m
-[33m[tester::#ZX1] [0m[36m][0m
-[33m[tester::#ZX1] [0m[36m[0m
-[33m[tester::#ZX1] [0m[92mReceived [[0m
-[33m[tester::#ZX1] [0m[92m  ["0-2", ["apple", "mango"]],[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-3",[0m
-[33m[tester::#ZX1] [0m[92m    ["orange", "strawberry"][0m
-[33m[tester::#ZX1] [0m[92m  ],[0m
-[33m[tester::#ZX1] [0m[92m  [[0m
-[33m[tester::#ZX1] [0m[92m    "0-4",[0m
-[33m[tester::#ZX1] [0m[92m    ["raspberry", "orange"][0m
-[33m[tester::#ZX1] [0m[92m  ][0m
-[33m[tester::#ZX1] [0m[92m][0m
-[33m[tester::#ZX1] [0m[92m[0m
+[33m[tester::#ZX1] [client] [0m[94m$ redis-cli XADD mango 0-1 mango banana[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-1\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD mango 0-2 apple mango[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$5\r\napple\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-2\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-2"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD mango 0-3 orange strawberry[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-3\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-3\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-3"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XADD mango 0-4 raspberry orange[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$3\r\n0-4\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "$3\r\n0-4\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP bulk string: "0-4"[0m
+[33m[tester::#ZX1] [client] [0m[92mReceived "0-4"[0m
+[33m[tester::#ZX1] [client] [0m[94m> XRANGE mango 0-2 0-4[0m
+[33m[tester::#ZX1] [client] [0m[36mSent bytes: "*4\r\n$6\r\nXRANGE\r\n$5\r\nmango\r\n$3\r\n0-2\r\n$3\r\n0-4\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived bytes: "*3\r\n*2\r\n$3\r\n0-2\r\n*2\r\n$5\r\napple\r\n$5\r\nmango\r\n*2\r\n$3\r\n0-3\r\n*2\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n*2\r\n$3\r\n0-4\r\n*2\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#ZX1] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#ZX1] [client] [0m[36m  ["0-2", ["apple", "mango"]],[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["orange", "strawberry"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ],[0m
+[33m[tester::#ZX1] [client] [0m[36m  [[0m
+[33m[tester::#ZX1] [client] [0m[36m    "0-4",[0m
+[33m[tester::#ZX1] [client] [0m[36m    ["raspberry", "orange"][0m
+[33m[tester::#ZX1] [client] [0m[36m  ][0m
+[33m[tester::#ZX1] [client] [0m[36m][0m
+[33m[tester::#ZX1] [client] [0m[92mReceived [[0m
+[33m[tester::#ZX1] [client] [0m[92m  ["0-2", ["apple", "mango"]],[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-3",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["orange", "strawberry"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ],[0m
+[33m[tester::#ZX1] [client] [0m[92m  [[0m
+[33m[tester::#ZX1] [client] [0m[92m    "0-4",[0m
+[33m[tester::#ZX1] [client] [0m[92m    ["raspberry", "orange"][0m
+[33m[tester::#ZX1] [client] [0m[92m  ][0m
+[33m[tester::#ZX1] [client] [0m[92m][0m
 [33m[tester::#ZX1] [0m[92mTest passed.[0m
 [33m[tester::#ZX1] [0m[36mTerminating program[0m
 [33m[tester::#ZX1] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XU6] [0m[94mRunning tests for Stage #XU6 (xu6)[0m
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XU6] [0m[94mclient: $ redis-cli XADD banana * foo bar[0m
-[33m[tester::#XU6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received bytes: "$15\r\n1751946710193-0\r\n"[0m
-[33m[tester::#XU6] [0m[36mclient: Received RESP bulk string: "1751946710193-0"[0m
-[33m[tester::#XU6] [0m[92mReceived "1751946710193-0"[0m
+[33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD banana * foo bar[0m
+[33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752030963723-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752030963723-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1752030963723-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -785,89 +758,89 @@ Debug = true
 
 [33m[tester::#YH3] [0m[94mRunning tests for Stage #YH3 (yh3)[0m
 [33m[tester::#YH3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YH3] [0m[94mclient: $ redis-cli XADD pear 0-* pineapple strawberry[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-*\r\n$9\r\npineapple\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "0-1"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD pear 1-* pineapple strawberry[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-*\r\n$9\r\npineapple\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-0\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-0"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-0"[0m
-[33m[tester::#YH3] [0m[94mclient: > XADD pear 1-* strawberry mango[0m
-[33m[tester::#YH3] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-*\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#YH3] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#YH3] [0m[92mReceived "1-1"[0m
+[33m[tester::#YH3] [client] [0m[94m$ redis-cli XADD pear 0-* pineapple strawberry[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n0-*\r\n$9\r\npineapple\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD pear 1-* pineapple strawberry[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-*\r\n$9\r\npineapple\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-0\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-0"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-0"[0m
+[33m[tester::#YH3] [client] [0m[94m> XADD pear 1-* strawberry mango[0m
+[33m[tester::#YH3] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$3\r\n1-*\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#YH3] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#YH3] [client] [0m[92mReceived "1-1"[0m
 [33m[tester::#YH3] [0m[92mTest passed.[0m
 [33m[tester::#YH3] [0m[36mTerminating program[0m
 [33m[tester::#YH3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#HQ8] [0m[94mRunning tests for Stage #HQ8 (hq8)[0m
 [33m[tester::#HQ8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HQ8] [0m[94mclient: $ redis-cli XADD pineapple 1-1 grape pear[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-1\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-1\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-1"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-1"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pineapple 1-2 raspberry pineapple[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-2\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "$3\r\n1-2\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP bulk string: "1-2"[0m
-[33m[tester::#HQ8] [0m[92mReceived "1-2"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pineapple 1-2 orange mango[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-2\r\n$6\r\norange\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pineapple 0-3 apple blueberry[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
-[33m[tester::#HQ8] [0m[94mclient: > XADD pineapple 0-0 banana strawberry[0m
-[33m[tester::#HQ8] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-0\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
-[33m[tester::#HQ8] [0m[36mclient: Received RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
-[33m[tester::#HQ8] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[94m$ redis-cli XADD pineapple 1-1 grape pear[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-1\r\n$5\r\ngrape\r\n$4\r\npear\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-1\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-1"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pineapple 1-2 raspberry pineapple[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-2\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "$3\r\n1-2\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP bulk string: "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "1-2"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pineapple 1-2 orange mango[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n1-2\r\n$6\r\norange\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pineapple 0-3 apple blueberry[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-3\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD is equal or smaller than the target stream top item\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD is equal or smaller than the target stream top item"[0m
+[33m[tester::#HQ8] [client] [0m[94m> XADD pineapple 0-0 banana strawberry[0m
+[33m[tester::#HQ8] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\npineapple\r\n$3\r\n0-0\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived bytes: "-ERR The ID specified in XADD must be greater than 0-0\r\n"[0m
+[33m[tester::#HQ8] [client] [0m[36mReceived RESP error: "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
+[33m[tester::#HQ8] [client] [0m[92mReceived "ERR: ERR The ID specified in XADD must be greater than 0-0"[0m
 [33m[tester::#HQ8] [0m[92mTest passed.[0m
 [33m[tester::#HQ8] [0m[36mTerminating program[0m
 [33m[tester::#HQ8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF6] [0m[94mRunning tests for Stage #CF6 (cf6)[0m
 [33m[tester::#CF6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CF6] [0m[94mclient: $ redis-cli XADD banana 0-1 foo bar[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "$3\r\n0-1\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP bulk string: "0-1"[0m
-[33m[tester::#CF6] [0m[92mReceived "0-1"[0m
-[33m[tester::#CF6] [0m[94mclient: > TYPE banana[0m
-[33m[tester::#CF6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received bytes: "+stream\r\n"[0m
-[33m[tester::#CF6] [0m[36mclient: Received RESP simple string: "stream"[0m
-[33m[tester::#CF6] [0m[92mReceived "stream"[0m
+[33m[tester::#CF6] [client] [0m[94m$ redis-cli XADD banana 0-1 foo bar[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$3\r\n0-1\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "$3\r\n0-1\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP bulk string: "0-1"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "0-1"[0m
+[33m[tester::#CF6] [client] [0m[94m> TYPE banana[0m
+[33m[tester::#CF6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived bytes: "+stream\r\n"[0m
+[33m[tester::#CF6] [client] [0m[36mReceived RESP simple string: "stream"[0m
+[33m[tester::#CF6] [client] [0m[92mReceived "stream"[0m
 [33m[tester::#CF6] [0m[92mTest passed.[0m
 [33m[tester::#CF6] [0m[36mTerminating program[0m
 [33m[tester::#CF6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CC3] [0m[94mRunning tests for Stage #CC3 (cc3)[0m
 [33m[tester::#CC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#CC3] [0m[94mclient: $ redis-cli SET pineapple raspberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CC3] [0m[92mReceived "OK"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE pineapple[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+string\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "string"[0m
-[33m[tester::#CC3] [0m[92mReceived "string"[0m
-[33m[tester::#CC3] [0m[94mclient: > TYPE missing_key_raspberry[0m
-[33m[tester::#CC3] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nTYPE\r\n$21\r\nmissing_key_raspberry\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received bytes: "+none\r\n"[0m
-[33m[tester::#CC3] [0m[36mclient: Received RESP simple string: "none"[0m
-[33m[tester::#CC3] [0m[92mReceived "none"[0m
+[33m[tester::#CC3] [client] [0m[94m$ redis-cli SET pineapple raspberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE pineapple[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+string\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "string"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "string"[0m
+[33m[tester::#CC3] [client] [0m[94m> TYPE missing_key_raspberry[0m
+[33m[tester::#CC3] [client] [0m[36mSent bytes: "*2\r\n$4\r\nTYPE\r\n$21\r\nmissing_key_raspberry\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived bytes: "+none\r\n"[0m
+[33m[tester::#CC3] [client] [0m[36mReceived RESP simple string: "none"[0m
+[33m[tester::#CC3] [client] [0m[92mReceived "none"[0m
 [33m[tester::#CC3] [0m[92mTest passed.[0m
 [33m[tester::#CC3] [0m[36mTerminating program[0m
 [33m[tester::#CC3] [0m[36mProgram terminated successfully[0m
@@ -881,253 +854,217 @@ Debug = true
 [33m[tester::#NA2] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#NA2] [setup] [0m[94m4. replica@6383 (Listening port = 6383)[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6380[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2֕lh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7͏\x00\xe91\xe0H"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ed99fa4bd04fecd76e6be8c07a78033dd1d5a450\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83\x8a)vc\x1bP\xe9"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2֕lh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x88\r\xd8.\xf4\xed\xbaT"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ed99fa4bd04fecd76e6be8c07a78033dd1d5a450\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff<J~X~\xc7\n\xf5"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2וlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx*cГh\x82*"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ed99fa4bd04fecd76e6be8c07a78033dd1d5a450\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9\x98\x9d\xc2\xe2\xf3dU"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
-[33m[tester::#NA2] [handshake] [0m[92mReceived "FULLRESYNC e472229314307b4704966a1ee0ff99eae4307d1c 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC ed99fa4bd04fecd76e6be8c07a78033dd1d5a450 0"[0m
 [33m[tester::#NA2] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2וlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(e472229314307b4704966a1ee0ff99eae4307d1c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x11?W\x1e+2\xebO"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf4\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ed99fa4bd04fecd76e6be8c07a78033dd1d5a450\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffP\x8d\xa9\fZ\xa9\r0"[0m
 [33m[tester::#NA2] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#NA2] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 1 500[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 1 500[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n1\r\n$3\r\n500\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 54[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 54[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n54\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Not sending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":1\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 1[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":1\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#NA2] [test] [0m[92mPassed first WAIT test.[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#NA2] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#NA2] [test] [0m[94mclient: > WAIT 4 2000[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#NA2] [test] [client] [0m[94m> WAIT 4 2000[0m
+[33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$4\r\n2000\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6380[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6380: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6381[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6381: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6382[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6382: > REPLCONF ACK 122[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSending ACK to Master[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[94m> REPLCONF ACK 122[0m
+[33m[tester::#NA2] [test] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n122\r\n"[0m
 [33m[tester::#NA2] [test] [0m[94mTesting Replica: replica@6383[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[94mreplica@6383: Expecting "REPLCONF GETACK *" from Master[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Received RESP array: ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[36m[0m
-[33m[tester::#NA2] [test] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
-[33m[tester::#NA2] [test] [0m[92m[0m
-[33m[tester::#NA2] [test] [0m[36mreplica@6383: Not sending ACK to Master[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received bytes: ":3\r\n"[0m
-[33m[tester::#NA2] [test] [0m[36mclient: Received RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2108 ms[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["SET", "baz", "789"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[94mExpecting "REPLCONF GETACK *" from Master[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mReceived RESP array: ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[92mReceived ["REPLCONF", "GETACK", "*"][0m
+[33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
+[33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1142,161 +1079,161 @@ Debug = true
 [33m[tester::#TU8] [setup] [0m[94m4. replica@6383 (Listening port = 6383)[0m
 [33m[tester::#TU8] [setup] [0m[94m5. replica@6384 (Listening port = 6384)[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6380[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x16Y(TLt\xaaK"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4608b5ce70eeb507f06621fefcd70694da3a926\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffԦ$ 1Hk\n"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa9\x99\x7fzQ\xa8\xf0W"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7\xdemh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4608b5ce70eeb507f06621fefcd70694da3a926\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffkfs\x0e,\x941\x16"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xacK\x9c\xe0͜\x9e\xf7"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7\xdemh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4608b5ce70eeb507f06621fefcd70694da3a926\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\xb4\x90\x94\xb0\xa0_\xb6"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF listening-port 6383[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6383: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF listening-port 6383[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6383\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6383: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5^\xa8.u\xc6\xf7\x92"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7\xdemh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4608b5ce70eeb507f06621fefcd70694da3a926\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\a\xa1\xa4Z\b\xfa6\xd3"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: $ redis-cli PING[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF listening-port 6384[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > REPLCONF capa psync2[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+OK\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#TU8] [handshake] [0m[94mreplica@6384: > PSYNC ? -1[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "+FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received RESP simple string: "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
-[33m[tester::#TU8] [handshake] [0m[92mReceived "FULLRESYNC 793281780016162560a4936ac38f3373906fb465 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "PONG"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF listening-port 6384[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6384\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC d4608b5ce70eeb507f06621fefcd70694da3a926 0"[0m
 [33m[tester::#TU8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [0m[36mreplica@6384: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ٕlh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(793281780016162560a4936ac38f3373906fb465\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x131\"\x99\xf8\vf\x8a"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf7\xdemh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d4608b5ce70eeb507f06621fefcd70694da3a926\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd1\xce.\xed\x857\xa7\xcb"[0m
 [33m[tester::#TU8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#TU8] [test] [0m[94mclient: $ redis-cli WAIT 3 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 5[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 4 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 5[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 5 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 5[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 6 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n6\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 5[0m
-[33m[tester::#TU8] [test] [0m[94mclient: > WAIT 7 500[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received bytes: ":5\r\n"[0m
-[33m[tester::#TU8] [test] [0m[36mclient: Received RESP integer: 5[0m
-[33m[tester::#TU8] [test] [0m[92mReceived 5[0m
+[33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 5[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 4 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n4\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 5[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 5 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n5\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 5[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 6 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n6\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 5[0m
+[33m[tester::#TU8] [test] [client] [0m[94m> WAIT 7 500[0m
+[33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n7\r\n$3\r\n500\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
+[33m[tester::#TU8] [test] [client] [0m[36mReceived RESP integer: 5[0m
+[33m[tester::#TU8] [test] [client] [0m[92mReceived 5[0m
 [33m[tester::#TU8] [0m[92mTest passed.[0m
 [33m[tester::#TU8] [0m[36mTerminating program[0m
 [33m[tester::#TU8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#MY8] [0m[94mRunning tests for Stage #MY8 (my8)[0m
 [33m[tester::#MY8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#MY8] [0m[94mclient: $ redis-cli WAIT 0 60000[0m
-[33m[tester::#MY8] [0m[36mclient: Sent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received bytes: ":0\r\n"[0m
-[33m[tester::#MY8] [0m[36mclient: Received RESP integer: 0[0m
-[33m[tester::#MY8] [0m[92mReceived 0[0m
+[33m[tester::#MY8] [client] [0m[94m$ redis-cli WAIT 0 60000[0m
+[33m[tester::#MY8] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived bytes: ":0\r\n"[0m
+[33m[tester::#MY8] [client] [0m[36mReceived RESP integer: 0[0m
+[33m[tester::#MY8] [client] [0m[92mReceived 0[0m
 [33m[tester::#MY8] [0m[92mTest passed.[0m
 [33m[tester::#MY8] [0m[36mTerminating program[0m
 [33m[tester::#MY8] [0m[36mProgram terminated successfully[0m
@@ -1304,92 +1241,78 @@ Debug = true
 [33m[tester::#YD3] [0m[94mRunning tests for Stage #YD3 (yd3)[0m
 [33m[tester::#YD3] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YD3] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[36m][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YD3] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YD3] [handshake] [0m[92m][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[36m[0m
-[33m[tester::#YD3] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YD3] [handshake] [0m[92m[0m
-[33m[tester::#YD3] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YD3] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YD3] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YD3] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > PING[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET apple orange[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$6\r\norange\r\n"[0m
-[33m[tester::#YD3] [propagation] [0m[94mmaster: > SET strawberry raspberry[0m
-[33m[tester::#YD3] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\nraspberry\r\n"[0m
-[33m[tester::#YD3] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n169\r\n"[0m
-[33m[tester::#YD3] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "169"][0m
-[33m[tester::#YD3] [test] [0m[36m[0m
-[33m[tester::#YD3] [test] [0m[92mReceived ["REPLCONF", "ACK", "169"][0m
-[33m[tester::#YD3] [test] [0m[92m[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92m][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YD3] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YD3] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YD3] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> PING[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$2\r\n51\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "51"][0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET apple orange[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$6\r\norange\r\n"[0m
+[33m[tester::#YD3] [propagation] [master] [0m[94m> SET strawberry raspberry[0m
+[33m[tester::#YD3] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#YD3] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$3\r\n169\r\n"[0m
+[33m[tester::#YD3] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "169"][0m
+[33m[tester::#YD3] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "169"][0m
 [33m[tester::#YD3] [0m[92mTest passed.[0m
 [33m[tester::#YD3] [0m[36mTerminating program[0m
 [33m[tester::#YD3] [0m[36mProgram terminated successfully[0m
@@ -1397,72 +1320,62 @@ Debug = true
 [33m[tester::#XV6] [0m[94mRunning tests for Stage #XV6 (xv6)[0m
 [33m[tester::#XV6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#XV6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[36m][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived [[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#XV6] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#XV6] [handshake] [0m[92m][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[36m[0m
-[33m[tester::#XV6] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#XV6] [handshake] [0m[92m[0m
-[33m[tester::#XV6] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#XV6] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#XV6] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#XV6] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#XV6] [test] [0m[94mmaster: > REPLCONF GETACK *[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
-[33m[tester::#XV6] [test] [0m[36mmaster: Received RESP array: ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[36m[0m
-[33m[tester::#XV6] [test] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
-[33m[tester::#XV6] [test] [0m[92m[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92m][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#XV6] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#XV6] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#XV6] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#XV6] [test] [master] [0m[94m> REPLCONF GETACK *[0m
+[33m[tester::#XV6] [test] [master] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$6\r\nGETACK\r\n$1\r\n*\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n"[0m
+[33m[tester::#XV6] [test] [master] [0m[36mReceived RESP array: ["REPLCONF", "ACK", "0"][0m
+[33m[tester::#XV6] [test] [master] [0m[92mReceived ["REPLCONF", "ACK", "0"][0m
 [33m[tester::#XV6] [0m[92mTest passed.[0m
 [33m[tester::#XV6] [0m[36mTerminating program[0m
 [33m[tester::#XV6] [0m[36mProgram terminated successfully[0m
@@ -1470,89 +1383,81 @@ Debug = true
 [33m[tester::#YG4] [0m[94mRunning tests for Stage #YG4 (yg4)[0m
 [33m[tester::#YG4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#YG4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PING"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "listening-port",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "6380"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[36m][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived [[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "REPLCONF",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "eof",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "psync2",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "capa",[0m
-[33m[tester::#YG4] [handshake] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#YG4] [handshake] [0m[92m][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[36m[0m
-[33m[tester::#YG4] [handshake] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#YG4] [handshake] [0m[92m[0m
-[33m[tester::#YG4] [handshake] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
-[33m[tester::#YG4] [handshake] [0m[36mSending RDB file...[0m
-[33m[tester::#YG4] [handshake] [0m[36mmaster: Sent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
-[33m[tester::#YG4] [handshake] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET foo 123[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET bar 456[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [propagation] [0m[94mmaster: > SET baz 789[0m
-[33m[tester::#YG4] [propagation] [0m[36mmaster: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "6380"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived [[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "eof",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "psync2",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "capa",[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92m][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "OK"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#YG4] [handshake] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
+[33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
+[33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
+[33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [0m[94mclient: $ redis-cli GET foo[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n123\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "123"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n123\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "123"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "123"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key bar[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET bar[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n456\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "456"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET bar[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbar\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n456\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "456"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "456"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key baz[0m
-[33m[tester::#YG4] [test] [0m[94mclient: > GET baz[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received bytes: "$3\r\n789\r\n"[0m
-[33m[tester::#YG4] [test] [0m[36mclient: Received RESP bulk string: "789"[0m
-[33m[tester::#YG4] [test] [0m[92mReceived "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[94m> GET baz[0m
+[33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nbaz\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n789\r\n"[0m
+[33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "789"[0m
+[33m[tester::#YG4] [test] [client] [0m[92mReceived "789"[0m
 [33m[tester::#YG4] [0m[92mTest passed.[0m
 [33m[tester::#YG4] [0m[36mTerminating program[0m
 [33m[tester::#YG4] [0m[36mProgram terminated successfully[0m
@@ -1564,252 +1469,224 @@ Debug = true
 [33m[tester::#HD5] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
 [33m[tester::#HD5] [setup] [0m[94m3. replica@6382 (Listening port = 6382)[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6380[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF listening-port 6380[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6380: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6380: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ەlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbc$\f\xe0\xa8]yf"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc383273a18a9f8c1266b31afcc39f14a33db778\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80\xebF\x00`ܚj"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF listening-port 6381[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6381: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF listening-port 6381[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6381\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6381: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ەlh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\fB?\xae\xba3t\x86"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9\xdemh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc383273a18a9f8c1266b31afcc39f14a33db778\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff0\x8duNr\xb2\x97\x8a"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: $ redis-cli PING[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF listening-port 6382[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > REPLCONF capa psync2[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [handshake] [0m[94mreplica@6382: > PSYNC ? -1[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "+FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received RESP simple string: "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
-[33m[tester::#HD5] [handshake] [0m[92mReceived "FULLRESYNC d88c22150e83e78a19ed8433ad845c8ba549dd76 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "PONG"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF listening-port 6382[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6382\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC cc383273a18a9f8c1266b31afcc39f14a33db778 0"[0m
 [33m[tester::#HD5] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [0m[36mreplica@6382: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d88c22150e83e78a19ed8433ad845c8ba549dd76\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82p\x12\x81\xd2\xc8\t\xae"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9\xdemh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc383273a18a9f8c1266b31afcc39f14a33db778\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa3P\xfd\xed\\\x10\xf9\xef"[0m
 [33m[tester::#HD5] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#HD5] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#HD5] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#HD5] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#HD5] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#HD5] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 1/3: replica@6380[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6380: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6380: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6380] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 2/3: replica@6381[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6381: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6381: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6381] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [test] [0m[94mTesting Replica 3/3: replica@6382[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
-[33m[tester::#HD5] [test] [0m[94mreplica@6382: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#HD5] [test] [0m[36mreplica@6382: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[36m[0m
-[33m[tester::#HD5] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#HD5] [test] [0m[92m[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#HD5] [test] [replica@6382] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#HD5] [0m[92mTest passed.[0m
 [33m[tester::#HD5] [0m[36mTerminating program[0m
 [33m[tester::#HD5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZN8] [0m[94mRunning tests for Stage #ZN8 (zn8)[0m
 [33m[tester::#ZN8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: $ redis-cli PING[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF listening-port 6380[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > REPLCONF capa psync2[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [handshake] [0m[94mreplica: > PSYNC ? -1[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "+FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received RESP simple string: "FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0"[0m
-[33m[tester::#ZN8] [handshake] [0m[92mReceived "FULLRESYNC d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 88082d288dff2a6f573b91365119cb3f11022e2c 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 88082d288dff2a6f573b91365119cb3f11022e2c 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 88082d288dff2a6f573b91365119cb3f11022e2c 0"[0m
 [33m[tester::#ZN8] [handshake] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [0m[36mreplica: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d2e0190dc588a2bb69afef4ca241e5bfd83e9cb2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83\xf2}\xa0k\b@3"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf9\xdemh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(88082d288dff2a6f573b91365119cb3f11022e2c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a\x9e\xac᭽\v\xd8"[0m
 [33m[tester::#ZN8] [handshake] [0m[92mReceived RDB file[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: $ redis-cli SET foo 123[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET bar 456[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
-[33m[tester::#ZN8] [test] [0m[94mclient: > SET baz 789[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Sent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET bar 456[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[94m> SET baz 789[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#ZN8] [test] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#ZN8] [test] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [test] [0m[92mSent 3 SET commands to master successfully.[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET foo 123" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SELECT", "0"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "foo", "123"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET bar 456" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "bar", "456"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
-[33m[tester::#ZN8] [test] [0m[94mreplica: Expecting "SET baz 789" to be propagated[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
-[33m[tester::#ZN8] [test] [0m[36mreplica: Received RESP array: ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[36m[0m
-[33m[tester::#ZN8] [test] [0m[92mReceived ["SET", "baz", "789"][0m
-[33m[tester::#ZN8] [test] [0m[92m[0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET foo 123" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SELECT", "0"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "foo", "123"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET bar 456" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n456\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "bar", "456"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[94mExpecting "SET baz 789" to be propagated[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
+[33m[tester::#ZN8] [test] [replica] [0m[36mReceived RESP array: ["SET", "baz", "789"][0m
+[33m[tester::#ZN8] [test] [replica] [0m[92mReceived ["SET", "baz", "789"][0m
 [33m[tester::#ZN8] [0m[92mTest passed.[0m
 [33m[tester::#ZN8] [0m[36mTerminating program[0m
 [33m[tester::#ZN8] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF8] [0m[94mRunning tests for Stage #CF8 (cf8)[0m
 [33m[tester::#CF8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#CF8] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#CF8] [0m[92mReceived "PONG"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#CF8] [0m[92mReceived "OK"[0m
-[33m[tester::#CF8] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#CF8] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "+FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0\r\n"[0m
-[33m[tester::#CF8] [0m[36mclient: Received RESP simple string: "FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0"[0m
-[33m[tester::#CF8] [0m[92mReceived "FULLRESYNC 762cbb51f0e34b6b0b2787bd82e4c506ae84113a 0"[0m
+[33m[tester::#CF8] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 3774f49c80ecca8e90803c867a081e13e4dc19b3 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 3774f49c80ecca8e90803c867a081e13e4dc19b3 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 3774f49c80ecca8e90803c867a081e13e4dc19b3 0"[0m
 [33m[tester::#CF8] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [0m[36mclient: Received bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ܕlh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(762cbb51f0e34b6b0b2787bd82e4c506ae84113a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw4M\x0f\aP\x1ca"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xfa\xdemh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3774f49c80ecca8e90803c867a081e13e4dc19b3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx\x90HD)?Ɠ"[0m
 [33m[tester::#CF8] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1817,47 +1694,47 @@ Debug = true
 
 [33m[tester::#VM3] [0m[94mRunning tests for Stage #VM3 (vm3)[0m
 [33m[tester::#VM3] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#VM3] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#VM3] [0m[92mReceived "PONG"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#VM3] [0m[92mReceived "OK"[0m
-[33m[tester::#VM3] [0m[94mclient: > PSYNC ? -1[0m
-[33m[tester::#VM3] [0m[36mclient: Sent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received bytes: "+FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0\r\n"[0m
-[33m[tester::#VM3] [0m[36mclient: Received RESP simple string: "FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0"[0m
-[33m[tester::#VM3] [0m[92mReceived "FULLRESYNC 310666f6bfe6c4eeced5102a1cc96b0dfd81a1b9 0"[0m
+[33m[tester::#VM3] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
+[33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 11c394c9e5a3063338ff5f1190d15c6d38d6aa4e 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 11c394c9e5a3063338ff5f1190d15c6d38d6aa4e 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 11c394c9e5a3063338ff5f1190d15c6d38d6aa4e 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#FJ0] [0m[94mRunning tests for Stage #FJ0 (fj0)[0m
 [33m[tester::#FJ0] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#FJ0] [0m[94mclient: $ redis-cli PING[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "PONG"[0m
-[33m[tester::#FJ0] [0m[92mReceived "PONG"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF listening-port 6380[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
-[33m[tester::#FJ0] [0m[94mclient: > REPLCONF capa psync2[0m
-[33m[tester::#FJ0] [0m[36mclient: Sent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received bytes: "+OK\r\n"[0m
-[33m[tester::#FJ0] [0m[36mclient: Received RESP simple string: "OK"[0m
-[33m[tester::#FJ0] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "PONG"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF listening-port 6380[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#FJ0] [client] [0m[94m> REPLCONF capa psync2[0m
+[33m[tester::#FJ0] [client] [0m[36mSent bytes: "*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#FJ0] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#FJ0] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#FJ0] [0m[92mTest passed.[0m
 [33m[tester::#FJ0] [0m[36mTerminating program[0m
 [33m[tester::#FJ0] [0m[36mProgram terminated successfully[0m
@@ -1865,62 +1742,54 @@ Debug = true
 [33m[tester::#JU6] [0m[94mRunning tests for Stage #JU6 (ju6)[0m
 [33m[tester::#JU6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#JU6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PING"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "listening-port",[0m
-[33m[tester::#JU6] [0m[36m  "6380"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "listening-port",[0m
-[33m[tester::#JU6] [0m[92m  "6380"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#JU6] [0m[36m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "eof",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "psync2",[0m
-[33m[tester::#JU6] [0m[36m  "capa",[0m
-[33m[tester::#JU6] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[36m][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived [[0m
-[33m[tester::#JU6] [0m[92m  "REPLCONF",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "eof",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "psync2",[0m
-[33m[tester::#JU6] [0m[92m  "capa",[0m
-[33m[tester::#JU6] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#JU6] [0m[92m][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#JU6] [0m[94mmaster: Waiting for replica to send "PSYNC" command[0m
-[33m[tester::#JU6] [0m[36mmaster: Received bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#JU6] [0m[36mmaster: Received RESP array: ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[36m[0m
-[33m[tester::#JU6] [0m[92mReceived ["PSYNC", "?", "-1"][0m
-[33m[tester::#JU6] [0m[92m[0m
-[33m[tester::#JU6] [0m[94mmaster: Sent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
-[33m[tester::#JU6] [0m[36mmaster: Sent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[36m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#JU6] [master] [0m[92m  "6380"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JU6] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[36m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[36m][0m
+[33m[tester::#JU6] [master] [0m[92mReceived [[0m
+[33m[tester::#JU6] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "eof",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "psync2",[0m
+[33m[tester::#JU6] [master] [0m[92m  "capa",[0m
+[33m[tester::#JU6] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#JU6] [master] [0m[92m][0m
+[33m[tester::#JU6] [master] [0m[94mSent "OK"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#JU6] [master] [0m[94mWaiting for replica to send "PSYNC" command[0m
+[33m[tester::#JU6] [master] [0m[36mReceived bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
+[33m[tester::#JU6] [master] [0m[36mReceived RESP array: ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[92mReceived ["PSYNC", "?", "-1"][0m
+[33m[tester::#JU6] [master] [0m[94mSent "FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0"[0m
+[33m[tester::#JU6] [master] [0m[36mSent bytes: "+FULLRESYNC 75cd7bc10c49047e0d163660f3b90625b1af31dc 0\r\n"[0m
 [33m[tester::#JU6] [0m[92mTest passed.[0m
 [33m[tester::#JU6] [0m[36mTerminating program[0m
 [33m[tester::#JU6] [0m[36mProgram terminated successfully[0m
@@ -1928,54 +1797,48 @@ Debug = true
 [33m[tester::#EH4] [0m[94mRunning tests for Stage #EH4 (eh4)[0m
 [33m[tester::#EH4] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#EH4] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived ["PING"][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF listening-port 6380" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "listening-port",[0m
-[33m[tester::#EH4] [0m[36m  "6380"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "listening-port",[0m
-[33m[tester::#EH4] [0m[92m  "6380"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
-[33m[tester::#EH4] [0m[94mmaster: Waiting for replica to send "REPLCONF capa" command[0m
-[33m[tester::#EH4] [0m[36mmaster: Received bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
-[33m[tester::#EH4] [0m[36mmaster: Received RESP array: [[0m
-[33m[tester::#EH4] [0m[36m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "eof",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "psync2",[0m
-[33m[tester::#EH4] [0m[36m  "capa",[0m
-[33m[tester::#EH4] [0m[36m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[36m][0m
-[33m[tester::#EH4] [0m[36m[0m
-[33m[tester::#EH4] [0m[92mReceived [[0m
-[33m[tester::#EH4] [0m[92m  "REPLCONF",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "eof",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "psync2",[0m
-[33m[tester::#EH4] [0m[92m  "capa",[0m
-[33m[tester::#EH4] [0m[92m  "rdb-channel-repl"[0m
-[33m[tester::#EH4] [0m[92m][0m
-[33m[tester::#EH4] [0m[92m[0m
-[33m[tester::#EH4] [0m[94mmaster: Sent "OK"[0m
-[33m[tester::#EH4] [0m[36mmaster: Sent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#EH4] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#EH4] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF listening-port 6380" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[36m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "listening-port",[0m
+[33m[tester::#EH4] [master] [0m[92m  "6380"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
+[33m[tester::#EH4] [master] [0m[94mWaiting for replica to send "REPLCONF capa" command[0m
+[33m[tester::#EH4] [master] [0m[36mReceived bytes: "*7\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$3\r\neof\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n$4\r\ncapa\r\n$16\r\nrdb-channel-repl\r\n"[0m
+[33m[tester::#EH4] [master] [0m[36mReceived RESP array: [[0m
+[33m[tester::#EH4] [master] [0m[36m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[36m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[36m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[36m][0m
+[33m[tester::#EH4] [master] [0m[92mReceived [[0m
+[33m[tester::#EH4] [master] [0m[92m  "REPLCONF",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "eof",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "psync2",[0m
+[33m[tester::#EH4] [master] [0m[92m  "capa",[0m
+[33m[tester::#EH4] [master] [0m[92m  "rdb-channel-repl"[0m
+[33m[tester::#EH4] [master] [0m[92m][0m
+[33m[tester::#EH4] [master] [0m[94mSent "OK"[0m
+[33m[tester::#EH4] [master] [0m[36mSent bytes: "+OK\r\n"[0m
 [33m[tester::#EH4] [0m[92mTest passed.[0m
 [33m[tester::#EH4] [0m[36mTerminating program[0m
 [33m[tester::#EH4] [0m[36mProgram terminated successfully[0m
@@ -1983,25 +1846,23 @@ Debug = true
 [33m[tester::#GL7] [0m[94mRunning tests for Stage #GL7 (gl7)[0m
 [33m[tester::#GL7] [0m[94mMaster is running on port 6379.[0m
 [33m[tester::#GL7] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#GL7] [0m[94mmaster: Waiting for replica to initiate handshake with "PING" command[0m
-[33m[tester::#GL7] [0m[36mmaster: Received bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#GL7] [0m[36mmaster: Received RESP array: ["PING"][0m
-[33m[tester::#GL7] [0m[36m[0m
-[33m[tester::#GL7] [0m[92mReceived ["PING"][0m
-[33m[tester::#GL7] [0m[92m[0m
-[33m[tester::#GL7] [0m[94mmaster: Sent "PONG"[0m
-[33m[tester::#GL7] [0m[36mmaster: Sent bytes: "+PONG\r\n"[0m
+[33m[tester::#GL7] [master] [0m[94mWaiting for replica to initiate handshake with "PING" command[0m
+[33m[tester::#GL7] [master] [0m[36mReceived bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#GL7] [master] [0m[36mReceived RESP array: ["PING"][0m
+[33m[tester::#GL7] [master] [0m[92mReceived ["PING"][0m
+[33m[tester::#GL7] [master] [0m[94mSent "PONG"[0m
+[33m[tester::#GL7] [master] [0m[36mSent bytes: "+PONG\r\n"[0m
 [33m[tester::#GL7] [0m[92mTest passed.[0m
 [33m[tester::#GL7] [0m[36mTerminating program[0m
 [33m[tester::#GL7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#XC1] [0m[94mRunning tests for Stage #XC1 (xc1)[0m
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XC1] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#XC1] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:84665401fc0b07fc6ad14e9ce7b45bc8d0270152\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3e6b01fd00f1f14acebf322cf30d5550916894ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3e6b01fd00f1f14acebf322cf30d5550916894ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3e6b01fd00f1f14acebf322cf30d5550916894ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2011,11 +1872,11 @@ Debug = true
 [33m[tester::#HC6] [0m[94mRunning tests for Stage #HC6 (hc6)[0m
 [33m[tester::#HC6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#HC6] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#HC6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -2023,11 +1884,11 @@ Debug = true
 
 [33m[tester::#YE5] [0m[94mRunning tests for Stage #YE5 (ye5)[0m
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YE5] [0m[94mclient: $ redis-cli INFO replication[0m
-[33m[tester::#YE5] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [0m[36mclient: Received RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:93ffbc94d2bf70f53f6a57d1e2def6755b07e411\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9f012d50db4ef97cad6441369edec7dfb09f37aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9f012d50db4ef97cad6441369edec7dfb09f37aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9f012d50db4ef97cad6441369edec7dfb09f37aa\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2059,31 +1920,31 @@ Debug = true
 [33m[tester::#SM4] [0m[36m00a0 | 73 70 62 65 72 72 79 ff 10 f6 99 42 96 77 a1 8d | spberry....B.w..[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
-[33m[tester::#SM4] [0m[94mclient: $ redis-cli GET pear[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET strawberry[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pineapple"[0m
-[33m[tester::#SM4] [0m[92mReceived "pineapple"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET orange[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "apple"[0m
-[33m[tester::#SM4] [0m[92mReceived "apple"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET grape[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$4\r\npear\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "pear"[0m
-[33m[tester::#SM4] [0m[92mReceived "pear"[0m
-[33m[tester::#SM4] [0m[94mclient: > GET apple[0m
-[33m[tester::#SM4] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#SM4] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#SM4] [0m[92mReceived "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[94m$ redis-cli GET pear[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET strawberry[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "pineapple"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET orange[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "apple"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "apple"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET grape[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "pear"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "pear"[0m
+[33m[tester::#SM4] [client] [0m[94m> GET apple[0m
+[33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#SM4] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#SM4] [client] [0m[92mReceived "raspberry"[0m
 [33m[tester::#SM4] [0m[92mTest passed.[0m
 [33m[tester::#SM4] [0m[36mTerminating program[0m
 [33m[tester::#SM4] [0m[36mProgram terminated successfully[0m
@@ -2103,26 +1964,26 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0070 | ff 97 22 dd 30 46 ee 83 03                      | ..".0F...[0m
 [33m[tester::#DQ3] [0m[36m[0m
 [33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
-[33m[tester::#DQ3] [0m[94mclient: $ redis-cli GET strawberry[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "mango"[0m
-[33m[tester::#DQ3] [0m[92mReceived "mango"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET mango[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$9\r\nraspberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "raspberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "raspberry"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET banana[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "grape"[0m
-[33m[tester::#DQ3] [0m[92mReceived "grape"[0m
-[33m[tester::#DQ3] [0m[94mclient: > GET apple[0m
-[33m[tester::#DQ3] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received bytes: "$10\r\nstrawberry\r\n"[0m
-[33m[tester::#DQ3] [0m[36mclient: Received RESP bulk string: "strawberry"[0m
-[33m[tester::#DQ3] [0m[92mReceived "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET strawberry[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "mango"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "mango"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET mango[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "raspberry"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET banana[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "grape"[0m
+[33m[tester::#DQ3] [client] [0m[94m> GET apple[0m
+[33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
+[33m[tester::#DQ3] [client] [0m[36mReceived RESP bulk string: "strawberry"[0m
+[33m[tester::#DQ3] [client] [0m[92mReceived "strawberry"[0m
 [33m[tester::#DQ3] [0m[92mTest passed.[0m
 [33m[tester::#DQ3] [0m[36mTerminating program[0m
 [33m[tester::#DQ3] [0m[36mProgram terminated successfully[0m
@@ -2142,23 +2003,21 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0070 | fb 6e db 72 08 1e 1b                            | .n.r...[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3062 --dbfilename orange.rdb[0m
-[33m[tester::#JW4] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JW4] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received bytes: "*4\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n$6\r\norange\r\n"[0m
-[33m[tester::#JW4] [0m[36mclient: Received RESP array: [[0m
-[33m[tester::#JW4] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [0m[36m  "strawberry",[0m
-[33m[tester::#JW4] [0m[36m  "mango",[0m
-[33m[tester::#JW4] [0m[36m  "orange"[0m
-[33m[tester::#JW4] [0m[36m][0m
-[33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[92mReceived [[0m
-[33m[tester::#JW4] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [0m[92m  "strawberry",[0m
-[33m[tester::#JW4] [0m[92m  "mango",[0m
-[33m[tester::#JW4] [0m[92m  "orange"[0m
-[33m[tester::#JW4] [0m[92m][0m
-[33m[tester::#JW4] [0m[92m[0m
+[33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\nbanana\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[36m  "orange",[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[36m][0m
+[33m[tester::#JW4] [client] [0m[92mReceived [[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[92m  "orange",[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -2175,11 +2034,11 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0040 | c7 19 1a 7f                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
 [33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3337 --dbfilename banana.rdb[0m
-[33m[tester::#GC6] [0m[94mclient: $ redis-cli GET grape[0m
-[33m[tester::#GC6] [0m[36mclient: Sent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received bytes: "$6\r\norange\r\n"[0m
-[33m[tester::#GC6] [0m[36mclient: Received RESP bulk string: "orange"[0m
-[33m[tester::#GC6] [0m[92mReceived "orange"[0m
+[33m[tester::#GC6] [client] [0m[94m$ redis-cli GET grape[0m
+[33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
+[33m[tester::#GC6] [client] [0m[36mReceived RESP bulk string: "orange"[0m
+[33m[tester::#GC6] [client] [0m[92mReceived "orange"[0m
 [33m[tester::#GC6] [0m[92mTest passed.[0m
 [33m[tester::#GC6] [0m[36mTerminating program[0m
 [33m[tester::#GC6] [0m[36mProgram terminated successfully[0m
@@ -2196,51 +2055,47 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0040 | 16 a7 2d 81 76 2a                               | ..-.v*[0m
 [33m[tester::#JZ6] [0m[36m[0m
 [33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1646 --dbfilename grape.rdb[0m
-[33m[tester::#JZ6] [0m[94mclient: $ redis-cli KEYS *[0m
-[33m[tester::#JZ6] [0m[36mclient: Sent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received bytes: "*1\r\n$4\r\npear\r\n"[0m
-[33m[tester::#JZ6] [0m[36mclient: Received RESP array: ["pear"][0m
-[33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[92mReceived ["pear"][0m
-[33m[tester::#JZ6] [0m[92m[0m
+[33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
+[33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$4\r\npear\r\n"[0m
+[33m[tester::#JZ6] [client] [0m[36mReceived RESP array: ["pear"][0m
+[33m[tester::#JZ6] [client] [0m[92mReceived ["pear"][0m
 [33m[tester::#JZ6] [0m[92mTest passed.[0m
 [33m[tester::#JZ6] [0m[36mTerminating program[0m
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
 [33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6307 --dbfilename apple.rdb[0m
-[33m[tester::#ZG5] [0m[94mclient: $ redis-cli CONFIG GET dir[0m
-[33m[tester::#ZG5] [0m[36mclient: Sent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-6307\r\n"[0m
-[33m[tester::#ZG5] [0m[36mclient: Received RESP array: ["dir", "/private/tmp/rdb-6307"][0m
-[33m[tester::#ZG5] [0m[36m[0m
-[33m[tester::#ZG5] [0m[92mReceived ["dir", "/private/tmp/rdb-6307"][0m
-[33m[tester::#ZG5] [0m[92m[0m
+[33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
+[33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-6307\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-6307"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-6307"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [0m[94m$ redis-cli SET apple grape px 100[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 09:36:59.774[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:59.774 (should not be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP bulk string: "grape"[0m
-[33m[tester::#YZ1] [0m[92mReceived "grape"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple grape px 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 09:01:13.260[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:01:13.260 (should not be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:36:59.877 (should be expired)[0m
-[33m[tester::#YZ1] [0m[94m> GET apple[0m
-[33m[tester::#YZ1] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived bytes: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
-[33m[tester::#YZ1] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 09:01:13.363 (should be expired)[0m
+[33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[92mReceived "$-1\r\n"[0m
 [33m[tester::#YZ1] [0m[92mTest passed.[0m
 [33m[tester::#YZ1] [0m[36mTerminating program[0m
 [33m[tester::#YZ1] [0m[36mProgram terminated successfully[0m
@@ -2248,89 +2103,89 @@ Debug = true
 [33m[tester::#LA7] [0m[94mRunning tests for Stage #LA7 (la7)[0m
 [33m[tester::#LA7] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#LA7] [0m[36mSetting key pear to pineapple[0m
-[33m[tester::#LA7] [0m[94m$ redis-cli SET pear pineapple[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "+OK\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP simple string: "OK"[0m
-[33m[tester::#LA7] [0m[92mReceived "OK"[0m
+[33m[tester::#LA7] [client] [0m[94m$ redis-cli SET pear pineapple[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP simple string: "OK"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#LA7] [0m[36mGetting key pear[0m
-[33m[tester::#LA7] [0m[94m> GET pear[0m
-[33m[tester::#LA7] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
-[33m[tester::#LA7] [0m[36mReceived RESP bulk string: "pineapple"[0m
-[33m[tester::#LA7] [0m[92mReceived "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[94m> GET pear[0m
+[33m[tester::#LA7] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
+[33m[tester::#LA7] [client] [0m[36mReceived RESP bulk string: "pineapple"[0m
+[33m[tester::#LA7] [client] [0m[92mReceived "pineapple"[0m
 [33m[tester::#LA7] [0m[92mTest passed.[0m
 [33m[tester::#LA7] [0m[36mTerminating program[0m
 [33m[tester::#LA7] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#QQ0] [0m[94mRunning tests for Stage #QQ0 (qq0)[0m
 [33m[tester::#QQ0] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#QQ0] [0m[94m$ redis-cli ECHO blueberry[0m
-[33m[tester::#QQ0] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$9\r\nblueberry\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
-[33m[tester::#QQ0] [0m[36mReceived RESP bulk string: "blueberry"[0m
-[33m[tester::#QQ0] [0m[92mReceived "blueberry"[0m
+[33m[tester::#QQ0] [client] [0m[94m$ redis-cli ECHO blueberry[0m
+[33m[tester::#QQ0] [client] [0m[36mSent bytes: "*2\r\n$4\r\nECHO\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
+[33m[tester::#QQ0] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
+[33m[tester::#QQ0] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#QQ0] [0m[92mTest passed.[0m
 [33m[tester::#QQ0] [0m[36mTerminating program[0m
 [33m[tester::#QQ0] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZU2] [0m[94mRunning tests for Stage #ZU2 (zu2)[0m
 [33m[tester::#ZU2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZU2] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-1: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[94mclient-2: > PING[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-1: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[94mclient-3: $ redis-cli PING[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Received RESP simple string: "PONG"[0m
-[33m[tester::#ZU2] [0m[92mReceived "PONG"[0m
-[33m[tester::#ZU2] [0m[36mclient-2: Success, closing connection...[0m
-[33m[tester::#ZU2] [0m[36mclient-3: Success, closing connection...[0m
+[33m[tester::#ZU2] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[94m> PING[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[94m$ redis-cli PING[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#ZU2] [client-3] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#ZU2] [client-3] [0m[92mReceived "PONG"[0m
+[33m[tester::#ZU2] [client-2] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#ZU2] [client-3] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#ZU2] [0m[92mTest passed.[0m
 [33m[tester::#ZU2] [0m[36mTerminating program[0m
 [33m[tester::#ZU2] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#WY1] [0m[94mRunning tests for Stage #WY1 (wy1)[0m
 [33m[tester::#WY1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#WY1] [0m[94mclient-1: $ redis-cli PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[94mclient-1: > PING[0m
-[33m[tester::#WY1] [0m[36mclient-1: Sent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received bytes: "+PONG\r\n"[0m
-[33m[tester::#WY1] [0m[36mclient-1: Received RESP simple string: "PONG"[0m
-[33m[tester::#WY1] [0m[92mReceived "PONG"[0m
-[33m[tester::#WY1] [0m[36mSuccess, closing connection...[0m
+[33m[tester::#WY1] [client-1] [0m[94m$ redis-cli PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[94m> PING[0m
+[33m[tester::#WY1] [client-1] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#WY1] [client-1] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[92mReceived "PONG"[0m
+[33m[tester::#WY1] [client-1] [0m[36mSuccess, closing connection...[0m
 [33m[tester::#WY1] [0m[92mTest passed.[0m
 [33m[tester::#WY1] [0m[36mTerminating program[0m
 [33m[tester::#WY1] [0m[36mProgram terminated successfully[0m
@@ -2338,11 +2193,11 @@ Debug = true
 [33m[tester::#RG2] [0m[94mRunning tests for Stage #RG2 (rg2)[0m
 [33m[tester::#RG2] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#RG2] [0m[36mConnection established, sending ping command...[0m
-[33m[tester::#RG2] [0m[94m$ redis-cli PING[0m
-[33m[tester::#RG2] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived bytes: "+PONG\r\n"[0m
-[33m[tester::#RG2] [0m[36mReceived RESP simple string: "PONG"[0m
-[33m[tester::#RG2] [0m[92mReceived "PONG"[0m
+[33m[tester::#RG2] [client] [0m[94m$ redis-cli PING[0m
+[33m[tester::#RG2] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
+[33m[tester::#RG2] [client] [0m[36mReceived RESP simple string: "PONG"[0m
+[33m[tester::#RG2] [client] [0m[92mReceived "PONG"[0m
 [33m[tester::#RG2] [0m[92mTest passed.[0m
 [33m[tester::#RG2] [0m[36mTerminating program[0m
 [33m[tester::#RG2] [0m[36mProgram terminated successfully[0m

--- a/internal/test_ping_pong.go
+++ b/internal/test_ping_pong.go
@@ -18,7 +18,7 @@ func testPingPongOnce(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "")
+	client, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client")
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,9 @@ func testPingPongMultiple(stageHarness *test_case_harness.TestCaseHarness) error
 		}
 	}
 
-	logger.Debugf("Success, closing connection...")
-	client.Close()
+	logger.WithAdditionalSecondaryPrefix(client.GetIdentifier(), func() {
+		logger.Debugf("Success, closing connection...")
+	})
 
 	return nil
 }
@@ -98,7 +99,10 @@ func testPingPongConcurrent(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
-	logger.Debugf("client-%d: Success, closing connection...", 1)
+	logger.WithAdditionalSecondaryPrefix(client1.GetIdentifier(), func() {
+		logger.Debugf("Success, closing connection...")
+	})
+
 	client1.Close()
 
 	client3, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6379", "client-3")
@@ -110,9 +114,14 @@ func testPingPongConcurrent(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
-	logger.Debugf("client-%d: Success, closing connection...", 2)
+	logger.WithAdditionalSecondaryPrefix(client2.GetIdentifier(), func() {
+		logger.Debugf("Success, closing connection...")
+	})
 	client2.Close()
-	logger.Debugf("client-%d: Success, closing connection...", 3)
+
+	logger.WithAdditionalSecondaryPrefix(client3.GetIdentifier(), func() {
+		logger.Debugf("Success, closing connection...")
+	})
 	client3.Close()
 
 	return nil

--- a/internal/test_repl_replica_cmd_processing.go
+++ b/internal/test_repl_replica_cmd_processing.go
@@ -17,7 +17,7 @@ func testReplCmdProcessing(stageHarness *test_case_harness.TestCaseHarness) erro
 	deleteRDBfile()
 
 	logger := stageHarness.Logger
-	defer logger.ResetSecondaryPrefix()
+	defer logger.ResetSecondaryPrefixes()
 
 	listener, err := net.Listen("tcp", ":6379")
 	if err != nil {
@@ -34,7 +34,7 @@ func testReplCmdProcessing(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("handshake")
+	logger.UpdateLastSecondaryPrefix("handshake")
 
 	conn, err := listener.Accept()
 	if err != nil {
@@ -55,7 +55,7 @@ func testReplCmdProcessing(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("propagation")
+	logger.UpdateLastSecondaryPrefix("propagation")
 
 	replicaClient, err := instrumented_resp_connection.NewFromAddr(logger, "localhost:6380", "client")
 	if err != nil {
@@ -78,7 +78,7 @@ func testReplCmdProcessing(stageHarness *test_case_harness.TestCaseHarness) erro
 		}
 	}
 
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 
 	for i := 1; i <= len(kvMap); i++ {
 		key, value := kvMap[i][0], kvMap[i][1]

--- a/internal/test_repl_replica_getack_nonzero.go
+++ b/internal/test_repl_replica_getack_nonzero.go
@@ -16,7 +16,7 @@ func testReplGetaAckNonZero(stageHarness *test_case_harness.TestCaseHarness) err
 	deleteRDBfile()
 
 	logger := stageHarness.Logger
-	defer logger.ResetSecondaryPrefix()
+	defer logger.ResetSecondaryPrefixes()
 
 	listener, err := net.Listen("tcp", ":6379")
 	if err != nil {
@@ -46,7 +46,7 @@ func testReplGetaAckNonZero(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("handshake")
+	logger.UpdateLastSecondaryPrefix("handshake")
 
 	receiveReplicationHandshakeTestCase := test_cases.ReceiveReplicationHandshakeTestCase{}
 
@@ -57,24 +57,24 @@ func testReplGetaAckNonZero(stageHarness *test_case_harness.TestCaseHarness) err
 	// The bytes received and sent during the handshake don't count towards offset.
 	// After finishing the handshake we reset the counters.
 	master.ResetByteCounters()
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 
 	getAckTestCase := test_cases.GetAckTestCase{}
 	if err := getAckTestCase.Run(master, logger, master.SentBytes); err != nil {
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("propagation")
+	logger.UpdateLastSecondaryPrefix("propagation")
 	if err := master.SendCommand("PING"); err != nil {
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 	if err := getAckTestCase.Run(master, logger, master.SentBytes); err != nil {
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("propagation")
+	logger.UpdateLastSecondaryPrefix("propagation")
 	key := testerutils_random.RandomWord()
 	value := testerutils_random.RandomWord()
 	if err := master.SendCommand("SET", []string{key, value}...); err != nil {
@@ -87,6 +87,6 @@ func testReplGetaAckNonZero(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 	return getAckTestCase.Run(master, logger, master.SentBytes)
 }

--- a/internal/test_repl_replica_getack_zero.go
+++ b/internal/test_repl_replica_getack_zero.go
@@ -15,7 +15,7 @@ func testReplGetaAckZero(stageHarness *test_case_harness.TestCaseHarness) error 
 	deleteRDBfile()
 
 	logger := stageHarness.Logger
-	defer logger.ResetSecondaryPrefix()
+	defer logger.ResetSecondaryPrefixes()
 
 	listener, err := net.Listen("tcp", ":6379")
 	if err != nil {
@@ -45,7 +45,7 @@ func testReplGetaAckZero(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("handshake")
+	logger.UpdateLastSecondaryPrefix("handshake")
 
 	receiveReplicationHandshakeTestCase := test_cases.ReceiveReplicationHandshakeTestCase{}
 
@@ -53,7 +53,7 @@ func testReplGetaAckZero(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 
 	getAckTestCase := test_cases.GetAckTestCase{}
 

--- a/internal/test_repl_wait_zero_offset.go
+++ b/internal/test_repl_wait_zero_offset.go
@@ -18,7 +18,7 @@ func testWaitZeroOffset(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
-	defer logger.ResetSecondaryPrefix()
+	defer logger.ResetSecondaryPrefixes()
 
 	replicaCount := testerutils_random.RandomInt(3, 9)
 	logger.Infof("Proceeding to create %v replicas.", replicaCount)
@@ -38,7 +38,7 @@ func testWaitZeroOffset(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	defer client.Close()
 
-	logger.UpdateSecondaryPrefix("test")
+	logger.UpdateLastSecondaryPrefix("test")
 
 	diff := ((replicaCount + 3) - 3) / 3
 	safeDiff := max(1, diff) // If diff is 0, it will get stuck in an infinite loop

--- a/internal/util.go
+++ b/internal/util.go
@@ -38,12 +38,12 @@ func SpawnReplicas(replicaCount int, stageHarness *test_case_harness.TestCaseHar
 
 	listeningPort := 6380
 	// Log the replicas we are going to create
-	logger.UpdateSecondaryPrefix("setup")
+	logger.UpdateLastSecondaryPrefix("setup")
 	logger.Infof("Creating %d replicas:", replicaCount)
 	for j := range replicaCount {
 		logger.Infof("%d. replica@%d (Listening port = %d)", (j + 1), listeningPort+j, listeningPort+j)
 	}
-	logger.ResetSecondaryPrefix()
+	logger.PopSecondaryPrefix()
 	for j := 0; j < replicaCount; j++ {
 		logger.Debugf("Creating replica@%d", listeningPort)
 		replica, err := instrumented_resp_connection.NewFromAddr(logger, addr, fmt.Sprintf("replica@%d", listeningPort))
@@ -52,13 +52,13 @@ func SpawnReplicas(replicaCount int, stageHarness *test_case_harness.TestCaseHar
 			return nil, err
 		}
 
-		logger.UpdateSecondaryPrefix("handshake")
+		logger.UpdateLastSecondaryPrefix("handshake")
 
 		if err := sendHandshakeTestCase.RunAll(replica, logger, listeningPort); err != nil {
 			return nil, err
 		}
 
-		logger.ResetSecondaryPrefix()
+		logger.PopSecondaryPrefix()
 
 		listeningPort += 1
 		// The bytes received and sent during the handshake don't count towards offset.


### PR DESCRIPTION
### Packages
- Update tester utils version

### Logging Improvements
- Connections are logged as secondary prefixes
- All connections are updated to have connection identifier
- Update fixtures
- Cases like `Syntax Error` now includes 'Received Bytes` line

### Test Cases Update
- Update blocking `XREAD` stages to use `BlockingClientGroupTestCase`
- Update `ReceiveCommandTestCase` to re-use `ReceiveValueTestCase`

