### PR TITLE
bugfix `SendCommandTestCase`

### DIFF
--- a/internal/test_cases/send_command_test_case.go
+++ b/internal/test_cases/send_command_test_case.go
@@ -27,8 +27,6 @@ type SendCommandTestCase struct {
 }
 
 func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *logger.Logger) error {
-	var value resp_value.Value
-	var err error
 	receiveValueTestCase := ReceiveValueTestCase{
 		Assertion:                 t.Assertion,
 		ShouldSkipUnreadDataCheck: t.ShouldSkipUnreadDataCheck,
@@ -41,12 +39,12 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 
 		command := strings.ToUpper(t.Command)
 
-		if err = client.SendCommand(command, t.Args...); err != nil {
+		if err := client.SendCommand(command, t.Args...); err != nil {
 			return err
 		}
 
 		t.readMutex.Lock()
-		err = receiveValueTestCase.RunWithoutAssert(client)
+		err := receiveValueTestCase.RunWithoutAssert(client)
 		t.readMutex.Unlock()
 
 		if err != nil {
@@ -60,7 +58,7 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		if t.ShouldRetryFunc == nil {
 			panic(fmt.Sprintf("Received SendCommand with retries: %d but no ShouldRetryFunc.", t.Retries))
 		} else {
-			if t.ShouldRetryFunc(value) {
+			if t.ShouldRetryFunc(receiveValueTestCase.ActualValue) {
 				// If ShouldRetryFunc returns true, we sleep and retry.
 				time.Sleep(500 * time.Millisecond)
 			} else {
@@ -69,6 +67,7 @@ func (t *SendCommandTestCase) Run(client *resp_client.RespConnection, logger *lo
 		}
 	}
 	t.ReceivedResponse = receiveValueTestCase.ActualValue
+
 	return receiveValueTestCase.Assert(client, logger)
 }
 


### PR DESCRIPTION
In the `SendCommandTestCase`, the `ShouldRetyFunc` is always called with the `value` local variable, which is not initialized properly and never assigned any value. Thus all the RESP assertions that the code passes into `ShouldRetryFunc` are called with the default zero RESP value, and not the actual value that was read from the client, and no retires are actually made. 

This caused the replication stages to fail.