### PR TITLE
Moved logs to no response test case

### DIFF
--- a/internal/test_cases/blocking_client_group_test_case.go
+++ b/internal/test_cases/blocking_client_group_test_case.go
@@ -55,7 +55,6 @@ func (t *BlockingClientGroupTestCase) AssertResponses(logger *logger.Logger) err
 	for _, clientWithExpectedResponse := range t.clientsWithExpectedResponses {
 		clientLogger := clientWithExpectedResponse.Client.GetLogger()
 		if clientWithExpectedResponse.Assertion == nil {
-			clientLogger.Infof("Expecting no response")
 			testCase := NoResponseTestCase{}
 			if err := testCase.Run(clientWithExpectedResponse.Client); err != nil {
 				return err

--- a/internal/test_cases/no_response_test_case.go
+++ b/internal/test_cases/no_response_test_case.go
@@ -9,6 +9,7 @@ import (
 type NoResponseTestCase struct{}
 
 func (n *NoResponseTestCase) Run(client *instrumented_resp_connection.InstrumentedRespConnection) error {
+	client.GetLogger().Infof("Expecting no response")
 	client.ReadIntoBuffer()
 	if client.UnreadBuffer.Len() > 0 {
 		return fmt.Errorf("%s received unexpected response: %q", client.GetIdentifier(), client.UnreadBuffer.String())


### PR DESCRIPTION
`NoResponseTestCase` is being re-used in Pub-Sub as well.

- This was remaining to be moved there.