### PR TITLE
Add small delays between BlockingCommands + add debug logs for "[client-n] Connected (port a -> port b)"

### DIFF
--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -151,6 +151,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"info_replication_bytes":  {regexp.MustCompile(`"\$[0-9]+\\r\\n# Replication\\r\\n[^"]+"`)},
 		"rdb_keys":                {regexp.MustCompile(`\[tester::#JW4\] .*Received .*`), regexp.MustCompile(`\[tester::#JW4\].*"(apple|orange|banana|pear|grape|pineapple|mango|strawberry|raspberry|blueberry)",?.*`)},
 		"hexdump":                 {regexp.MustCompile(`[0-9a-fA-F]{4} \| [0-9a-fA-F ]{47} \| .{0,16}`)},
+		"client_port":             {regexp.MustCompile(`client-\d+ connected from port \d+`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -151,7 +151,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"info_replication_bytes":  {regexp.MustCompile(`"\$[0-9]+\\r\\n# Replication\\r\\n[^"]+"`)},
 		"rdb_keys":                {regexp.MustCompile(`\[tester::#JW4\] .*Received .*`), regexp.MustCompile(`\[tester::#JW4\].*"(apple|orange|banana|pear|grape|pineapple|mango|strawberry|raspberry|blueberry)",?.*`)},
 		"hexdump":                 {regexp.MustCompile(`[0-9a-fA-F]{4} \| [0-9a-fA-F ]{47} \| .{0,16}`)},
-		"client_port":             {regexp.MustCompile(`client-\d+ connected from port \d+`)},
+		"client_connected":        {regexp.MustCompile(`Connected \(port \d+ -> port \d+\)`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/test_cases/blocking_client_group_test_case.go
+++ b/internal/test_cases/blocking_client_group_test_case.go
@@ -48,7 +48,7 @@ func (t *BlockingClientGroupTestCase) SendBlockingCommands() error {
 		if err := clientWithExpectedResponse.Client.SendCommand(clientWithExpectedResponse.Command, clientWithExpectedResponse.Args...); err != nil {
 			return err
 		}
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond) // Ensure server receives commands in order
 	}
 
 	return nil

--- a/internal/test_cases/blocking_client_group_test_case.go
+++ b/internal/test_cases/blocking_client_group_test_case.go
@@ -1,6 +1,8 @@
 package test_cases
 
 import (
+	"time"
+
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -46,6 +48,7 @@ func (t *BlockingClientGroupTestCase) SendBlockingCommands() error {
 		if err := clientWithExpectedResponse.Client.SendCommand(clientWithExpectedResponse.Command, clientWithExpectedResponse.Args...); err != nil {
 			return err
 		}
+		time.Sleep(20 * time.Millisecond)
 	}
 
 	return nil

--- a/internal/test_cases/blocking_client_group_test_case.go
+++ b/internal/test_cases/blocking_client_group_test_case.go
@@ -48,7 +48,7 @@ func (t *BlockingClientGroupTestCase) SendBlockingCommands() error {
 		if err := clientWithExpectedResponse.Client.SendCommand(clientWithExpectedResponse.Command, clientWithExpectedResponse.Args...); err != nil {
 			return err
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	return nil

--- a/internal/test_helpers/fixtures/lists/blpop_wrong_client
+++ b/internal/test_helpers/fixtures/lists/blpop_wrong_client
@@ -4,6 +4,9 @@ Debug = true
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mLogs from your program will appear here!
 [33m[your_program] [0mRedis server listening on 0.0.0.0:6379
+[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 37624[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 37628[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 37634[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pear 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP pear 0[0m

--- a/internal/test_helpers/fixtures/lists/blpop_wrong_client
+++ b/internal/test_helpers/fixtures/lists/blpop_wrong_client
@@ -4,9 +4,9 @@ Debug = true
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[your_program] [0mLogs from your program will appear here!
 [33m[your_program] [0mRedis server listening on 0.0.0.0:6379
-[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 37624[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 37628[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 37634[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 54886 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 54900 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 54916 -> port 6379)[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pear 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP pear 0[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -7,6 +7,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XJ7] [0m[36m[Setup] client-1 connected from port 51342[0m
+[33m[tester::#XJ7] [0m[36m[Setup] client-2 connected from port 51350[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.2[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.2\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry mango[0m
@@ -24,6 +26,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 51374[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 51386[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 51398[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP banana 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP banana 0[0m
@@ -360,6 +365,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 33702[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 33712[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 33728[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 44[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -462,6 +470,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 33744[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 33758[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET banana pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -564,6 +574,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 33776[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 33788[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -609,6 +621,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 33808[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 33816[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1108,9 +1122,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752559750573-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752559750573-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1752559750573-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121211756-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121211756-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753121211756-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1231,11 +1245,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xf0uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(803677afe3caa18009830bffc937b33dd4e4c426\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb2\x06\\-\x98p˛"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4.\xf5\bD\x16\x89!"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1255,11 +1269,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xf0uh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(803677afe3caa18009830bffc937b33dd4e4c426\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\r\xc6\v\x03\x85\xac\x91\x87"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg\xe3\x9e>\x7f\xbf\xbd\xac"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1279,11 +1293,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 803677afe3caa18009830bffc937b33dd4e4c426 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xf0uh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(803677afe3caa18009830bffc937b33dd4e4c426\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\b\x14\xe8\x99\x19\x98\xff'"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8My9\x1a\x043\x9c"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1376,7 +1390,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2013 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2087 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1410,11 +1424,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\xf0uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae\xdfF\x8e\x9a\xf1\xbb<"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfb\x85\xd7/nɚ3"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1434,11 +1448,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\xf0uh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x11\x1f\x11\xa0\x87-\xe1 "[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8H\xbc\x19U`\xae\xbe"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1458,11 +1472,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\xf0uh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x14\xcd\xf2:\x1b\x19\x8f\x80"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg\xe6[\x1e0\xdb \x8e"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1482,11 +1496,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u0089\xf0uh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff}\xd8\xc6\xf4\xa3C\xe6\xe5"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbfK\x94ve俴"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1506,11 +1520,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\xf0uh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdf:2\xb7pzմ"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdf\x02\xe2_\xfe\xa5u\xbd"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -1530,11 +1544,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\xf0uh\xfa\bused-mem\xc2@I\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xda\xe8\xd1-\xecN\xbb\x14"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x98@]\xdd\xcc\x0f\xad"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -1554,11 +1568,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 460a8c9ad3e943ed46bd25eb7089e742691109ba 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008a\xf0uh\xfa\bused-mem\u0090R\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(460a8c9ad3e943ed46bd25eb7089e742691109ba\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb3\xfd\xe5\xe3T\x14\xd2q"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff!\x93̼\xfeX\x8dE"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1843,11 +1857,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\xf0uh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1f9e0277bc7437637435ae43ecee5b2a105730a8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xebw\x99\xb5\x82\xa4\xba}"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01v\x14\u07bfh\xb6\xc7"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1867,11 +1881,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\xf0uh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1f9e0277bc7437637435ae43ecee5b2a105730a8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff[\x11\xaa\xfb\x90ʷ\x9d"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\x8a\xbe³\x870\r"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1891,11 +1905,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 1f9e0277bc7437637435ae43ecee5b2a105730a8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008b\xf0uh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1f9e0277bc7437637435ae43ecee5b2a105730a8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc8\xcc\"X\xbeh\xd9\xf8"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffpm,\x92\xa5\xfb\x99?"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1980,11 +1994,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 70ec9811a60c30126bfcdd324989dddba46d3caa 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 70ec9811a60c30126bfcdd324989dddba46d3caa 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 70ec9811a60c30126bfcdd324989dddba46d3caa 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\xf0uh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(70ec9811a60c30126bfcdd324989dddba46d3caa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv߶\n\xc7\x04\x8d\r"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9fdf898ff5d3142df1de39fea2ef8b8931e833df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfc\x0ere\x87\xf4E\x92"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2039,11 +2053,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 5ba88ebdfd2bda577369a0039944adaca7737aa4 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 5ba88ebdfd2bda577369a0039944adaca7737aa4 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 5ba88ebdfd2bda577369a0039944adaca7737aa4 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\u008c\xf0uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5ba88ebdfd2bda577369a0039944adaca7737aa4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffϲi*\x80B\xe2\x89"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d6ef6e340376b3f162e233fccb860c4ace65d905\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffs\x11\xac\xc5N\xbf\x9b\xf1"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2068,9 +2082,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC f07078aae8e34e50ff0653194788e238f533d66b 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC f07078aae8e34e50ff0653194788e238f533d66b 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC f07078aae8e34e50ff0653194788e238f533d66b 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2217,9 +2231,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3f62e785c49be4b64255f98b98768b2a27e5cff6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3f62e785c49be4b64255f98b98768b2a27e5cff6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3f62e785c49be4b64255f98b98768b2a27e5cff6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2243,9 +2257,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1be655704f2d2bc93af6555e1d136fbc071bb0c8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1be655704f2d2bc93af6555e1d136fbc071bb0c8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1be655704f2d2bc93af6555e1d136fbc071bb0c8\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2264,17 +2278,17 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 9c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 03 fc 00 9c | er.7.2.0........[0m
 [33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 06 62 61 6e 61 6e 61 06 6f | ..~.....banana.o[0m
 [33m[tester::#SM4] [0m[36m0040 | 72 61 6e 67 65 fc 00 0c 28 8a c7 01 00 00 00 09 | range...(.......[0m
 [33m[tester::#SM4] [0m[36m0050 | 70 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 | pineapple.raspbe[0m
 [33m[tester::#SM4] [0m[36m0060 | 72 72 79 fc 00 0c 28 8a c7 01 00 00 00 05 67 72 | rry...(.......gr[0m
-[33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 1e 63 cd 24 aa 2f | ape.apple..c.$./[0m
-[33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
+[33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 4e 02 f5 7b e4 77 | ape.apple.N..{.w[0m
+[33m[tester::#SM4] [0m[36m0080 | 59 da                                           | Y.[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9439 --dbfilename pineapple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9439 --dbfilename pineapple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -2308,7 +2322,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 79 00 05 67 72 61 70 65 06 62 61 6e 61 6e 61 ff | y..grape.banana.[0m
 [33m[tester::#DQ3] [0m[36m0070 | 22 42 53 9d 9d 75 69 c1                         | "BS..ui.[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2904 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2904 --dbfilename raspberry.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET orange[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
@@ -2348,23 +2362,23 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff 8b | ..grape.orange..[0m
 [33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9251 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9251 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$5\r\ngrape\r\n$9\r\nraspberry\r\n$6\r\nbanana\r\n$4\r\npear\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
-[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[36m  "pear",[0m
-[33m[tester::#JW4] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92mReceived [[0m
-[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[92m  "pear",[0m
-[33m[tester::#JW4] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2381,7 +2395,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 65 61 72 05 61 70 70 6c 65 ff 4e 07 75 77 a0 9f | ear.apple.N.uw..[0m
 [33m[tester::#GC6] [0m[36m0040 | 21 94                                           | !.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2337 --dbfilename apple.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2337 --dbfilename apple.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
@@ -2402,7 +2416,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 73 70 62 65 72 72 79 05 61 70 70 6c 65 ff 55 | aspberry.apple.U[0m
 [33m[tester::#JZ6] [0m[36m0040 | 43 23 e0 5a 6e 28 62                            | C#.Zn(b[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1316 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1316 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
@@ -2413,12 +2427,12 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5701 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-5701 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5701\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-5701"][0m
-[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-5701"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-5701\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-5701"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/tmp/rdb-5701"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
@@ -2430,15 +2444,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 11:54:19.507[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 11:54:19.507 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 18:07:00.215[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 18:07:00.215 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 11:54:19.610 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 18:07:00.317 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -7,8 +7,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#XJ7] [0m[36m[Setup] client-1 connected from port 51342[0m
-[33m[tester::#XJ7] [0m[36m[Setup] client-2 connected from port 51350[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 54948 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 54958 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.2[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.2\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry mango[0m
@@ -26,9 +26,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 51374[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 51386[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 51398[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 54974 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 54978 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 54984 -> port 6379)[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP banana 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP banana 0[0m
@@ -365,9 +365,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 33702[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 33712[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 33728[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 55184 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 55196 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 55206 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 44[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -470,8 +470,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 33744[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 33758[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 55216 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 55232 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET banana pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -574,8 +574,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 33776[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 33788[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 55278 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 55292 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -621,8 +621,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 33808[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 33816[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 55318 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 55326 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1122,9 +1122,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121211756-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121211756-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1753121211756-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753156170236-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753156170236-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753156170236-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1245,11 +1245,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4.\xf5\bD\x16\x89!"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2J\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbcac944259884bcfa02c7b8ee71f81164906671\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa7XbA\x7f\xdeg\xe0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1269,11 +1269,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg\xe3\x9e>\x7f\xbf\xbd\xac"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2J\n\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbcac944259884bcfa02c7b8ee71f81164906671\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf4\x95\twDwSm"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1293,11 +1293,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 97e6564b07202319f70a8066ddc0e2ac465ab237 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC dbcac944259884bcfa02c7b8ee71f81164906671 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¼\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(97e6564b07202319f70a8066ddc0e2ac465ab237\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8My9\x1a\x043\x9c"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2J\n\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbcac944259884bcfa02c7b8ee71f81164906671\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff;;\xeep!\xcc\xdd]"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1390,7 +1390,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2087 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2086 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1424,11 +1424,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfb\x85\xd7/nɚ3"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa6\xfa\xbfs8v\xc7\x1e"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1448,11 +1448,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8H\xbc\x19U`\xae\xbe"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf57\xd4E\x03\xdf\xf3\x93"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1472,11 +1472,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¾\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffg\xe6[\x1e0\xdb \x8e"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff:\x993Bfd}\xa3"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1496,11 +1496,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbfK\x94ve俴"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x17\xc1\xa4N\xc8\xea\xb4G"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1520,11 +1520,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdf\x02\xe2_\xfe\xa5u\xbd"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw\x88\xd2gS\xab~N"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -1544,11 +1544,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x98@]\xdd\xcc\x0f\xad"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem¨\x0f\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2\x12pep\xc2\x04^"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -1568,11 +1568,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 2070c28cbbf9035346a7b5f1bfe99e0834159d2a 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived "FULLRESYNC 33dfcb9790a3988fc3aeb139c9242b87de1083f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime¿\x81~h\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2070c28cbbf9035346a7b5f1bfe99e0834159d2a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff!\x93̼\xfeX\x8dE"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2M\n\x7fh\xfa\bused-mem\xc2 \x19\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(33dfcb9790a3988fc3aeb139c9242b87de1083f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89\x19\xfc\x84SV\x86\xb6"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1857,11 +1857,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x01v\x14\u07bfh\xb6\xc7"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\n\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(35cb9484bb6cf94b5243cdaaabff05f25410180d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\x93k\x90\xbe\xc2=\x83"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1881,11 +1881,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8\x8a\xbe³\x870\r"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\n\x7fh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(35cb9484bb6cf94b5243cdaaabff05f25410180d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbbo\xc1\x8c\xb2-\xbbI"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1905,11 +1905,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 35cb9484bb6cf94b5243cdaaabff05f25410180d 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0\x81~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(689c8b9fe5fa05a8133c143b7157b8a9cfecdf9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffpm,\x92\xa5\xfb\x99?"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\n\x7fh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(35cb9484bb6cf94b5243cdaaabff05f25410180d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf3\x88SܤQ\x12{"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1994,11 +1994,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 9fdf898ff5d3142df1de39fea2ef8b8931e833df 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 384716cf05dc84c3ff4b471da972960e98b062ad 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 384716cf05dc84c3ff4b471da972960e98b062ad 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 384716cf05dc84c3ff4b471da972960e98b062ad 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9fdf898ff5d3142df1de39fea2ef8b8931e833df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfc\x0ere\x87\xf4E\x92"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\n\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(384716cf05dc84c3ff4b471da972960e98b062ad\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1c\xad}\x8aD\xff`\x14"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2053,11 +2053,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC d6ef6e340376b3f162e233fccb860c4ace65d905 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC d1445921af1f87ab6f048ff9e6b31de6d6c7d2bf 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d1445921af1f87ab6f048ff9e6b31de6d6c7d2bf 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC d1445921af1f87ab6f048ff9e6b31de6d6c7d2bf 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d6ef6e340376b3f162e233fccb860c4ace65d905\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffs\x11\xac\xc5N\xbf\x9b\xf1"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2O\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d1445921af1f87ab6f048ff9e6b31de6d6c7d2bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1%\xd2_\x8a\x01\x89a"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2082,9 +2082,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 6604995db17f9cb50270b1ac2b943ac30d6fd1da 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 1a725ade11afebfcd380800b13d156d41b6ee856 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 1a725ade11afebfcd380800b13d156d41b6ee856 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 1a725ade11afebfcd380800b13d156d41b6ee856 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2231,9 +2231,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9972236092d88df00647f29ccd9cfd1486e99156\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:20712c99460d09ac1800b431adc2bace96d632cc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:20712c99460d09ac1800b431adc2bace96d632cc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:20712c99460d09ac1800b431adc2bace96d632cc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2257,9 +2257,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:654dd9830b2c4168a6f01f362a6747ef5a14bd36\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:29927531d5192f5c396c917a9bb15b93d7ee4e5a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:29927531d5192f5c396c917a9bb15b93d7ee4e5a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:29927531d5192f5c396c917a9bb15b93d7ee4e5a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2278,15 +2278,15 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 03 03 fc 00 9c | er.7.2.0........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 03 03 fc 00 9c | s-bits.@........[0m
 [33m[tester::#SM4] [0m[36m0030 | ef 12 7e 01 00 00 00 06 62 61 6e 61 6e 61 06 6f | ..~.....banana.o[0m
 [33m[tester::#SM4] [0m[36m0040 | 72 61 6e 67 65 fc 00 0c 28 8a c7 01 00 00 00 09 | range...(.......[0m
 [33m[tester::#SM4] [0m[36m0050 | 70 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 | pineapple.raspbe[0m
 [33m[tester::#SM4] [0m[36m0060 | 72 72 79 fc 00 0c 28 8a c7 01 00 00 00 05 67 72 | rry...(.......gr[0m
-[33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 4e 02 f5 7b e4 77 | ape.apple.N..{.w[0m
-[33m[tester::#SM4] [0m[36m0080 | 59 da                                           | Y.[0m
+[33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 1e 63 cd 24 aa 2f | ape.apple..c.$./[0m
+[33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
 [33m[tester::#SM4] [0m[36m[0m
 [33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9439 --dbfilename pineapple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET banana[0m
@@ -2352,33 +2352,33 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 09 70 | s-bits.@.......p[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 09 70 | er.7.2.0.......p[0m
 [33m[tester::#JW4] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 04 70 65 61 72 00 06 62 | ineapple.pear..b[0m
 [33m[tester::#JW4] [0m[36m0040 | 61 6e 61 6e 61 05 67 72 61 70 65 00 04 70 65 61 | anana.grape..pea[0m
 [33m[tester::#JW4] [0m[36m0050 | 72 09 72 61 73 70 62 65 72 72 79 00 09 72 61 73 | r.raspberry..ras[0m
 [33m[tester::#JW4] [0m[36m0060 | 70 62 65 72 72 79 09 70 69 6e 65 61 70 70 6c 65 | pberry.pineapple[0m
-[33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff 8b | ..grape.orange..[0m
-[33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
+[33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff d4 | ..grape.orange..[0m
+[33m[tester::#JW4] [0m[36m0080 | 85 66 33 f0 1c e7 1b                            | .f3....[0m
 [33m[tester::#JW4] [0m[36m[0m
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9251 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n$4\r\npear\r\n$9\r\nraspberry\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[36m  "pear",[0m
 [33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
-[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[36m  "banana"[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92mReceived [[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[92m  "pear",[0m
 [33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
-[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[92m  "banana"[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2444,15 +2444,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 18:07:00.215[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 18:07:00.215 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 03:49:38.631[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 03:49:38.631 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 18:07:00.317 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 03:49:38.734 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/pubsub/pass
+++ b/internal/test_helpers/fixtures/pubsub/pass
@@ -2,6 +2,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#ZE9] [0m[36m[Setup] client-1 connected from port 37648[0m
+[33m[tester::#ZE9] [0m[36m[Setup] client-2 connected from port 37658[0m
+[33m[tester::#ZE9] [0m[36m[Setup] client-3 connected from port 37670[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE apple[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\napple\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\napple\r\n:1\r\n"[0m
@@ -81,6 +84,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#DN4] [0m[36m[Setup] client-1 connected from port 37690[0m
+[33m[tester::#DN4] [0m[36m[Setup] client-2 connected from port 37696[0m
+[33m[tester::#DN4] [0m[36m[Setup] client-3 connected from port 37706[0m
+[33m[tester::#DN4] [0m[36m[Setup] client-4 connected from port 37716[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE orange[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\norange\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\norange\r\n:1\r\n"[0m
@@ -154,6 +161,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#HF2] [0m[36m[Setup] client-1 connected from port 37740[0m
+[33m[tester::#HF2] [0m[36m[Setup] client-2 connected from port 37754[0m
+[33m[tester::#HF2] [0m[36m[Setup] client-3 connected from port 37768[0m
+[33m[tester::#HF2] [0m[36m[Setup] client-4 connected from port 37782[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE banana[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\nbanana\r\n:1\r\n"[0m
@@ -185,6 +196,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#LF1] [0m[36m[Setup] client-1 connected from port 37808[0m
+[33m[tester::#LF1] [0m[36m[Setup] client-2 connected from port 37812[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE blueberry[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nblueberry\r\n:1\r\n"[0m
@@ -237,6 +250,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#ZC8] [0m[36m[Setup] client-1 connected from port 37838[0m
+[33m[tester::#ZC8] [0m[36m[Setup] client-2 connected from port 37840[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE raspberry[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nraspberry\r\n:1\r\n"[0m
@@ -299,6 +314,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92mReceived "$-1\r\n"[0m
+[33m[tester::#XJ7] [0m[36m[Setup] client-1 connected from port 37884[0m
+[33m[tester::#XJ7] [0m[36m[Setup] client-2 connected from port 37890[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP grape 0.2[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$5\r\ngrape\r\n$3\r\n0.2\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH grape orange[0m
@@ -316,6 +333,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 37912[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 37924[0m
+[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 37936[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pear 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP pear 0[0m
@@ -628,6 +648,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 38108[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 38120[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 38126[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET strawberry 54[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$2\r\n54\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -730,6 +753,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 38144[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 38148[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pear apple[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -832,6 +857,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 38182[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 38194[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -877,6 +904,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 54976[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 54984[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1360,9 +1389,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD apple * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752730852811-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752730852811-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1752730852811-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121281017-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121281017-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753121281017-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1484,11 +1513,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\x8cxh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x86\xa2\xa3\x98O\xf8\xbe\xda"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f@U\x89}\x82E\xf1"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1508,11 +1537,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\x8cxh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff9b\xf4\xb6R$\xe4\xc6"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\x8d>\xbfF+q|"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1532,11 +1561,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\x8cxh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff<\xb0\x17,\xce\x10\x8af"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83#ٸ#\x90\xffL"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1556,11 +1585,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe5\x8cxh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d33327ea0fbe69d1a53ef15846dde5e17ca1cf4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffU\xa5#\xe2vJ\xe3\x03"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae{N\xb4\x8d\x1e6\xa8"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1675,7 +1704,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2093 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2097 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1707,11 +1736,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\x8cxh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9772e7bebb245dfb1344f444aeb452696ccec823\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x87\xb5\x17\xec٘=\x19"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xfcj\x81n\xa3-\x92"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1731,11 +1760,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\x8cxh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9772e7bebb245dfb1344f444aeb452696ccec823\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff8u@\xc2\xc4Dg\x05"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@1\x01\xb7U\n\x19\x1f"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1755,11 +1784,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\x8cxh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9772e7bebb245dfb1344f444aeb452696ccec823\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff=\xa7\xa3XXp\t\xa5"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8f\x9f\xe6\xb00\xb1\x97/"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1779,11 +1808,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\x8cxh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9772e7bebb245dfb1344f444aeb452696ccec823\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffT\xb2\x97\x96\xe0*`\xc0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\xc7q\xbc\x9e?^\xcb"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1803,11 +1832,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 9772e7bebb245dfb1344f444aeb452696ccec823 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xe8\x8cxh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9772e7bebb245dfb1344f444aeb452696ccec823\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\xdd\x1d!m\xe7\xf1\xd8"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\u008e\a\x95\x05~\x94\xc2"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2097,11 +2126,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x8cxh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(057e66ccde432e3c65196d94239bca56041fa344\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1\x80\x9a\xb3\x00]l\xb3"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe7*W48\x9c\x89P"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2121,11 +2150,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x8cxh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(057e66ccde432e3c65196d94239bca56041fa344\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x11\xe6\xa9\xfd\x123aS"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde\xd6\xfd(4s\x0f\x9a"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2145,11 +2174,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 057e66ccde432e3c65196d94239bca56041fa344 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x8cxh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(057e66ccde432e3c65196d94239bca56041fa344\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82;!^<\x91\x0f6"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x961ox\"\x0f\xa6\xa8"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2234,11 +2263,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 23d2796c0809fc064db3d122399c2303a234074f 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 23d2796c0809fc064db3d122399c2303a234074f 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 23d2796c0809fc064db3d122399c2303a234074f 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x8cxh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(23d2796c0809fc064db3d122399c2303a234074f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x80\xd1c@\xcc\xe1b\x98"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d20378366af9b82706e6baa423a26600a6d22d38\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\x17\xa7\bEy]}"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2293,11 +2322,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 4d3f5e169551d528f2e309416479519d24d2ef0e 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 4d3f5e169551d528f2e309416479519d24d2ef0e 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 4d3f5e169551d528f2e309416479519d24d2ef0e 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xea\x8cxh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d3f5e169551d528f2e309416479519d24d2ef0e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff{L\xd7\xe3\xf7\a\xd7\x00"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\a\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9e05db9da0f517eb12314622c9716ff615497dce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff*'*\x13\x87\xf6\xb1I"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2322,9 +2351,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC d2fc388240ecfd89eb7651f8889f9cf72734a118 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d2fc388240ecfd89eb7651f8889f9cf72734a118 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC d2fc388240ecfd89eb7651f8889f9cf72734a118 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2471,9 +2500,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:daba79d3252e4ad31f8d57579f023281a309ba5c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:daba79d3252e4ad31f8d57579f023281a309ba5c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:daba79d3252e4ad31f8d57579f023281a309ba5c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2485,9 +2514,9 @@ Debug = true
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
 [33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -2497,9 +2526,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ed9de8ed3833ca6d305f1f8c0ad32cfc8bbd681\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ed9de8ed3833ca6d305f1f8c0ad32cfc8bbd681\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3ed9de8ed3833ca6d305f1f8c0ad32cfc8bbd681\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2531,7 +2560,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m00a0 | 67 65 05 6d 61 6e 67 6f ff e4 0e a8 69 c8 e6 85 | ge.mango....i...[0m
 [33m[tester::#SM4] [0m[36m00b0 | 00                                              | .[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-8610 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-8610 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET apple[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
@@ -2576,7 +2605,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0070 | 04 70 65 61 72 05 61 70 70 6c 65 ff 08 b8 d3 51 | .pear.apple....Q[0m
 [33m[tester::#DQ3] [0m[36m0080 | 60 fe d6 39                                     | `..9[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3052 --dbfilename pear.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3052 --dbfilename pear.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
@@ -2619,12 +2648,12 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 79 00 05 6d 61 6e 67 6f 05 61 70 70 6c 65 ff 00 | y..mango.apple..[0m
 [33m[tester::#JW4] [0m[36m0060 | 59 56 4b 50 c8 fe 02                            | YVKP...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3598 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3598 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived RESP array: ["mango", "strawberry", "grape"][0m
-[33m[tester::#JW4] [client] [0m[92mReceived ["mango", "strawberry", "grape"][0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: ["strawberry", "grape", "mango"][0m
+[33m[tester::#JW4] [client] [0m[92mReceived ["strawberry", "grape", "mango"][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -2640,7 +2669,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 61 6e 67 6f 0a 73 74 72 61 77 62 65 72 72 79 ff | ango.strawberry.[0m
 [33m[tester::#GC6] [0m[36m0040 | 61 1c 88 75 f5 a8 97 56                         | a..u...V[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3891 --dbfilename apple.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3891 --dbfilename apple.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET mango[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
@@ -2655,13 +2684,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 05 61 | er.7.2.0.......a[0m
-[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 6f 72 61 6e 67 65 ff 97 68 b8 a7 | pple.orange..h..[0m
-[33m[tester::#JZ6] [0m[36m0040 | 28 60 89 aa                                     | (`..[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 61 | s-bits.@.......a[0m
+[33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 6f 72 61 6e 67 65 ff 02 51 6c 32 | pple.orange..Ql2[0m
+[33m[tester::#JZ6] [0m[36m0040 | 97 93 08 f8                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9656 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9656 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$5\r\napple\r\n"[0m
@@ -2672,12 +2701,12 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-8499 --dbfilename apple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-8499 --dbfilename apple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-8499\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-8499"][0m
-[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-8499"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-8499\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-8499"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/tmp/rdb-8499"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
@@ -2689,15 +2718,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 11:26:01.888[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 11:26:01.888 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 18:08:09.963[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 18:08:09.963 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 11:26:01.992 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 18:08:10.066 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/pubsub/pass
+++ b/internal/test_helpers/fixtures/pubsub/pass
@@ -2,9 +2,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZE9] [0m[36m[Setup] client-1 connected from port 37648[0m
-[33m[tester::#ZE9] [0m[36m[Setup] client-2 connected from port 37658[0m
-[33m[tester::#ZE9] [0m[36m[Setup] client-3 connected from port 37670[0m
+[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 46522 -> port 6379)[0m
+[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 46526 -> port 6379)[0m
+[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 46534 -> port 6379)[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE apple[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\napple\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\napple\r\n:1\r\n"[0m
@@ -84,10 +84,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#DN4] [0m[36m[Setup] client-1 connected from port 37690[0m
-[33m[tester::#DN4] [0m[36m[Setup] client-2 connected from port 37696[0m
-[33m[tester::#DN4] [0m[36m[Setup] client-3 connected from port 37706[0m
-[33m[tester::#DN4] [0m[36m[Setup] client-4 connected from port 37716[0m
+[33m[tester::#DN4] [client-1] [0m[36mConnected (port 46558 -> port 6379)[0m
+[33m[tester::#DN4] [client-2] [0m[36mConnected (port 46562 -> port 6379)[0m
+[33m[tester::#DN4] [client-3] [0m[36mConnected (port 46568 -> port 6379)[0m
+[33m[tester::#DN4] [client-4] [0m[36mConnected (port 46578 -> port 6379)[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE orange[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\norange\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\norange\r\n:1\r\n"[0m
@@ -161,10 +161,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HF2] [0m[36m[Setup] client-1 connected from port 37740[0m
-[33m[tester::#HF2] [0m[36m[Setup] client-2 connected from port 37754[0m
-[33m[tester::#HF2] [0m[36m[Setup] client-3 connected from port 37768[0m
-[33m[tester::#HF2] [0m[36m[Setup] client-4 connected from port 37782[0m
+[33m[tester::#HF2] [client-1] [0m[36mConnected (port 46584 -> port 6379)[0m
+[33m[tester::#HF2] [client-2] [0m[36mConnected (port 46596 -> port 6379)[0m
+[33m[tester::#HF2] [client-3] [0m[36mConnected (port 46606 -> port 6379)[0m
+[33m[tester::#HF2] [client-4] [0m[36mConnected (port 46618 -> port 6379)[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE banana[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\nbanana\r\n:1\r\n"[0m
@@ -196,8 +196,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LF1] [0m[36m[Setup] client-1 connected from port 37808[0m
-[33m[tester::#LF1] [0m[36m[Setup] client-2 connected from port 37812[0m
+[33m[tester::#LF1] [client-1] [0m[36mConnected (port 46638 -> port 6379)[0m
+[33m[tester::#LF1] [client-2] [0m[36mConnected (port 46642 -> port 6379)[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE blueberry[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nblueberry\r\n:1\r\n"[0m
@@ -250,8 +250,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZC8] [0m[36m[Setup] client-1 connected from port 37838[0m
-[33m[tester::#ZC8] [0m[36m[Setup] client-2 connected from port 37840[0m
+[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 46674 -> port 6379)[0m
+[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 46688 -> port 6379)[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE raspberry[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nraspberry\r\n:1\r\n"[0m
@@ -314,8 +314,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92mReceived "$-1\r\n"[0m
-[33m[tester::#XJ7] [0m[36m[Setup] client-1 connected from port 37884[0m
-[33m[tester::#XJ7] [0m[36m[Setup] client-2 connected from port 37890[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 46712 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 46714 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP grape 0.2[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$5\r\ngrape\r\n$3\r\n0.2\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH grape orange[0m
@@ -333,9 +333,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-1 connected from port 37912[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-2 connected from port 37924[0m
-[33m[tester::#EC3] [0m[36m[Setup] client-3 connected from port 37936[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 46734 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 46750 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 46762 -> port 6379)[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pear 0[0m
 [33m[tester::#EC3] [client-2] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-3] [0m[94m$ redis-cli BLPOP pear 0[0m
@@ -648,9 +648,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 38108[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 38120[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 38126[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 46926 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 46928 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 46942 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET strawberry 54[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$10\r\nstrawberry\r\n$2\r\n54\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -753,8 +753,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 38144[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 38148[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 46954 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 46960 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pear apple[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$4\r\npear\r\n$5\r\napple\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -857,8 +857,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 38182[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 38194[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 47006 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 47008 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -904,8 +904,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 54976[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 54984[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 47028 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 47030 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1389,9 +1389,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD apple * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\napple\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121281017-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121281017-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1753121281017-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753156114092-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753156114092-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753156114092-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1513,11 +1513,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f@U\x89}\x82E\xf1"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(edfc5c63f15845c7314d053d9670b1ea5aa3e162\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff-\xfd6\x7f\xdbK\x12\x18"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1537,11 +1537,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\x8d>\xbfF+q|"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\n\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(edfc5c63f15845c7314d053d9670b1ea5aa3e162\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff~0]I\xe0\xe2&\x95"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1561,11 +1561,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x83#ٸ#\x90\xffL"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\n\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(edfc5c63f15845c7314d053d9670b1ea5aa3e162\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb1\x9e\xbaN\x85Y\xa8\xa5"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1585,11 +1585,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC f6966e2171194039c697ad885a98a5fc53164f58 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC edfc5c63f15845c7314d053d9670b1ea5aa3e162 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x01\x82~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6966e2171194039c697ad885a98a5fc53164f58\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xae{N\xb4\x8d\x1e6\xa8"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x12\n\x7fh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(edfc5c63f15845c7314d053d9670b1ea5aa3e162\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9c\xc6-B+\xd7aA"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1704,7 +1704,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2097 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2098 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1736,11 +1736,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xfcj\x81n\xa3-\x92"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a62798f9572db364e39b337575a56b7db70aa978\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%8Q,\x148\v\xef"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1760,11 +1760,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@1\x01\xb7U\n\x19\x1f"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\n\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a62798f9572db364e39b337575a56b7db70aa978\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv\xf5:\x1a/\x91?b"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1784,11 +1784,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8f\x9f\xe6\xb00\xb1\x97/"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\n\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a62798f9572db364e39b337575a56b7db70aa978\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb9[\xdd\x1dJ*\xb1R"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1808,11 +1808,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\xc7q\xbc\x9e?^\xcb"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\n\x7fh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a62798f9572db364e39b337575a56b7db70aa978\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x94\x03J\x11\xe4\xa4x\xb6"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1832,11 +1832,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC f0927c8ffee824e9315312a943a0ec7208c0e9ee 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC a62798f9572db364e39b337575a56b7db70aa978 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x04\x82~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f0927c8ffee824e9315312a943a0ec7208c0e9ee\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\u008e\a\x95\x05~\x94\xc2"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x15\n\x7fh\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a62798f9572db364e39b337575a56b7db70aa978\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf4J<8\x7f岿"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2126,11 +2126,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe7*W48\x9c\x89P"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\n\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(aba3c778143e4b7ed9f948777ceb1c729773b033\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x06(\b\x8e}*\xac\xb2"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2150,11 +2150,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xde\xd6\xfd(4s\x0f\x9a"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\n\x7fh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(aba3c778143e4b7ed9f948777ceb1c729773b033\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff?Ԣ\x92q\xc5*x"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2174,11 +2174,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 28e921d8bbd76927b79a812077d342debe705a3e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC aba3c778143e4b7ed9f948777ceb1c729773b033 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(28e921d8bbd76927b79a812077d342debe705a3e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x961ox\"\x0f\xa6\xa8"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\n\x7fh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(aba3c778143e4b7ed9f948777ceb1c729773b033\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffw30\xc2g\xb9\x83J"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2263,11 +2263,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC d20378366af9b82706e6baa423a26600a6d22d38 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 90d5a86f708149ce61a3154b4c541fded17fcee7 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 90d5a86f708149ce61a3154b4c541fded17fcee7 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 90d5a86f708149ce61a3154b4c541fded17fcee7 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x06\x82~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d20378366af9b82706e6baa423a26600a6d22d38\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr\x17\xa7\bEy]}"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x17\n\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(90d5a86f708149ce61a3154b4c541fded17fcee7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaaˡV\xbe\xc0\x1a\x83"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2322,11 +2322,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 9e05db9da0f517eb12314622c9716ff615497dce 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 5d06332fd02183830ac40667df430ab943f8b3d0 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 5d06332fd02183830ac40667df430ab943f8b3d0 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC 5d06332fd02183830ac40667df430ab943f8b3d0 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\a\x82~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9e05db9da0f517eb12314622c9716ff615497dce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff*'*\x13\x87\xf6\xb1I"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x18\n\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5d06332fd02183830ac40667df430ab943f8b3d0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf2\x0f\xacw\xa0\xdf'\x97"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2351,9 +2351,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 6c64e3b7644d2e97fefb7ff7d30b0b9e52610e8c 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 1e1708294a7d6d2c2d311b1e52edf279731a3c0f 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 1e1708294a7d6d2c2d311b1e52edf279731a3c0f 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 1e1708294a7d6d2c2d311b1e52edf279731a3c0f 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2500,9 +2500,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2e0583efa67ce662a9b0f04f95fb5948e6a9f307\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9ca29cec60a6eb4f9572e0a5d7db40b8c511a8a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9ca29cec60a6eb4f9572e0a5d7db40b8c511a8a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:9ca29cec60a6eb4f9572e0a5d7db40b8c511a8a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2526,9 +2526,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:22c33ccf99af5672c901758cf82de1dceb5827ac\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de451195026273852c168c9467992223562b3d6c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de451195026273852c168c9467992223562b3d6c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de451195026273852c168c9467992223562b3d6c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2651,9 +2651,9 @@ Debug = true
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3598 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$10\r\nstrawberry\r\n$5\r\ngrape\r\n$5\r\nmango\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived RESP array: ["strawberry", "grape", "mango"][0m
-[33m[tester::#JW4] [client] [0m[92mReceived ["strawberry", "grape", "mango"][0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$5\r\nmango\r\n$5\r\ngrape\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived RESP array: ["mango", "grape", "strawberry"][0m
+[33m[tester::#JW4] [client] [0m[92mReceived ["mango", "grape", "strawberry"][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
 [33m[tester::#JW4] [0m[36mProgram terminated successfully[0m
@@ -2718,15 +2718,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 18:08:09.963[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 18:08:09.963 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 03:48:42.995[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 03:48:42.995 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 18:08:10.066 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "strawberry" at 03:48:43.097 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET strawberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -2,9 +2,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 49020[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 49036[0m
-[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 49052[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 60780 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 60788 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 60790 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET blueberry 80[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -107,8 +107,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 49066[0m
-[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 49082[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 60814 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 60826 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pineapple pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -211,8 +211,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 49112[0m
-[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 49122[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 60864 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 60868 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -258,8 +258,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 49144[0m
-[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 49160[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 60882 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 60896 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -759,9 +759,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121258811-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121258811-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1753121258811-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753156077028-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753156077028-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753156077028-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -883,11 +883,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfff\xb5\x84\x15}\xa0YA"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\t\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e9a3c53787256870b4a98cfd1aa20d9e88539f3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9c`e\x1b\xbd\x95\xefs"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -907,11 +907,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff5x\xef#F\tm\xcc"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\t\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e9a3c53787256870b4a98cfd1aa20d9e88539f3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffϭ\x0e-\x86<\xdb\xfe"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -931,11 +931,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfa\xd6\b$#\xb2\xe3\xfc"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\t\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e9a3c53787256870b4a98cfd1aa20d9e88539f3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\x03\xe9*\xe3\x87U\xce"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -955,11 +955,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 8e9a3c53787256870b4a98cfd1aa20d9e88539f3 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\u05ce\x9f(\x8d<*\x18"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xed\t\x7fh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e9a3c53787256870b4a98cfd1aa20d9e88539f3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff-[~&M\t\x9c*"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1076,7 +1076,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2089 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2093 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1108,11 +1108,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x93\x93\xae.;\xfbX\x00"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\t\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31bfb42022302467484c8a8843db6e43e1b8aba6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc3S;l\xa8]\xe5G"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1132,11 +1132,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0^\xc5\x18\x00Rl\x8d"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\t\x7fh\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31bfb42022302467484c8a8843db6e43e1b8aba6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x90\x9ePZ\x93\xf4\xd1\xca"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1156,11 +1156,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\xf0\"\x1fe\xe9\xe2\xbd"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\t\x7fh\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31bfb42022302467484c8a8843db6e43e1b8aba6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff_0\xb7]\xf6O_\xfa"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1180,11 +1180,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\xa8\xb5\x13\xcbg+Y"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\t\x7fh\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31bfb42022302467484c8a8843db6e43e1b8aba6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffrh QX\xc1\x96\x1e"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1204,11 +1204,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 31bfb42022302467484c8a8843db6e43e1b8aba6 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffB\xe1\xc3:P&\xe1P"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\t\x7fh\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(31bfb42022302467484c8a8843db6e43e1b8aba6\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12!VxÀ\\\x17"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1498,11 +1498,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1c\xc7\x14ڐ\x8d\x14B"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\t\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2072cd925af2c41f109172e816e879a1e0083ce4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf3\xf0G6\t\xca\xc8\xc9"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1522,11 +1522,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%;\xbeƜb\x92\x88"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\t\x7fh\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2072cd925af2c41f109172e816e879a1e0083ce4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xca\f\xed*\x05%N\x03"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1546,11 +1546,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 2072cd925af2c41f109172e816e879a1e0083ce4 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xdc,\x96\x8a\x1e;\xba"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\t\x7fh\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(2072cd925af2c41f109172e816e879a1e0083ce4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\xeb\x7fz\x13Y\xe71"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 34343f9aa02b4e9582e4307b1a56fa968c01b8aa 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 34343f9aa02b4e9582e4307b1a56fa968c01b8aa 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 34343f9aa02b4e9582e4307b1a56fa968c01b8aa 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbdf4af2cdb4fc057c6188956aae05590b2246a3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xef\x12\xe2>\xb27\x91:"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf2\t\x7fh\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(34343f9aa02b4e9582e4307b1a56fa968c01b8aa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffۢ,\xdf\x02?\x82\x8f"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1694,11 +1694,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC db9741899431cee761b906ba9ef4b5c69c16d4f1 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC db9741899431cee761b906ba9ef4b5c69c16d4f1 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC db9741899431cee761b906ba9ef4b5c69c16d4f1 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acaac9395691d40bcd4e65bd09d819aafd192558\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3<m\n\xc0\xbepT"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf3\t\x7fh\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db9741899431cee761b906ba9ef4b5c69c16d4f1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff,'.\xb0}bD\x17"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1723,9 +1723,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC d2ec1508bd9f7c378b2549f0ebbef6b1e61d31b3 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d2ec1508bd9f7c378b2549f0ebbef6b1e61d31b3 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC d2ec1508bd9f7c378b2549f0ebbef6b1e61d31b3 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1872,9 +1872,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:15cae4312dd902d61f60fc3378a80c0ebe677eef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:15cae4312dd902d61f60fc3378a80c0ebe677eef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:15cae4312dd902d61f60fc3378a80c0ebe677eef\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1886,9 +1886,9 @@ Debug = true
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
 [33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived bytes: "$679\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#HC6] [client] [0m[92mReceived "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_link_down_since_seconds:1\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#HC6] [0m[92mFound role:slave in response.[0m
 [33m[tester::#HC6] [0m[92mTest passed.[0m
 [33m[tester::#HC6] [0m[36mTerminating program[0m
@@ -1898,9 +1898,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:42501979a2bdf00b3d41088690db3d0cb9889062\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:42501979a2bdf00b3d41088690db3d0cb9889062\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:42501979a2bdf00b3d41088690db3d0cb9889062\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2017,18 +2017,18 @@ Debug = true
 [33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3062 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$5\r\nmango\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
 [33m[tester::#JW4] [client] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[36m  "banana"[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92mReceived [[0m
 [33m[tester::#JW4] [client] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[92m  "banana"[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2094,15 +2094,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 18:07:47.756[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:07:47.756 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 03:48:05.927[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 03:48:05.927 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:07:47.858 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 03:48:06.030 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -2,6 +2,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-1 connected from port 49020[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-2 connected from port 49036[0m
+[33m[tester::#JF8] [0m[36m[Setup] client-3 connected from port 49052[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET blueberry 80[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -104,6 +107,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-1 connected from port 49066[0m
+[33m[tester::#SG9] [0m[36m[Setup] client-2 connected from port 49082[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pineapple pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -206,6 +211,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-1 connected from port 49112[0m
+[33m[tester::#FY6] [0m[36m[Setup] client-2 connected from port 49122[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -251,6 +258,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-1 connected from port 49144[0m
+[33m[tester::#RS9] [0m[36m[Setup] client-2 connected from port 49160[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -750,9 +759,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1752498740697-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1752498740697-0"[0m
-[33m[tester::#XU6] [client] [0m[92mReceived "1752498740697-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1753121258811-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1753121258811-0"[0m
+[33m[tester::#XU6] [client] [0m[92mReceived "1753121258811-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -874,11 +883,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x02uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(18c0dbbbb7a2d959afc1d57ac0dc231c0447e174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8cdW$\x9d\xc9\xf2\x12"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfff\xb5\x84\x15}\xa0YA"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -898,11 +907,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x02uh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(18c0dbbbb7a2d959afc1d57ac0dc231c0447e174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff3\xa4\x00\n\x80\x15\xa8\x0e"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff5x\xef#F\tm\xcc"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -922,11 +931,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x02uh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(18c0dbbbb7a2d959afc1d57ac0dc231c0447e174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff6v\xe3\x90\x1c!Ʈ"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfa\xd6\b$#\xb2\xe3\xfc"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -946,11 +955,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 18c0dbbbb7a2d959afc1d57ac0dc231c0447e174 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 8989a2102f4c166fb9f39d6ac126fa5c9af1e50b 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc25\x02uh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(18c0dbbbb7a2d959afc1d57ac0dc231c0447e174\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff_c\xd7^\xa4{\xaf\xcb"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeb\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8989a2102f4c166fb9f39d6ac126fa5c9af1e50b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\u05ce\x9f(\x8d<*\x18"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1067,7 +1076,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2105 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2089 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1099,11 +1108,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc28\x02uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7609e52d8367bc6e7fec5d8aa595fbdc97c1899e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x7f\x11\f\xeeF8\x8b\x13"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x93\x93\xae.;\xfbX\x00"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1123,11 +1132,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc28\x02uh\xfa\bused-mem\xc2 $\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7609e52d8367bc6e7fec5d8aa595fbdc97c1899e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0\xd1[\xc0[\xe4\xd1\x0f"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xe0\xe9\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0^\xc5\x18\x00Rl\x8d"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1147,11 +1156,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc28\x02uh\xfa\bused-mem\xc2`-\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7609e52d8367bc6e7fec5d8aa595fbdc97c1899e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc5\x03\xb8Z\xc7п\xaf"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2P\xf3\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\xf0\"\x1fe\xe9\xe2\xbd"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1171,11 +1180,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc28\x02uh\xfa\bused-mem°6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7609e52d8367bc6e7fec5d8aa595fbdc97c1899e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xac\x16\x8c\x94\x7f\x8a\xd6\xca"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc2\xc0\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\xa8\xb5\x13\xcbg+Y"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1195,11 +1204,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC 7609e52d8367bc6e7fec5d8aa595fbdc97c1899e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived "FULLRESYNC cc97b0a7a86c17ebb7af642faf6f70333db79727 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc28\x02uh\xfa\bused-mem\xc2\x00@\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7609e52d8367bc6e7fec5d8aa595fbdc97c1899e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffzy\x06#\xf2GG\xd2"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xee\x81~h\xfa\bused-mem\xc28\x06\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cc97b0a7a86c17ebb7af642faf6f70333db79727\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffB\xe1\xc3:P&\xe1P"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1489,11 +1498,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x02uh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(72d6d5a9bd5f973b712e7549dfdb145ae928e866\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x93\x1az\x88\x85\xa5a\x97"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1c\xc7\x14ڐ\x8d\x14B"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1513,11 +1522,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x02uh\xfa\bused-mem\xc2 i\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(72d6d5a9bd5f973b712e7549dfdb145ae928e866\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff#|IƗ\xcblw"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2 /\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff%;\xbeƜb\x92\x88"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1537,11 +1546,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 72d6d5a9bd5f973b712e7549dfdb145ae928e866 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived "FULLRESYNC 6c9f1114f3dfda56ca66cd677d5e764280d5a6bf 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x02uh\xfa\bused-mem\xc2p6\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(72d6d5a9bd5f973b712e7549dfdb145ae928e866\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb0\xa1\xc1e\xb9i\x02\x12"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\u0090\xfc\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6c9f1114f3dfda56ca66cd677d5e764280d5a6bf\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffm\xdc,\x96\x8a\x1e;\xba"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1626,11 +1635,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 0b2c5a1c1ba24aa8d1a04c6bb7ebce14145998a1 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 0b2c5a1c1ba24aa8d1a04c6bb7ebce14145998a1 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC 0b2c5a1c1ba24aa8d1a04c6bb7ebce14145998a1 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived "FULLRESYNC dbdf4af2cdb4fc057c6188956aae05590b2246a3 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2:\x02uh\xfa\bused-mem\xc2p\xc3\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0b2c5a1c1ba24aa8d1a04c6bb7ebce14145998a1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffB\xf1~\x99\xfd\xfc<3"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2@\x89\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dbdf4af2cdb4fc057c6188956aae05590b2246a3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xef\x12\xe2>\xb27\x91:"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1685,11 +1694,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC f9ae472f7db749be004ce2b7eb2ce72a0ff27331 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC f9ae472f7db749be004ce2b7eb2ce72a0ff27331 0"[0m
-[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC f9ae472f7db749be004ce2b7eb2ce72a0ff27331 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0"[0m
+[33m[tester::#CF8] [client] [0m[92mReceived "FULLRESYNC acaac9395691d40bcd4e65bd09d819aafd192558 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2;\x02uh\xfa\bused-mem\xc2P~\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f9ae472f7db749be004ce2b7eb2ce72a0ff27331\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd1%\x03c\xbe\xc3\x00"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.0.3\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf0\x81~h\xfa\bused-mem\xc2\xf0C\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acaac9395691d40bcd4e65bd09d819aafd192558\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3<m\n\xc0\xbepT"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1714,9 +1723,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92mReceived "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC dcdd3d7efe18cdb14e1e817a1bb20ca041fd8287 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC dcdd3d7efe18cdb14e1e817a1bb20ca041fd8287 0"[0m
-[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC dcdd3d7efe18cdb14e1e817a1bb20ca041fd8287 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0"[0m
+[33m[tester::#VM3] [client] [0m[92mReceived "FULLRESYNC 05467d65ae78b286b59ada086703b25e87db2be5 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1863,9 +1872,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8bdff45973c7a545896d2abe1d08eceffcbaa75d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8bdff45973c7a545896d2abe1d08eceffcbaa75d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8bdff45973c7a545896d2abe1d08eceffcbaa75d\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:161542d4eae86ccff3cdd762eb75e63c1af723b6\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1889,9 +1898,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:12c0dcd2358454f09f0ed7947fc288165758f6a7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:12c0dcd2358454f09f0ed7947fc288165758f6a7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:12c0dcd2358454f09f0ed7947fc288165758f6a7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92mReceived "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:373f351aef950a3298e4adc212d3783c18ff4ace\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1922,7 +1931,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0090 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 72 61 | (.......apple.ra[0m
 [33m[tester::#SM4] [0m[36m00a0 | 73 70 62 65 72 72 79 ff 10 f6 99 42 96 77 a1 8d | spberry....B.w..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9534 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -1966,7 +1975,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
 [33m[tester::#DQ3] [0m[36m0070 | ff 97 22 dd 30 46 ee 83 03                      | ..".0F...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1438 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET strawberry[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -2005,21 +2014,21 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 79 00 05 6d 61 6e 67 6f 05 67 72 61 70 65 ff ba | y..mango.grape..[0m
 [33m[tester::#JW4] [0m[36m0070 | fb 6e db 72 08 1e 1b                            | .n.r...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3062 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3062 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$6\r\nbanana\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
 [33m[tester::#JW4] [client] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
-[33m[tester::#JW4] [client] [0m[36m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[36m  "mango",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92mReceived [[0m
 [33m[tester::#JW4] [client] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
-[33m[tester::#JW4] [client] [0m[92m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[92m  "mango",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2030,13 +2039,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 05 67 | er.7.2.0.......g[0m
-[33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 ff 4a 4f bd 38 | rape.orange.JO.8[0m
-[33m[tester::#GC6] [0m[36m0040 | 78 ea 9b 2d                                     | x..-[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 ff df 76 69 ad | rape.orange..vi.[0m
+[33m[tester::#GC6] [0m[36m0040 | c7 19 1a 7f                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3337 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3337 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET grape[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
@@ -2051,13 +2060,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 04 70 | er.7.2.0.......p[0m
-[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 09 70 69 6e 65 61 70 70 6c 65 ff 4b c7 | ear.pineapple.K.[0m
-[33m[tester::#JZ6] [0m[36m0040 | 88 8a 61 a2 ab c3                               | ..a...[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 04 70 | s-bits.@.......p[0m
+[33m[tester::#JZ6] [0m[36m0030 | 65 61 72 09 70 69 6e 65 61 70 70 6c 65 ff a1 e2 | ear.pineapple...[0m
+[33m[tester::#JZ6] [0m[36m0040 | 16 a7 2d 81 76 2a                               | ..-.v*[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1646 --dbfilename grape.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1646 --dbfilename grape.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$4\r\npear\r\n"[0m
@@ -2068,12 +2077,12 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6307 --dbfilename apple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-6307 --dbfilename apple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-6307\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-6307"][0m
-[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/private/tmp/rdb-6307"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-6307\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-6307"][0m
+[33m[tester::#ZG5] [client] [0m[92mReceived ["dir", "/tmp/rdb-6307"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
@@ -2085,15 +2094,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 18:57:30.336[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:57:30.337 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 18:07:47.756[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:07:47.756 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [client] [0m[92mReceived "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:57:30.440 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 18:07:47.858 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/util.go
+++ b/internal/util.go
@@ -83,8 +83,10 @@ func SpawnClients(clientCount int, addr string, stageHarness *test_case_harness.
 			logFriendlyError(logger, err)
 			return nil, err
 		}
+		logger.Debugf("[Setup] client-%d connected from port %s", i+1, strings.Split(client.Conn.LocalAddr().String(), ":")[1])
 		clients = append(clients, client)
 	}
+
 	return clients, nil
 }
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,8 +85,10 @@ func SpawnClients(clientCount int, addr string, stageHarness *test_case_harness.
 			return nil, err
 		}
 
-		addrParts := strings.Split(client.Conn.LocalAddr().String(), ":")
-		logger.Debugf("[Setup] client-%d connected from port %s", i+1, addrParts[len(addrParts)-1])
+		clientLogger := client.GetLogger()
+		clientPort := client.Conn.LocalAddr().(*net.TCPAddr).Port
+		serverPort := client.Conn.RemoteAddr().(*net.TCPAddr).Port
+		clientLogger.Debugf("Connected (port %d -> port %d)", clientPort, serverPort)
 
 		clients = append(clients, client)
 	}

--- a/internal/util.go
+++ b/internal/util.go
@@ -83,7 +83,10 @@ func SpawnClients(clientCount int, addr string, stageHarness *test_case_harness.
 			logFriendlyError(logger, err)
 			return nil, err
 		}
-		logger.Debugf("[Setup] client-%d connected from port %s", i+1, strings.Split(client.Conn.LocalAddr().String(), ":")[1])
+
+		addrParts := strings.Split(client.Conn.LocalAddr().String(), ":")
+		logger.Debugf("[Setup] client-%d connected from port %s", i+1, addrParts[len(addrParts)-1])
+
 		clients = append(clients, client)
 	}
 


### PR DESCRIPTION
Context:

https://codecrafters-io.slack.com/archives/C07H9EY1Z6X/p1753119467804309

New fixture:

<img width="2042" height="1010" alt="image" src="https://github.com/user-attachments/assets/c43c54e6-c6d6-413c-87a9-8b9c60a219d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a brief delay after sending commands in test scenarios to enhance timing consistency.
  * Added detailed debug logging showing client connection information during client spawning.
  * Enhanced test logs with explicit client connection messages and updated environment-specific output values for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->