### PR TITLE
Split `data_structures` module

### DIFF
--- a/internal/data_structures/sorted_set/sorted_set.go
+++ b/internal/data_structures/sorted_set/sorted_set.go
@@ -1,4 +1,4 @@
-package data_structures
+package sorted_set
 
 import (
 	"sort"

--- a/internal/test_cases/zadd_test_case.go
+++ b/internal/test_cases/zadd_test_case.go
@@ -3,7 +3,7 @@ package test_cases
 import (
 	"strconv"
 
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -11,7 +11,7 @@ import (
 
 type ZaddTestCase struct {
 	Key                       string
-	Member                    data_structures.SortedSetMember
+	Member                    sorted_set.SortedSetMember
 	ExpectedAddedMembersCount int
 }
 

--- a/internal/test_zset_zadd1.go
+++ b/internal/test_zset_zadd1.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
@@ -26,14 +26,14 @@ func testZsetZadd1(stageHarness *test_case_harness.TestCaseHarness) error {
 	keyMemberPair := testerutils_random.RandomWords(2)
 
 	zsetKey := keyMemberPair[0]
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count: 1,
 	})
 	member := sortedSet.GetMembers()[0]
 
 	zaddTestCase := test_cases.ZaddTestCase{
 		Key: zsetKey,
-		Member: data_structures.SortedSetMember{
+		Member: sorted_set.SortedSetMember{
 			Name:  member.Name,
 			Score: member.Score,
 		},

--- a/internal/test_zset_zadd2.go
+++ b/internal/test_zset_zadd2.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
@@ -24,7 +24,7 @@ func testZsetZadd2(stageHarness *test_case_harness.TestCaseHarness) error {
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count: testerutils_random.RandomInt(2, 4),
 	})
 	members := sortedSet.GetMembers()
@@ -43,10 +43,10 @@ func testZsetZadd2(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Test by updating an existing member
 	memberToUpdate := members[testerutils_random.RandomInt(0, sortedSet.Size())]
-	newScore := data_structures.GetRandomSortedSetScore()
+	newScore := sorted_set.GetRandomSortedSetScore()
 	zaddTestCase := test_cases.ZaddTestCase{
 		Key: zsetKey,
-		Member: data_structures.SortedSetMember{
+		Member: sorted_set.SortedSetMember{
 			Name:  memberToUpdate.Name,
 			Score: newScore,
 		},

--- a/internal/test_zset_zcard.go
+++ b/internal/test_zset_zcard.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
@@ -27,7 +27,7 @@ func testZsetZcard(stageHarness *test_case_harness.TestCaseHarness) error {
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count:          testerutils_random.RandomInt(3, 5),
 		SameScoreCount: 2,
 	})
@@ -58,10 +58,10 @@ func testZsetZcard(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	// Update an existing member
 	memberToUpdate := members[testerutils_random.RandomInt(0, sortedSet.Size())]
-	newScore := data_structures.GetRandomSortedSetScore()
+	newScore := sorted_set.GetRandomSortedSetScore()
 	zaddTestCase := test_cases.ZaddTestCase{
 		Key: zsetKey,
-		Member: data_structures.SortedSetMember{
+		Member: sorted_set.SortedSetMember{
 			Name:  memberToUpdate.Name,
 			Score: newScore,
 		},

--- a/internal/test_zset_zrange_neg_index.go
+++ b/internal/test_zset_zrange_neg_index.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
@@ -24,7 +24,7 @@ func testZsetZrangeNegIndex(stageHarness *test_case_harness.TestCaseHarness) err
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count:          testerutils_random.RandomInt(3, 5),
 		SameScoreCount: 2,
 	})

--- a/internal/test_zset_zrange_pos_index.go
+++ b/internal/test_zset_zrange_pos_index.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
@@ -26,7 +26,7 @@ func testZsetZrangePosIndex(stageHarness *test_case_harness.TestCaseHarness) err
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count:          testerutils_random.RandomInt(3, 5),
 		SameScoreCount: 2,
 	})

--- a/internal/test_zset_zrank.go
+++ b/internal/test_zset_zrank.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
@@ -27,7 +27,7 @@ func testZsetZrank(stageHarness *test_case_harness.TestCaseHarness) error {
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count:          testerutils_random.RandomInt(3, 5),
 		SameScoreCount: 2,
 	})

--- a/internal/test_zset_zrem.go
+++ b/internal/test_zset_zrem.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
@@ -27,7 +27,7 @@ func testZsetZrem(stageHarness *test_case_harness.TestCaseHarness) error {
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count: testerutils_random.RandomInt(2, 4),
 	})
 	members := sortedSet.GetMembers()

--- a/internal/test_zset_zscore.go
+++ b/internal/test_zset_zscore.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"github.com/codecrafters-io/redis-tester/internal/data_structures"
+	"github.com/codecrafters-io/redis-tester/internal/data_structures/sorted_set"
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/redis_executable"
 	"github.com/codecrafters-io/redis-tester/internal/resp_assertions"
@@ -25,7 +25,7 @@ func testZsetZscore(stageHarness *test_case_harness.TestCaseHarness) error {
 	defer client.Close()
 
 	zsetKey := testerutils_random.RandomWord()
-	sortedSet := data_structures.GenerateSortedSetWithRandomMembers(data_structures.SortedSetMemberGenerationOption{
+	sortedSet := sorted_set.GenerateSortedSetWithRandomMembers(sorted_set.SortedSetMemberGenerationOption{
 		Count:          testerutils_random.RandomInt(3, 5),
 		SameScoreCount: 2,
 	})
@@ -57,10 +57,10 @@ func testZsetZscore(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	// Update an existing member
-	newScore := data_structures.GetRandomSortedSetScore()
+	newScore := sorted_set.GetRandomSortedSetScore()
 	zaddTestCase := test_cases.ZaddTestCase{
 		Key: zsetKey,
-		Member: data_structures.SortedSetMember{
+		Member: sorted_set.SortedSetMember{
 			Name:  memberToTest.Name,
 			Score: newScore,
 		},


### PR DESCRIPTION
This is a PR to facilitate Redis/Geospatial for splitting `data_structures` module

- **No complex changes**
- Move Sorted Set from `data_structures` to `sorted_set` module

