### PR TITLE
Add delay in client connection to ensure order of connections

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/codecrafters-io/redis-tester/internal/instrumented_resp_connection"
 	"github.com/codecrafters-io/redis-tester/internal/test_cases"
@@ -91,6 +92,7 @@ func SpawnClients(clientCount int, addr string, stageHarness *test_case_harness.
 		clientLogger.Debugf("Connected (port %d -> port %d)", clientPort, serverPort)
 
 		clients = append(clients, client)
+		time.Sleep(8 * time.Millisecond) // Ensure the connection order
 	}
 
 	return clients, nil


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/submission-issues-in-blocking-retrieval-ec3/15145/10

Choice of delay:

From manually testing, the smallest delay that can ensure the order is 6ms. I chose 8ms just to be safe.