### PR TITLE
Add TransformReceivedBytes callback to RespConnectionCallbacks for byte processing

### DIFF
--- a/internal/instrumented_resp_connection/instrumented_resp_connection.go
+++ b/internal/instrumented_resp_connection/instrumented_resp_connection.go
@@ -85,3 +85,11 @@ func (c *InstrumentedRespConnection) UpdateBaseLogger(l *logger.Logger) {
 	c.logger = newLogger
 	c.UpdateCallBacks(defaultCallbacks(c.logger))
 }
+
+func (c *InstrumentedRespConnection) SetReceivedBytesTransformation(transformFunction func([]byte) []byte) {
+	c.RespConnection.Callbacks.TransformReceivedBytes = transformFunction
+}
+
+func (c *InstrumentedRespConnection) UnsetReceivedBytesTransformation() {
+	c.RespConnection.Callbacks.TransformReceivedBytes = nil
+}


### PR DESCRIPTION
Example usage: 

```go
func (t TestCase) Run() {
  connection.SetReceivedBytesTransformation(normalizeRedisGeoCodeBytes)
  defer connection.UnsetReceivedBytesTransformation()

  ... run the SendCommandTestCase
}

function normalizeRedisGeoCodeBytes(geoCodeBytes []byte) {
  value, err := DecodeResp(geoCodeBytes)
  if err != nil {
    // Invalid value was read, so don't transform
    return geoCodeBytes 
  }
  
  if value.TYPE != BulkString {
    // This is an invalid value too, ignore
    return geoCodeBytes
  }
  
  value = reducePrecision(value)
  return EncodeResp(value)
}
```