### PR TITLE
Update 'px' to 'PX'

### DIFF
--- a/internal/test_expiry.go
+++ b/internal/test_expiry.go
@@ -32,7 +32,7 @@ func testExpiry(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	setCommandTestCase := test_cases.SendCommandTestCase{
 		Command:   "set",
-		Args:      []string{key, value, "px", "100"},
+		Args:      []string{key, value, "PX", "100"},
 		Assertion: resp_assertions.NewStringAssertion("OK"),
 	}
 

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -93,7 +93,7 @@ extensions:
     name: "Transactions"
     description_markdown: |-
       In this challenge extension you'll add support for [Transactions][redis-transactions] to your Redis implementation.
-      
+
       Along the way, you'll learn about the [MULTI][multi-command], [EXEC][exec-command], and [DISCARD][discard-command] commands, as well as how Redis handles transactions atomically.
 
       [redis-transactions]: https://redis.io/docs/latest/develop/interact/transactions/
@@ -103,7 +103,7 @@ extensions:
 
   - slug: "lists"
     name: "Lists"
-    description_markdown : |-
+    description_markdown: |-
       In this challenge extension you'll add support for [Lists][redis-lists] to your Redis implementation.
 
       Along the way, you'll learn commands like RPUSH, LRANGE, and more.
@@ -114,7 +114,7 @@ extensions:
 
   - slug: "pub-sub"
     name: "Pub/Sub"
-    description_markdown : |-
+    description_markdown: |-
       In this challenge extension you'll add support for [Publish/Subscribe (Pub/Sub)][redis-pub-sub] to your Redis implementation.
 
       Along the way, you'll learn commands like [SUBSCRIBE][subscribe-command], [PUBLISH][publish-command], and more.
@@ -125,7 +125,7 @@ extensions:
 
   - slug: "sorted-sets"
     name: "Sorted Sets"
-    description_markdown : |-
+    description_markdown: |-
       In this challenge extension you'll add support for [Sorted Sets (zsets)][redis-zset] to your Redis implementation.
 
       Along the way, you'll learn commands like [ZADD][zadd-command], [ZRANGE][zrange-command], and more.
@@ -463,7 +463,7 @@ stages:
       The expiry for a key can be provided using the "PX" argument to the [SET](https://redis.io/commands/set) command. The expiry is provided in milliseconds.
 
       ```bash
-      $ redis-cli SET foo bar px 100 # Sets the key "foo" to "bar" with an expiry of 100 milliseconds
+      $ redis-cli SET foo bar PX 100 # Sets the key "foo" to "bar" with an expiry of 100 milliseconds
       OK
       ```
 
@@ -485,7 +485,7 @@ stages:
       It'll then send a `SET` command to your server to set a key with an expiry:
 
       ```bash
-      $ redis-cli SET foo bar px 100
+      $ redis-cli SET foo bar PX 100
       ```
 
       It'll then immediately send a `GET` command to retrieve the value:
@@ -3576,7 +3576,7 @@ stages:
     name: "Blocking retrieval with timeout"
     difficulty: medium
     marketing_md: In this stage, you will add support for a non-zero timeout duration for the `BLPOP` command.
-  
+
   # Pub-Sub
   - slug: "mx3"
     primary_extension_slug: "pub-sub"
@@ -3595,7 +3595,7 @@ stages:
     name: "Enter subscribed mode"
     difficulty: medium
     marketing_md: In this stage, you'll add support for marking a client as having entered subscribed mode.
-    
+
   - slug: "lf1"
     primary_extension_slug: "pub-sub"
     name: "PING in subscribed mode"

--- a/internal/test_helpers/fixtures/expiry/pass
+++ b/internal/test_helpers/fixtures/expiry/pass
@@ -2,20 +2,20 @@ Debug = true
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 07:22:35.924[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 07:22:35.924 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:22:04.157[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:22:04.157 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 07:22:36.031 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:22:04.261 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/geospatial/pass
+++ b/internal/test_helpers/fixtures/geospatial/pass
@@ -27,8 +27,8 @@ Debug = true
 [33m[tester::#RM9] [client] [0m[36mReceived bytes: ":1\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#RM9] [client] [0m[92m✔︎ Received 1[0m
-[33m[tester::#RM9] [client] [0m[94m> GEOSEARCH pear FROMLONLAT -11.919344841619989 26.666003057840747 BYRADIUS 4139692.253223797 m[0m
-[33m[tester::#RM9] [client] [0m[36mSent bytes: "*8\r\n$9\r\nGEOSEARCH\r\n$4\r\npear\r\n$10\r\nFROMLONLAT\r\n$19\r\n-11.919344841619989\r\n$18\r\n26.666003057840747\r\n$8\r\nBYRADIUS\r\n$17\r\n4139692.253223797\r\n$1\r\nm\r\n"[0m
+[33m[tester::#RM9] [client] [0m[94m> GEOSEARCH pear FROMLONLAT -11.919344841619989 26.666003057840747 BYRADIUS 4139692.2532237964 m[0m
+[33m[tester::#RM9] [client] [0m[36mSent bytes: "*8\r\n$9\r\nGEOSEARCH\r\n$4\r\npear\r\n$10\r\nFROMLONLAT\r\n$19\r\n-11.919344841619989\r\n$18\r\n26.666003057840747\r\n$8\r\nBYRADIUS\r\n$18\r\n4139692.2532237964\r\n$1\r\nm\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived bytes: "*0\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived RESP array: [][0m
 [33m[tester::#RM9] [client] [0m[92m✔︎ Received [][0m
@@ -650,9 +650,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 37658 -> port 6379)[0m
-[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 37664 -> port 6379)[0m
-[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 37676 -> port 6379)[0m
+[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 50521 -> port 6379)[0m
+[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 50522 -> port 6379)[0m
+[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 50523 -> port 6379)[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE mango[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\nmango\r\n:1\r\n"[0m
@@ -716,10 +716,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#DN4] [client-1] [0m[36mConnected (port 37692 -> port 6379)[0m
-[33m[tester::#DN4] [client-2] [0m[36mConnected (port 37694 -> port 6379)[0m
-[33m[tester::#DN4] [client-3] [0m[36mConnected (port 37698 -> port 6379)[0m
-[33m[tester::#DN4] [client-4] [0m[36mConnected (port 37706 -> port 6379)[0m
+[33m[tester::#DN4] [client-1] [0m[36mConnected (port 50526 -> port 6379)[0m
+[33m[tester::#DN4] [client-2] [0m[36mConnected (port 50527 -> port 6379)[0m
+[33m[tester::#DN4] [client-3] [0m[36mConnected (port 50528 -> port 6379)[0m
+[33m[tester::#DN4] [client-4] [0m[36mConnected (port 50529 -> port 6379)[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE mango[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\nmango\r\n:1\r\n"[0m
@@ -769,10 +769,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HF2] [client-1] [0m[36mConnected (port 37716 -> port 6379)[0m
-[33m[tester::#HF2] [client-2] [0m[36mConnected (port 37720 -> port 6379)[0m
-[33m[tester::#HF2] [client-3] [0m[36mConnected (port 37732 -> port 6379)[0m
-[33m[tester::#HF2] [client-4] [0m[36mConnected (port 37734 -> port 6379)[0m
+[33m[tester::#HF2] [client-1] [0m[36mConnected (port 50532 -> port 6379)[0m
+[33m[tester::#HF2] [client-2] [0m[36mConnected (port 50533 -> port 6379)[0m
+[33m[tester::#HF2] [client-3] [0m[36mConnected (port 50534 -> port 6379)[0m
+[33m[tester::#HF2] [client-4] [0m[36mConnected (port 50535 -> port 6379)[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE strawberry[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$10\r\nstrawberry\r\n:1\r\n"[0m
@@ -804,8 +804,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LF1] [client-1] [0m[36mConnected (port 37752 -> port 6379)[0m
-[33m[tester::#LF1] [client-2] [0m[36mConnected (port 37762 -> port 6379)[0m
+[33m[tester::#LF1] [client-1] [0m[36mConnected (port 50538 -> port 6379)[0m
+[33m[tester::#LF1] [client-2] [0m[36mConnected (port 50539 -> port 6379)[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE grape[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\ngrape\r\n:1\r\n"[0m
@@ -858,8 +858,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 37790 -> port 6379)[0m
-[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 37794 -> port 6379)[0m
+[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 50545 -> port 6379)[0m
+[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 50546 -> port 6379)[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE banana[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\nbanana\r\n:1\r\n"[0m
@@ -922,8 +922,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null array: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92m✔︎ Received "*-1\r\n"[0m
-[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 37820 -> port 6379)[0m
-[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 37824 -> port 6379)[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 50553 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 50554 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.3[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.3\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry raspberry[0m
@@ -941,9 +941,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [client-1] [0m[36mConnected (port 37848 -> port 6379)[0m
-[33m[tester::#EC3] [client-2] [0m[36mConnected (port 37862 -> port 6379)[0m
-[33m[tester::#EC3] [client-3] [0m[36mConnected (port 37878 -> port 6379)[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 50557 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 50558 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 50559 -> port 6379)[0m
 [33m[tester::#EC3] [client-1] [0m[94m$ redis-cli BLPOP strawberry 0[0m
 [33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$10\r\nstrawberry\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP strawberry 0[0m
@@ -1264,9 +1264,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 38032 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 38040 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 38054 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 50589 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 50590 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 50591 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 66[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n66\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1369,8 +1369,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 38074 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 38084 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 50594 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 50595 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET mango orange[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$6\r\norange\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1473,8 +1473,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 38116 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 38122 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 50601 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 50602 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1520,8 +1520,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 38144 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 38156 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 50605 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 50606 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -2005,9 +2005,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD blueberry * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758637469670-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758637469670-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758637469670-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407802767-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407802767-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407802767-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -2129,11 +2129,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9bf2bcba35165628623e43c41dd723e9cea775b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffuS\x89\x96ɺu]"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\xbb\x9au\xff\xb7a\xe3"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2153,11 +2153,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9bf2bcba35165628623e43c41dd723e9cea775b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfaHX\xf7\u009dO\xfb"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5EU{{,a\xd8"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2177,11 +2177,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9bf2bcba35165628623e43c41dd723e9cea775b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffD\x95'\xdbhB\x9c\xbd"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff^&\xc0ڨ\xb8\x1c\x01"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -2201,11 +2201,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC d9bf2bcba35165628623e43c41dd723e9cea775b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u009e\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d9bf2bcba35165628623e43c41dd723e9cea775b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb4q|\xcfG\xcf\xd6&"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffb\xe5\xbe\xfe\xbc^\xa9u"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2322,7 +2322,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2088 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2102 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -2357,11 +2357,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u00a0\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff'\xfa\x8e\x88\x10Q\xe1\xe3"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff*\x86\x90\xec\x1avK\xf8"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2381,11 +2381,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u00a0\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\xe1_\xe9\x1bv\xdbE"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff`x_\xe2\x9e\xedK\xc3"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2405,11 +2405,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\xc9x\xa1J\x18^\xdd"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\x1b\xcaCMy6\x1a"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -2429,11 +2429,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13-#\xb5e\x95\x14F"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7شgY\x9f\x83n"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -2453,11 +2453,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffܗ\x94\xb9@\xadX@"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf6Oԑ\xf9\x813S"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -2477,11 +2477,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\u0080\x93\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffV\xab\xf1\x12,\x81\xd2|"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffH\xba\v\xab\xd3Xex"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -2501,11 +2501,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\xc2\xf8\x9c\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf4\t\xb0$2\x94=2"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1dt!\xb3\x00\xe6:M"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6387[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m$ redis-cli PING[0m
@@ -2525,11 +2525,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC 3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¡\xad\xd2h\xfa\bused-mem\xc2`\xe2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(3ea8f63d3d8c2b35b0d4aaa42a398507b2a72d43\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2>\x82pp\x0f\xc8\x1d"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\u00a0\xb1\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\xf8\xbb\x87:Ο\x17"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2814,11 +2814,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¢\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xed>\xec\x00\xb0\x1e\xa2\xf8"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0e$\r\x91\f\xef`\xb8"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2838,11 +2838,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¢\xad\xd2h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1cM\xb6\xa5\xff\xdf\xc5\x11"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"q\xf2\xc3@\x9e\xdd>"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2862,11 +2862,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£\xad\xd2h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8751f2d7e9d1511bb77c95c457f69f1f6cc80fa3\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1b2\xb6ƿ\x8atS"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc2\xf1\xe1)`\xc0\xb4\xc9"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2951,11 +2951,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 0c5d88205d788d099268f0aae3c719c8b8f0fbdd 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 0c5d88205d788d099268f0aae3c719c8b8f0fbdd 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 0c5d88205d788d099268f0aae3c719c8b8f0fbdd 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0c5d88205d788d099268f0aae3c719c8b8f0fbdd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x93bS\x8c6\x84%\xf3"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db4a9334fad48fad3a5c256d9961313a86561856\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb4K\xa1\x9e\x192&\xe7"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -3010,11 +3010,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 8e177c5c8f4089fba500e008986b0b4b6431ecce 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 8e177c5c8f4089fba500e008986b0b4b6431ecce 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 8e177c5c8f4089fba500e008986b0b4b6431ecce 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8e177c5c8f4089fba500e008986b0b4b6431ecce\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff!)\x15\"\xac\x8d\x9d\\"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(89605d984aae7f3d0355b9b0d1b0ba1f7372f58f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\xb9fʛ\xf7\xc7\x18"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -3039,9 +3039,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 0bdb88304e88dce574de6b003856024f7243da60 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 0bdb88304e88dce574de6b003856024f7243da60 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 0bdb88304e88dce574de6b003856024f7243da60 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -3188,9 +3188,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:16d661f0f9a2092234f3415ab41dec5a0c8f0026\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:16d661f0f9a2092234f3415ab41dec5a0c8f0026\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:16d661f0f9a2092234f3415ab41dec5a0c8f0026\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -3214,9 +3214,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:92f3435391ddee77a03d56e2b8721adc596252a4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:92f3435391ddee77a03d56e2b8721adc596252a4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:92f3435391ddee77a03d56e2b8721adc596252a4\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -3246,7 +3246,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 00 00 06 6f 72 61 6e 67 65 09 72 61 73 70 62 65 | ...orange.raspbe[0m
 [33m[tester::#SM4] [0m[36m0090 | 72 72 79 ff 93 40 72 7c a9 01 97 96             | rry..@r|....[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-7219 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-7219 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET strawberry[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -3285,7 +3285,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 ff 30 | erry.blueberry.0[0m
 [33m[tester::#DQ3] [0m[36m0070 | 90 48 3d 58 d0 02 a1                            | .H=X...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1619 --dbfilename apple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1619 --dbfilename apple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
@@ -3315,30 +3315,30 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 05 67 | er.7.2.0.......g[0m
 [33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 00 0a 73 74 72 61 77 | rape.pear..straw[0m
 [33m[tester::#JW4] [0m[36m0040 | 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 00 | berry.blueberry.[0m
 [33m[tester::#JW4] [0m[36m0050 | 09 70 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 | .pineapple.raspb[0m
 [33m[tester::#JW4] [0m[36m0060 | 65 72 72 79 00 05 6d 61 6e 67 6f 05 61 70 70 6c | erry..mango.appl[0m
-[33m[tester::#JW4] [0m[36m0070 | 65 ff 9b e7 0f 44 4e 3b 74 1d                   | e....DN;t.[0m
+[33m[tester::#JW4] [0m[36m0070 | 65 ff eb 29 d9 56 e9 6c 45 55                   | e..).V.lEU[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9921 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9921 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$5\r\ngrape\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n$9\r\npineapple\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[36m  "grape",[0m
 [33m[tester::#JW4] [client] [0m[36m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
-[33m[tester::#JW4] [client] [0m[36m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[92m  "grape",[0m
 [33m[tester::#JW4] [client] [0m[92m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
-[33m[tester::#JW4] [client] [0m[92m  "pineapple"[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -3355,7 +3355,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 05 6d 61 6e 67 6f ff dd | ineapple.mango..[0m
 [33m[tester::#GC6] [0m[36m0040 | a9 87 2e 31 ef 21 b4                            | ...1.!.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9914 --dbfilename pear.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9914 --dbfilename pear.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -3376,7 +3376,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
 [33m[tester::#JZ6] [0m[36m0040 | 6b 9a                                           | k.[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-8712 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-8712 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -3387,32 +3387,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-4834 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-4834 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-4834\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-4834"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-4834"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-4834\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-4834"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-4834"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET blueberry apple px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$5\r\napple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET blueberry apple PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$5\r\napple\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:24:38.603[0m
-[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 14:24:38.603 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:23:32.543[0m
+[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 21:23:32.543 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET blueberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "apple"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 14:24:38.710 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 21:23:32.647 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET blueberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/geospatial/pass
+++ b/internal/test_helpers/fixtures/geospatial/pass
@@ -27,8 +27,8 @@ Debug = true
 [33m[tester::#RM9] [client] [0m[36mReceived bytes: ":1\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived RESP integer: 1[0m
 [33m[tester::#RM9] [client] [0m[92m✔︎ Received 1[0m
-[33m[tester::#RM9] [client] [0m[94m> GEOSEARCH pear FROMLONLAT -11.919344841619989 26.666003057840747 BYRADIUS 4139692.2532237964 m[0m
-[33m[tester::#RM9] [client] [0m[36mSent bytes: "*8\r\n$9\r\nGEOSEARCH\r\n$4\r\npear\r\n$10\r\nFROMLONLAT\r\n$19\r\n-11.919344841619989\r\n$18\r\n26.666003057840747\r\n$8\r\nBYRADIUS\r\n$18\r\n4139692.2532237964\r\n$1\r\nm\r\n"[0m
+[33m[tester::#RM9] [client] [0m[94m> GEOSEARCH pear FROMLONLAT -11.919344841619989 26.666003057840747 BYRADIUS 4139692.253223797 m[0m
+[33m[tester::#RM9] [client] [0m[36mSent bytes: "*8\r\n$9\r\nGEOSEARCH\r\n$4\r\npear\r\n$10\r\nFROMLONLAT\r\n$19\r\n-11.919344841619989\r\n$18\r\n26.666003057840747\r\n$8\r\nBYRADIUS\r\n$17\r\n4139692.253223797\r\n$1\r\nm\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived bytes: "*0\r\n"[0m
 [33m[tester::#RM9] [client] [0m[36mReceived RESP array: [][0m
 [33m[tester::#RM9] [client] [0m[92m✔︎ Received [][0m
@@ -650,9 +650,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 50521 -> port 6379)[0m
-[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 50522 -> port 6379)[0m
-[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 50523 -> port 6379)[0m
+[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 55102 -> port 6379)[0m
+[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 55118 -> port 6379)[0m
+[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 55132 -> port 6379)[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE mango[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\nmango\r\n:1\r\n"[0m
@@ -716,10 +716,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#DN4] [client-1] [0m[36mConnected (port 50526 -> port 6379)[0m
-[33m[tester::#DN4] [client-2] [0m[36mConnected (port 50527 -> port 6379)[0m
-[33m[tester::#DN4] [client-3] [0m[36mConnected (port 50528 -> port 6379)[0m
-[33m[tester::#DN4] [client-4] [0m[36mConnected (port 50529 -> port 6379)[0m
+[33m[tester::#DN4] [client-1] [0m[36mConnected (port 55162 -> port 6379)[0m
+[33m[tester::#DN4] [client-2] [0m[36mConnected (port 55178 -> port 6379)[0m
+[33m[tester::#DN4] [client-3] [0m[36mConnected (port 55188 -> port 6379)[0m
+[33m[tester::#DN4] [client-4] [0m[36mConnected (port 55194 -> port 6379)[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE mango[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\nmango\r\n:1\r\n"[0m
@@ -769,10 +769,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HF2] [client-1] [0m[36mConnected (port 50532 -> port 6379)[0m
-[33m[tester::#HF2] [client-2] [0m[36mConnected (port 50533 -> port 6379)[0m
-[33m[tester::#HF2] [client-3] [0m[36mConnected (port 50534 -> port 6379)[0m
-[33m[tester::#HF2] [client-4] [0m[36mConnected (port 50535 -> port 6379)[0m
+[33m[tester::#HF2] [client-1] [0m[36mConnected (port 55218 -> port 6379)[0m
+[33m[tester::#HF2] [client-2] [0m[36mConnected (port 55230 -> port 6379)[0m
+[33m[tester::#HF2] [client-3] [0m[36mConnected (port 55246 -> port 6379)[0m
+[33m[tester::#HF2] [client-4] [0m[36mConnected (port 55252 -> port 6379)[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE strawberry[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$10\r\nstrawberry\r\n:1\r\n"[0m
@@ -804,8 +804,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LF1] [client-1] [0m[36mConnected (port 50538 -> port 6379)[0m
-[33m[tester::#LF1] [client-2] [0m[36mConnected (port 50539 -> port 6379)[0m
+[33m[tester::#LF1] [client-1] [0m[36mConnected (port 55268 -> port 6379)[0m
+[33m[tester::#LF1] [client-2] [0m[36mConnected (port 55272 -> port 6379)[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE grape[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\ngrape\r\n:1\r\n"[0m
@@ -858,8 +858,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 50545 -> port 6379)[0m
-[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 50546 -> port 6379)[0m
+[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 55294 -> port 6379)[0m
+[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 55304 -> port 6379)[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE banana[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$6\r\nbanana\r\n:1\r\n"[0m
@@ -922,8 +922,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null array: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92m✔︎ Received "*-1\r\n"[0m
-[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 50553 -> port 6379)[0m
-[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 50554 -> port 6379)[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 55344 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 55358 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.3[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.3\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry raspberry[0m
@@ -941,9 +941,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [client-1] [0m[36mConnected (port 50557 -> port 6379)[0m
-[33m[tester::#EC3] [client-2] [0m[36mConnected (port 50558 -> port 6379)[0m
-[33m[tester::#EC3] [client-3] [0m[36mConnected (port 50559 -> port 6379)[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 55372 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 55382 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 55390 -> port 6379)[0m
 [33m[tester::#EC3] [client-1] [0m[94m$ redis-cli BLPOP strawberry 0[0m
 [33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$10\r\nstrawberry\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP strawberry 0[0m
@@ -1264,9 +1264,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 50589 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 50590 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 50591 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 55580 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 55588 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 55600 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 66[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n66\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1369,8 +1369,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 50594 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 50595 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 55614 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 55622 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET mango orange[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\nmango\r\n$6\r\norange\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1473,8 +1473,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 50601 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 50602 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 55660 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 55674 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1520,8 +1520,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 50605 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 50606 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 55696 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 55698 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -2005,9 +2005,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD blueberry * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nblueberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407802767-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407802767-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407802767-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759408506625-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759408506625-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759408506625-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -2129,11 +2129,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\xbb\x9au\xff\xb7a\xe3"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2{q\xdeh\xfa\bused-mem\xc2\x18H\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff0\x18̶H\x83~\xb7"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2153,11 +2153,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5EU{{,a\xd8"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2{q\xdeh\xfa\bused-mem\xc2\b\xee\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd8\xc2[\xc4:\xc3t\xf8"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2177,11 +2177,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff^&\xc0ڨ\xb8\x1c\x01"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2{q\xdeh\xfa\bused-mem\xc2x\xf7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn5`\xe5h\xf75\xac"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -2201,11 +2201,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC eb04303641e62998c94c99a541a31ae5b84120df 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime»n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(eb04303641e62998c94c99a541a31ae5b84120df\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffb\xe5\xbe\xfe\xbc^\xa9u"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2{q\xdeh\xfa\bused-mem\xc2\xe8\x00\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a2899b6a13cfc302eaf0a7a49cdfb6e84e7f6fb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa0\xe1\xb1\xf1\xe9=\xcb\xf0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2322,7 +2322,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2102 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2092 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -2357,11 +2357,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff*\x86\x90\xec\x1avK\xf8"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}q\xdeh\xfa\bused-mem\xc2\x18H\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx\xdeT\x92\xfd\x96\x13\xc4"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2381,11 +2381,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff`x_\xe2\x9e\xedK\xc3"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}q\xdeh\xfa\bused-mem\xc2\b\xee\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x90\x04\xc3\xe0\x8f\xd6\x19\x8b"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2405,11 +2405,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\x1b\xcaCMy6\x1a"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}q\xdeh\xfa\bused-mem\xc2x\xf7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\xf3\xf8\xc1\xdd\xe2X\xdf"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -2429,11 +2429,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7شgY\x9f\x83n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2~q\xdeh\xfa\bused-mem\xc2\xe8\x00\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9c\xaaW!\x02\xdc\x04\xca"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -2453,11 +2453,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf6Oԑ\xf9\x813S"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2~q\xdeh\xfa\bused-mem\xc2`\n\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffS\x10\xe0-'\xe4H\xcc"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -2477,11 +2477,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffH\xba\v\xab\xd3Xex"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2~q\xdeh\xfa\bused-mem\xc2\xd0\x13\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8_\x1d\xad\x84\xac\x9f\x86"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -2501,11 +2501,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1dt!\xb3\x00\xe6:M"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2~q\xdeh\xfa\bused-mem\xc2H\x1d\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\x18y\xa4(\xed\xbbo"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6387[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m$ redis-cli PING[0m
@@ -2525,11 +2525,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC 03ad226ecf3e046de02b05d3b6f3285dd60f8012 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC c9d81805db9a3bba5575d736db076517ce81d3f2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¾n\xdeh\xfa\bused-mem\u00a0\xb1\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(03ad226ecf3e046de02b05d3b6f3285dd60f8012\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xad\xf8\xbb\x87:Ο\x17"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2~q\xdeh\xfa\bused-mem°b\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c9d81805db9a3bba5575d736db076517ce81d3f2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffc\x94\x989\xb7\x97\xa9\x15"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2814,11 +2814,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0e$\r\x91\f\xef`\xb8"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x7fq\xdeh\xfa\bused-mem\xc2h\x8d\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6e446a922f71b087d5ec6a1b6426d7f812ff4a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\v\xa5\v\v~\xc1\xb9\x82"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2838,11 +2838,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"q\xf2\xc3@\x9e\xdd>"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x7fq\xdeh\xfa\bused-mem\xc2H3\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6e446a922f71b087d5ec6a1b6426d7f812ff4a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcd\x03\xfe\x91-\x13\xa1\v"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2862,11 +2862,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC a343c68191de5961166fea4cdf0673c0232514bd 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC f6e446a922f71b087d5ec6a1b6426d7f812ff4a5 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a343c68191de5961166fea4cdf0673c0232514bd\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc2\xf1\xe1)`\xc0\xb4\xc9"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\x7fq\xdeh\xfa\bused-mem¸\x00\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f6e446a922f71b087d5ec6a1b6426d7f812ff4a5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x992u_K\x16\xa1\xc2"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2951,11 +2951,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC db4a9334fad48fad3a5c256d9961313a86561856 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC bcf587b189a5a40ad158c2c7c84f74101ac56ae5 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC bcf587b189a5a40ad158c2c7c84f74101ac56ae5 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC bcf587b189a5a40ad158c2c7c84f74101ac56ae5 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc0n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(db4a9334fad48fad3a5c256d9961313a86561856\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb4K\xa1\x9e\x192&\xe7"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0080q\xdeh\xfa\bused-mem\xc2h\x8d\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bcf587b189a5a40ad158c2c7c84f74101ac56ae5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\t\xb5\x97\xf1\xaf$;"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -3010,11 +3010,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 89605d984aae7f3d0355b9b0d1b0ba1f7372f58f 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC dc4c930e6057e99352848e12670aff3dcb9524dc 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC dc4c930e6057e99352848e12670aff3dcb9524dc 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC dc4c930e6057e99352848e12670aff3dcb9524dc 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xc1n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(89605d984aae7f3d0355b9b0d1b0ba1f7372f58f\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffL\xb9fʛ\xf7\xc7\x18"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0080q\xdeh\xfa\bused-mem\xc2\x18H\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(dc4c930e6057e99352848e12670aff3dcb9524dc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf2\xb8\xde\xdc\xfa\xa9;o"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -3039,9 +3039,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 305f24b4016ce65fcdd0bfb13b98bd2a069772b6 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC b85e42d207458df5bd38097d05b02d35985e6a17 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC b85e42d207458df5bd38097d05b02d35985e6a17 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC b85e42d207458df5bd38097d05b02d35985e6a17 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -3188,9 +3188,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7810f5366ca7db4f6fdbf553b03149198e2976f2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f8c677b4dcf7d82229c1e47d1336403b50dfe181\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f8c677b4dcf7d82229c1e47d1336403b50dfe181\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f8c677b4dcf7d82229c1e47d1336403b50dfe181\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -3214,9 +3214,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c1183b533935eb70591b42821b511f4e2998f798\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fd8612861601276ba2c3220b0e78ca0abab9f98e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fd8612861601276ba2c3220b0e78ca0abab9f98e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fd8612861601276ba2c3220b0e78ca0abab9f98e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -3246,7 +3246,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 00 00 06 6f 72 61 6e 67 65 09 72 61 73 70 62 65 | ...orange.raspbe[0m
 [33m[tester::#SM4] [0m[36m0090 | 72 72 79 ff 93 40 72 7c a9 01 97 96             | rry..@r|....[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-7219 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-7219 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET strawberry[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -3285,7 +3285,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 ff 30 | erry.blueberry.0[0m
 [33m[tester::#DQ3] [0m[36m0070 | 90 48 3d 58 d0 02 a1                            | .H=X...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1619 --dbfilename apple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1619 --dbfilename apple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
@@ -3315,30 +3315,30 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 00 00 05 67 | er.7.2.0.......g[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 00 00 05 67 | s-bits.@.......g[0m
 [33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 00 0a 73 74 72 61 77 | rape.pear..straw[0m
 [33m[tester::#JW4] [0m[36m0040 | 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 79 00 | berry.blueberry.[0m
 [33m[tester::#JW4] [0m[36m0050 | 09 70 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 | .pineapple.raspb[0m
 [33m[tester::#JW4] [0m[36m0060 | 65 72 72 79 00 05 6d 61 6e 67 6f 05 61 70 70 6c | erry..mango.appl[0m
-[33m[tester::#JW4] [0m[36m0070 | 65 ff eb 29 d9 56 e9 6c 45 55                   | e..).V.lEU[0m
+[33m[tester::#JW4] [0m[36m0070 | 65 ff 9b e7 0f 44 4e 3b 74 1d                   | e....DN;t.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9921 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9921 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n$10\r\nstrawberry\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
 [33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[36m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[36m  "strawberry"[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "mango"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
 [33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[92m  "mango",[0m
-[33m[tester::#JW4] [client] [0m[92m  "strawberry"[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "mango"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -3355,7 +3355,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 05 6d 61 6e 67 6f ff dd | ineapple.mango..[0m
 [33m[tester::#GC6] [0m[36m0040 | a9 87 2e 31 ef 21 b4                            | ...1.!.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9914 --dbfilename pear.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9914 --dbfilename pear.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -3370,13 +3370,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 05 67 | s-bits.@.......g[0m
-[33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff 3b d6 76 4a 40 88 | rape.pear.;.vJ@.[0m
-[33m[tester::#JZ6] [0m[36m0040 | 6b 9a                                           | k.[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 05 67 | er.7.2.0.......g[0m
+[33m[tester::#JZ6] [0m[36m0030 | 72 61 70 65 04 70 65 61 72 ff f8 12 5e 91 93 5d | rape.pear...^..][0m
+[33m[tester::#JZ6] [0m[36m0040 | a5 2e                                           | ..[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-8712 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-8712 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$5\r\ngrape\r\n"[0m
@@ -3387,12 +3387,12 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-4834 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-4834 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-4834\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-4834"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-4834"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-4834\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-4834"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-4834"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
@@ -3404,15 +3404,15 @@ Debug = true
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 21:23:32.543[0m
-[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 21:23:32.543 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 12:35:15.277[0m
+[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 12:35:15.277 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET blueberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "apple"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 21:23:32.647 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "blueberry" at 12:35:15.380 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET blueberry[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/lists/pass
+++ b/internal/test_helpers/fixtures/lists/pass
@@ -7,8 +7,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null array: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92m✔︎ Received "*-1\r\n"[0m
-[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 59366 -> port 6379)[0m
-[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 59374 -> port 6379)[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 49221 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 49222 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP raspberry 0.2[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nraspberry\r\n$3\r\n0.2\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH raspberry mango[0m
@@ -26,9 +26,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [client-1] [0m[36mConnected (port 59394 -> port 6379)[0m
-[33m[tester::#EC3] [client-2] [0m[36mConnected (port 59410 -> port 6379)[0m
-[33m[tester::#EC3] [client-3] [0m[36mConnected (port 59426 -> port 6379)[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 49225 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 49226 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 49227 -> port 6379)[0m
 [33m[tester::#EC3] [client-1] [0m[94m$ redis-cli BLPOP banana 0[0m
 [33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$6\r\nbanana\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP banana 0[0m
@@ -365,9 +365,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 59584 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 59586 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 59590 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 49257 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 49258 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 49259 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET apple 44[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$5\r\napple\r\n$2\r\n44\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -470,8 +470,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 59614 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 59628 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 49262 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 49263 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET banana pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -574,8 +574,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 59672 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 59686 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 49269 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 49270 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -621,8 +621,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 59700 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 59716 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 49273 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 49274 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1122,9 +1122,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD pear * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$4\r\npear\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758637379641-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758637379641-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758637379641-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407676060-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407676060-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407676060-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1245,11 +1245,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2D\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(23a932fa3715ac5b92336fed5d46467ddd46bbc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff#>S74\xbd\xeb\xd5"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx\xed;\xbf\xb2\x8b\xf9\x11"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1269,11 +1269,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2D\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(23a932fa3715ac5b92336fed5d46467ddd46bbc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xac%\x82V?\x9a\xd1s"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2\x13\xf4\xb16\x10\xf9*"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1293,11 +1293,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 23a932fa3715ac5b92336fed5d46467ddd46bbc7 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2D\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(23a932fa3715ac5b92336fed5d46467ddd46bbc7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x12\xf8\xfdz\x95E\x025"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2<n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4db624e70d4aa5b98dcc6f8dc19c7d2b78f1dbbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd9pa\x10億\xf3"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1390,7 +1390,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2094 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2013 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1424,11 +1424,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2F\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8f\u05cb۱\xef\x9dw"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\nZ\xef\xe29=\xbaV"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1448,11 +1448,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2F\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x00\xccZ\xba\xbaȧ\xd1"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff@\xa4 콦\xbam"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1472,11 +1472,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2F\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbe\x11%\x96\x10\x17t\x97"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabǵMn2Ǵ"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1496,11 +1496,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2G\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbb\x00&\xe6\xc4+h\xd2"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x97\x04\xcbiz\xd4r\xc0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1520,11 +1520,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2G\xad\xd2h\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\xba\x91\xea\xe1\x13$\xd4"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff֓\xab\x9f\xda\xca\xc2\xfd"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -1544,11 +1544,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2G\xad\xd2h\xfa\bused-mem\u0080\x93\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfe\x86\xf4A\x8d?\xae\xe8"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffhft\xa5\xf0\x13\x94\xd6"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -1568,11 +1568,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 11ead8edef1d110f1ad435944648fb7dc8ea1e59 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 6529e13a8666edc526983fb145bff77171e14646 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2G\xad\xd2h\xfa\bused-mem\xc2\xf8\x9c\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(11ead8edef1d110f1ad435944648fb7dc8ea1e59\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\\$\xb5w\x93*A\xa6"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2?n\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6529e13a8666edc526983fb145bff77171e14646\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff=\xa8^\xbd#\xad\xcb\xe3"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1857,11 +1857,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(60461e3902336b7147d0af98980ae92153521267\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8\x11\xc5\x1c\xaeSL\xfd"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2An\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c630022d7c2d25791191f13e4a888f2ecaee5514\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffZI1\"\xe5 +\xf8"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1881,11 +1881,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xad\xd2h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(60461e3902336b7147d0af98980ae92153521267\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x19b\x9f\xb9\xe1\x92+\x14"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2An\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c630022d7c2d25791191f13e4a888f2ecaee5514\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv\x1c\xcep\xa9Q\x96~"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1905,11 +1905,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 60461e3902336b7147d0af98980ae92153521267 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c630022d7c2d25791191f13e4a888f2ecaee5514 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2H\xad\xd2h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(60461e3902336b7147d0af98980ae92153521267\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeb\xe8ǾZv̈"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2An\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c630022d7c2d25791191f13e4a888f2ecaee5514\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x96\x9cݚ\x89\x0f\xff\x89"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1994,11 +1994,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 609bf9b95ec0fe2eee8759a8cd4f7ee037e1368b 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 609bf9b95ec0fe2eee8759a8cd4f7ee037e1368b 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 609bf9b95ec0fe2eee8759a8cd4f7ee037e1368b 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 6d0d099d4654725753d9e2756ef0144aefaf4288 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 6d0d099d4654725753d9e2756ef0144aefaf4288 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 6d0d099d4654725753d9e2756ef0144aefaf4288 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2I\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(609bf9b95ec0fe2eee8759a8cd4f7ee037e1368b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffcjiE\xe7d\xe1\x0f"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2An\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6d0d099d4654725753d9e2756ef0144aefaf4288\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x18\x19̸)\xbe\x99\x90"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2053,11 +2053,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 6a8fb53c78d777b6e0c575bebf3190a31593d086 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6a8fb53c78d777b6e0c575bebf3190a31593d086 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 6a8fb53c78d777b6e0c575bebf3190a31593d086 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 01514311e577bb7a121d1415291f67bced1bdba7 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 01514311e577bb7a121d1415291f67bced1bdba7 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 01514311e577bb7a121d1415291f67bced1bdba7 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2I\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6a8fb53c78d777b6e0c575bebf3190a31593d086\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\r\xe6\u05c99y\x1c"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Bn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(01514311e577bb7a121d1415291f67bced1bdba7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x85\xb7\x9e]\xac:#`"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2082,9 +2082,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 78f3b275adaf0433e2619e8d3535c2aba75ce20c 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 78f3b275adaf0433e2619e8d3535c2aba75ce20c 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 78f3b275adaf0433e2619e8d3535c2aba75ce20c 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 62c04e7eb560cb7f6b56a8e2a93c451ed243310f 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 62c04e7eb560cb7f6b56a8e2a93c451ed243310f 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 62c04e7eb560cb7f6b56a8e2a93c451ed243310f 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2231,9 +2231,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fee3c361ca328115af21c4430517472074e673eb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fee3c361ca328115af21c4430517472074e673eb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:fee3c361ca328115af21c4430517472074e673eb\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:45ccf3b5f83e83725dfc7ad62b019fa58ab4d351\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:45ccf3b5f83e83725dfc7ad62b019fa58ab4d351\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:45ccf3b5f83e83725dfc7ad62b019fa58ab4d351\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2257,9 +2257,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4de8eb2ebfac223a913c3fa88477b48813fec115\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4de8eb2ebfac223a913c3fa88477b48813fec115\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:4de8eb2ebfac223a913c3fa88477b48813fec115\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a8f1577014f5c6ba294d3f4de6692f03225628ab\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a8f1577014f5c6ba294d3f4de6692f03225628ab\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:a8f1577014f5c6ba294d3f4de6692f03225628ab\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2288,7 +2288,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0070 | 61 70 65 05 61 70 70 6c 65 ff 1e 63 cd 24 aa 2f | ape.apple..c.$./[0m
 [33m[tester::#SM4] [0m[36m0080 | da c1                                           | ..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9439 --dbfilename pineapple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9439 --dbfilename pineapple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -2322,7 +2322,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 79 00 05 67 72 61 70 65 06 62 61 6e 61 6e 61 ff | y..grape.banana.[0m
 [33m[tester::#DQ3] [0m[36m0070 | 22 42 53 9d 9d 75 69 c1                         | "BS..ui.[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2904 --dbfilename raspberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2904 --dbfilename raspberry.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET orange[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
@@ -2362,23 +2362,23 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0070 | 00 05 67 72 61 70 65 06 6f 72 61 6e 67 65 ff 8b | ..grape.orange..[0m
 [33m[tester::#JW4] [0m[36m0080 | 4f 6c 51 75 05 80 c6                            | OlQu...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9251 --dbfilename blueberry.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9251 --dbfilename blueberry.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n$4\r\npear\r\n$5\r\ngrape\r\n$9\r\nraspberry\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$6\r\nbanana\r\n$4\r\npear\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
-[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[36m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[36m  "pear",[0m
-[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[36m  "raspberry"[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
-[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
+[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[92m  "banana",[0m
 [33m[tester::#JW4] [client] [0m[92m  "pear",[0m
-[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
-[33m[tester::#JW4] [client] [0m[92m  "raspberry"[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2395,7 +2395,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 65 61 72 05 61 70 70 6c 65 ff 4e 07 75 77 a0 9f | ear.apple.N.uw..[0m
 [33m[tester::#GC6] [0m[36m0040 | 21 94                                           | !.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2337 --dbfilename apple.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2337 --dbfilename apple.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
@@ -2416,7 +2416,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 61 73 70 62 65 72 72 79 05 61 70 70 6c 65 ff 55 | aspberry.apple.U[0m
 [33m[tester::#JZ6] [0m[36m0040 | 43 23 e0 5a 6e 28 62                            | C#.Zn(b[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1316 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1316 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$9\r\nraspberry\r\n"[0m
@@ -2427,32 +2427,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-5701 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5701 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-5701\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-5701"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-5701"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5701\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-5701"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-5701"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET mango blueberry px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET mango blueberry PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$9\r\nblueberry\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:23:08.353[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:23:08.353 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:21:25.524[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 21:21:25.524 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:23:08.461 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 21:21:25.627 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/pubsub/pass
+++ b/internal/test_helpers/fixtures/pubsub/pass
@@ -2,9 +2,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 39728 -> port 6379)[0m
-[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 39742 -> port 6379)[0m
-[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 39746 -> port 6379)[0m
+[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 49452 -> port 6379)[0m
+[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 49453 -> port 6379)[0m
+[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 49454 -> port 6379)[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE apple[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\napple\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\napple\r\n:1\r\n"[0m
@@ -84,10 +84,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#DN4] [client-1] [0m[36mConnected (port 39770 -> port 6379)[0m
-[33m[tester::#DN4] [client-2] [0m[36mConnected (port 39784 -> port 6379)[0m
-[33m[tester::#DN4] [client-3] [0m[36mConnected (port 39800 -> port 6379)[0m
-[33m[tester::#DN4] [client-4] [0m[36mConnected (port 39812 -> port 6379)[0m
+[33m[tester::#DN4] [client-1] [0m[36mConnected (port 49457 -> port 6379)[0m
+[33m[tester::#DN4] [client-2] [0m[36mConnected (port 49458 -> port 6379)[0m
+[33m[tester::#DN4] [client-3] [0m[36mConnected (port 49459 -> port 6379)[0m
+[33m[tester::#DN4] [client-4] [0m[36mConnected (port 49460 -> port 6379)[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE blueberry[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nblueberry\r\n:1\r\n"[0m
@@ -161,10 +161,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HF2] [client-1] [0m[36mConnected (port 39828 -> port 6379)[0m
-[33m[tester::#HF2] [client-2] [0m[36mConnected (port 39832 -> port 6379)[0m
-[33m[tester::#HF2] [client-3] [0m[36mConnected (port 39836 -> port 6379)[0m
-[33m[tester::#HF2] [client-4] [0m[36mConnected (port 39846 -> port 6379)[0m
+[33m[tester::#HF2] [client-1] [0m[36mConnected (port 49463 -> port 6379)[0m
+[33m[tester::#HF2] [client-2] [0m[36mConnected (port 49464 -> port 6379)[0m
+[33m[tester::#HF2] [client-3] [0m[36mConnected (port 49465 -> port 6379)[0m
+[33m[tester::#HF2] [client-4] [0m[36mConnected (port 49466 -> port 6379)[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE grape[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\ngrape\r\n:1\r\n"[0m
@@ -196,8 +196,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LF1] [client-1] [0m[36mConnected (port 39850 -> port 6379)[0m
-[33m[tester::#LF1] [client-2] [0m[36mConnected (port 39858 -> port 6379)[0m
+[33m[tester::#LF1] [client-1] [0m[36mConnected (port 49469 -> port 6379)[0m
+[33m[tester::#LF1] [client-2] [0m[36mConnected (port 49470 -> port 6379)[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE apple[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\napple\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\napple\r\n:1\r\n"[0m
@@ -250,8 +250,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 39904 -> port 6379)[0m
-[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 39918 -> port 6379)[0m
+[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 49476 -> port 6379)[0m
+[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 49477 -> port 6379)[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE blueberry[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\nblueberry\r\n:1\r\n"[0m
@@ -314,8 +314,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null array: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92m✔︎ Received "*-1\r\n"[0m
-[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 39954 -> port 6379)[0m
-[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 39960 -> port 6379)[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 49484 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 49485 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP blueberry 0.1[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\nblueberry\r\n$3\r\n0.1\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH blueberry grape[0m
@@ -333,9 +333,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [client-1] [0m[36mConnected (port 39978 -> port 6379)[0m
-[33m[tester::#EC3] [client-2] [0m[36mConnected (port 39990 -> port 6379)[0m
-[33m[tester::#EC3] [client-3] [0m[36mConnected (port 39992 -> port 6379)[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 49488 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 49489 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 49490 -> port 6379)[0m
 [33m[tester::#EC3] [client-1] [0m[94m$ redis-cli BLPOP pear 0[0m
 [33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$4\r\npear\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pear 0[0m
@@ -652,9 +652,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 40162 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 40176 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 40184 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 49520 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 49521 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 49522 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET blueberry 60[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n60\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -757,8 +757,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 40198 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 40202 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 49525 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 49526 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET orange apple[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -861,8 +861,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 40228 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 40236 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 49532 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 49533 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -908,8 +908,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 40256 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 40272 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 49536 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 49537 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1401,9 +1401,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD mango * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$5\r\nmango\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758687860310-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758687860310-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758687860310-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407697334-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407697334-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407697334-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1524,11 +1524,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2tr\xd3h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4ea32011081fc2721652f77ef5a277eb571ba444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff捦2\f\xe5l\x82"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Rn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9b>\x81d\x05\x9d\xa3u"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1548,11 +1548,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2tr\xd3h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4ea32011081fc2721652f77ef5a277eb571ba444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffi\x96wS\a\xc2V$"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Rn\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd1\xc0Nj\x81\x06\xa3N"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1572,11 +1572,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 4ea32011081fc2721652f77ef5a277eb571ba444 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ur\xd3h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4ea32011081fc2721652f77ef5a277eb571ba444\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\xbeP\x1bV\xacӼ"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Rn\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(8a491e85bf3f1dd5f7e3eb812dc60ea7133b7ffb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff:\xa3\xdb\xcbR\x92ޗ"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1669,7 +1669,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2099 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2016 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1704,11 +1704,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff`[\x9eR\xd2pܟ"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb4\xe1\x00B\xd5\x05v\xed"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1728,11 +1728,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xef@O3\xd9W\xe69"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tn\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfe\x1f\xcfLQ\x9ev\xd6"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1752,11 +1752,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffQ\x9d0\x1fs\x885\x7f"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tn\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x15|Z\xed\x82\n\v\x0f"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1776,11 +1776,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa1yk\v\\\x05\x7f\xe4"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tn\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff)\xbf$ɖ\xec\xbe{"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1800,11 +1800,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffn\xc3\xdc\ay=3\xe2"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Tn\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffh(D?6\xf2\x0eF"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -1824,11 +1824,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wr\xd3h\xfa\bused-mem\u0080\x93\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe4\xff\xb9\xac\x15\x11\xb9\xde"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Un\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff#(\xc3a\xe7\x9a\x0e\xb3"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -1848,11 +1848,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2xr\xd3h\xfa\bused-mem\xc2\xf8\x9c\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x89v\xeb\xe7}\a&\xd4"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Un\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv\xe6\xe9y4$Q\x86"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6387[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m$ redis-cli PING[0m
@@ -1872,11 +1872,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC c90270edde1712295aab528cacb46289819ee195 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC 4d590fb7275c77b6ddecf179a4fd3fbacd56401c 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2xr\xd3h\xfa\bused-mem\xc2`\xe2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c90270edde1712295aab528cacb46289819ee195\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffOAٳ?\x9c\xd3\xfb"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Un\xdeh\xfa\bused-mem\u00a0\xb1\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4d590fb7275c77b6ddecf179a4fd3fbacd56401c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6jsM\x0e\f\xf4\xdc"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2161,11 +2161,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2yr\xd3h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b107903847bf97af7e8be7132c6f95d05fa7c87e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe4\x8a\xf0\xdc$ݧ\x12"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Vn\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cfead0151f3a6baa3994e495f95cd689b73db693\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd\xb8\u0081\aUaY"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2185,11 +2185,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2yr\xd3h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b107903847bf97af7e8be7132c6f95d05fa7c87e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x15\xf9\xaayk\x1c\xc0\xfb"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Vn\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cfead0151f3a6baa3994e495f95cd689b73db693\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd1\xed=\xd3K$\xdc\xdf"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2209,11 +2209,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC b107903847bf97af7e8be7132c6f95d05fa7c87e 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC cfead0151f3a6baa3994e495f95cd689b73db693 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2yr\xd3h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b107903847bf97af7e8be7132c6f95d05fa7c87e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe7s\xf2~\xd0\xf8'g"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Vn\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(cfead0151f3a6baa3994e495f95cd689b73db693\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1m.9kz\xb5("[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2298,11 +2298,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 43742325934a612994512b870d5dbe7883a321e4 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 43742325934a612994512b870d5dbe7883a321e4 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 43742325934a612994512b870d5dbe7883a321e4 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 9d7996cbd989f94b672c20c48906a7634281656b 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 9d7996cbd989f94b672c20c48906a7634281656b 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 9d7996cbd989f94b672c20c48906a7634281656b 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2yr\xd3h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(43742325934a612994512b870d5dbe7883a321e4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffC\x12\xc0\xf4v\xf2|D"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Wn\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9d7996cbd989f94b672c20c48906a7634281656b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffqp\xe9\x06\xdc5\xf4M"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2357,11 +2357,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 29e31aceecaa3f7b51ef533e1b19c5e1d6e822b7 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 29e31aceecaa3f7b51ef533e1b19c5e1d6e822b7 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 29e31aceecaa3f7b51ef533e1b19c5e1d6e822b7 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 6dd30226c41d3b25c37a47c8b02f6d20c5578a39 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6dd30226c41d3b25c37a47c8b02f6d20c5578a39 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 6dd30226c41d3b25c37a47c8b02f6d20c5578a39 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zr\xd3h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(29e31aceecaa3f7b51ef533e1b19c5e1d6e822b7\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffmX]Cq\xb5\x9a\x14"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Wn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6dd30226c41d3b25c37a47c8b02f6d20c5578a39\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8b\x95\x05\x7f\x96\xaa\x91J"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2386,9 +2386,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 3c9c0f47e6a49e9995bac8330e0d8ade28e1e344 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 3c9c0f47e6a49e9995bac8330e0d8ade28e1e344 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 3c9c0f47e6a49e9995bac8330e0d8ade28e1e344 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 3fd6d322c786aa6827211dc84b17ff3c9dfc2054 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 3fd6d322c786aa6827211dc84b17ff3c9dfc2054 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 3fd6d322c786aa6827211dc84b17ff3c9dfc2054 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2535,9 +2535,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8466a8e3fc483a57f84b0ee01428aa5ae10e5cff\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8466a8e3fc483a57f84b0ee01428aa5ae10e5cff\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:8466a8e3fc483a57f84b0ee01428aa5ae10e5cff\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3d499b4f85ee3372a9605f9e7451547c42e9dacc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3d499b4f85ee3372a9605f9e7451547c42e9dacc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3d499b4f85ee3372a9605f9e7451547c42e9dacc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2561,9 +2561,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3fc48c48a8db5bd764ffbdd9cc36f5068781b839\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3fc48c48a8db5bd764ffbdd9cc36f5068781b839\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:3fc48c48a8db5bd764ffbdd9cc36f5068781b839\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:21858165fe7c3d5dc0cc363de891ad206efdd43b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:21858165fe7c3d5dc0cc363de891ad206efdd43b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:21858165fe7c3d5dc0cc363de891ad206efdd43b\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2593,7 +2593,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | 8a c7 01 00 00 00 06 62 61 6e 61 6e 61 09 62 6c | .......banana.bl[0m
 [33m[tester::#SM4] [0m[36m0090 | 75 65 62 65 72 72 79 ff 9c d6 8c f0 c0 75 f9 3b | ueberry......u.;[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1612 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1612 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET mango[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -2623,17 +2623,17 @@ Debug = true
 [33m[tester::#DQ3] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#DQ3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#DQ3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#DQ3] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#DQ3] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 06 62 | er.7.2.0.......b[0m
+[33m[tester::#DQ3] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#DQ3] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#DQ3] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 06 62 | s-bits.@.......b[0m
 [33m[tester::#DQ3] [0m[36m0030 | 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 79 00 | anana.raspberry.[0m
 [33m[tester::#DQ3] [0m[36m0040 | 06 6f 72 61 6e 67 65 05 67 72 61 70 65 00 05 6d | .orange.grape..m[0m
 [33m[tester::#DQ3] [0m[36m0050 | 61 6e 67 6f 09 70 69 6e 65 61 70 70 6c 65 00 09 | ango.pineapple..[0m
 [33m[tester::#DQ3] [0m[36m0060 | 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 00 09 | blueberry.pear..[0m
 [33m[tester::#DQ3] [0m[36m0070 | 72 61 73 70 62 65 72 72 79 0a 73 74 72 61 77 62 | raspberry.strawb[0m
-[33m[tester::#DQ3] [0m[36m0080 | 65 72 72 79 ff d0 8f 79 c0 6c a9 34 37          | erry...y.l.47[0m
+[33m[tester::#DQ3] [0m[36m0080 | 65 72 72 79 ff fe 6a 2c e0 c1 a3 bb e4          | erry..j,.....[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9341 --dbfilename pear.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9341 --dbfilename pear.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
@@ -2676,18 +2676,18 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 70 70 6c 65 00 09 72 61 73 70 62 65 72 72 79 05 | pple..raspberry.[0m
 [33m[tester::#JW4] [0m[36m0060 | 67 72 61 70 65 ff 5f 53 81 09 8b 10 26 91       | grape._S....&.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9097 --dbfilename mango.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9097 --dbfilename mango.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$9\r\nblueberry\r\n$9\r\nraspberry\r\n$6\r\norange\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n$6\r\norange\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
-[33m[tester::#JW4] [client] [0m[36m  "blueberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "blueberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "orange"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
-[33m[tester::#JW4] [client] [0m[92m  "blueberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "blueberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "orange"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -2705,7 +2705,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 65 61 72 05 6d 61 6e 67 6f ff 22 ca 81 20 8c 80 | ear.mango.".. ..[0m
 [33m[tester::#GC6] [0m[36m0040 | ed 0c                                           | ..[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3534 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3534 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -2726,7 +2726,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 74 72 61 77 62 65 72 72 79 04 70 65 61 72 ff 0a | trawberry.pear..[0m
 [33m[tester::#JZ6] [0m[36m0040 | fb b5 21 76 5e c9 f2                            | ..!v^..[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3042 --dbfilename pineapple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3042 --dbfilename pineapple.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$10\r\nstrawberry\r\n"[0m
@@ -2737,32 +2737,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2965 --dbfilename raspberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2965 --dbfilename raspberry.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-2965\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-2965"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-2965"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-2965\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-2965"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-2965"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET banana raspberry px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET banana raspberry PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 04:24:29.276[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 04:24:29.276 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:21:46.916[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 21:21:46.916 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "raspberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 04:24:29.380 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 21:21:47.019 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
+++ b/internal/test_helpers/fixtures/rdb-read-value-with-expiry/pass
@@ -5,18 +5,18 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 04 fc 00 0c | er.7.2.0........[0m
 [33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 | (.......blueberr[0m
 [33m[tester::#SM4] [0m[36m0040 | 79 04 70 65 61 72 fc 00 0c 28 8a c7 01 00 00 00 | y.pear...(......[0m
 [33m[tester::#SM4] [0m[36m0050 | 05 6d 61 6e 67 6f 09 72 61 73 70 62 65 72 72 79 | .mango.raspberry[0m
 [33m[tester::#SM4] [0m[36m0060 | fc 00 9c ef 12 7e 01 00 00 00 05 67 72 61 70 65 | .....~.....grape[0m
 [33m[tester::#SM4] [0m[36m0070 | 05 67 72 61 70 65 fc 00 0c 28 8a c7 01 00 00 00 | .grape...(......[0m
-[33m[tester::#SM4] [0m[36m0080 | 04 70 65 61 72 06 6f 72 61 6e 67 65 ff 9c 12 84 | .pear.orange....[0m
-[33m[tester::#SM4] [0m[36m0090 | bd e8 ad 48 6f                                  | ...Ho[0m
+[33m[tester::#SM4] [0m[36m0080 | 04 70 65 61 72 06 6f 72 61 6e 67 65 ff 78 2a 69 | .pear.orange.x*i[0m
+[33m[tester::#SM4] [0m[36m0090 | d0 d8 5f a4 28                                  | .._.([0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-6623 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6623 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET blueberry[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
@@ -54,7 +54,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 70 6c 65 04 70 65 61 72 ff ec 0e 82 6d 87 2b 51 | ple.pear....m.+Q[0m
 [33m[tester::#DQ3] [0m[36m0060 | 91                                              | .[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2020 --dbfilename apple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2020 --dbfilename apple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET apple[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -87,7 +87,7 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0050 | 00 05 6d 61 6e 67 6f 09 62 6c 75 65 62 65 72 72 | ..mango.blueberr[0m
 [33m[tester::#JW4] [0m[36m0060 | 79 ff 68 0f 5f 46 25 26 d0 08                   | y.h._F%&..[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-7468 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-7468 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived bytes: "*3\r\n$5\r\nmango\r\n$5\r\napple\r\n$9\r\nblueberry\r\n"[0m
@@ -108,7 +108,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 61 73 70 62 65 72 72 79 09 70 69 6e 65 61 70 70 | aspberry.pineapp[0m
 [33m[tester::#GC6] [0m[36m0040 | 6c 65 ff 6c 09 59 cc 38 db e8 71                | le.l.Y.8..q[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1000 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1000 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET raspberry[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
@@ -123,13 +123,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 06 62 | s-bits.@.......b[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 06 62 | er.7.2.0.......b[0m
 [33m[tester::#JZ6] [0m[36m0030 | 61 6e 61 6e 61 09 72 61 73 70 62 65 72 72 79 ff | anana.raspberry.[0m
-[33m[tester::#JZ6] [0m[36m0040 | c5 21 ea c1 d2 83 0b 3f                         | .!.....?[0m
+[33m[tester::#JZ6] [0m[36m0040 | e7 5b ba ce 60 e3 1e 39                         | .[..`..9[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-816 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-816 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$6\r\nbanana\r\n"[0m
@@ -140,32 +140,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-5582 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5582 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-5582\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-5582"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-5582"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-5582\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-5582"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-5582"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET orange apple px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET orange apple PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\norange\r\n$5\r\napple\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 07:21:11.946[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 07:21:11.946 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:22:51.623[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 21:22:51.623 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET orange[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "apple"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "apple"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "orange" at 07:21:12.054 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "orange" at 21:22:51.726 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET orange[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\norange\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -26,11 +26,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Yɦh\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4e3e7e1712d89912d5a76c4503cca5ca211d663e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff.g\x99\x16\x02M\x1b\x9b"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2#n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2)S\xb8\x84u\x11T"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -50,11 +50,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Zɦh\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4e3e7e1712d89912d5a76c4503cca5ca211d663e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd5\xf16\x83W\x9e\x83t"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2#n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe8ל\xb6\x00\xee\x11o"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -74,11 +74,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Zɦh\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4e3e7e1712d89912d5a76c4503cca5ca211d663e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffk,I\xaf\xfdAP2"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2#n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x03\xb4\t\x17\xd3zl\xb6"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -98,11 +98,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 4e3e7e1712d89912d5a76c4503cca5ca211d663e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2Zɦh\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(4e3e7e1712d89912d5a76c4503cca5ca211d663e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9b\xc8\x12\xbb\xd2\xcc\x1a\xa9"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2#n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(ae477e7f468a40fdfbbec4d5a908e3f0935bb9fc\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff?ww3ǜ\xd9\xc2"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -219,7 +219,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2110 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2092 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -253,11 +253,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\\ɦh\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf5MW\x05\xb5[\"W"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdc\xf9/\x0e\x06\xf5\xa3%"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -277,11 +277,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\\ɦh\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffzV\x86d\xbe|\x18\xf1"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x96\a\xe0\x00\x82n\xa3\x1e"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -301,11 +301,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\\ɦh\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffċ\xf9H\x14\xa3˷"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff}du\xa1Q\xfa\xde\xc7"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -325,11 +325,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\\ɦh\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff4o\xa2\\;.\x81,"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA\xa7\v\x85E\x1ck\xb3"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -349,11 +349,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2]ɦh\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0e M4姛\xf4"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x000ks\xe5\x02ێ"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -373,11 +373,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2]ɦh\xfa\bused-mem\u0080\x93\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x84\x1c(\x9f\x89\x8b\x11\xc8"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbeŴI\xcfۍ\xa5"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -397,11 +397,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC c5722a8414889527968f6bccf237df4da29f2ffe 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 45981bc48dd92489ff7b7710bc93192988cc84ff 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2]ɦh\xfa\bused-mem\xc2\xf8\x9c\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c5722a8414889527968f6bccf237df4da29f2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\xbei\xa9\x97\x9e\xfe\x86"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2&n\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(45981bc48dd92489ff7b7710bc93192988cc84ff\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeb\v\x9eQ\x1ceҐ"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -686,11 +686,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^ɦh\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(39331c584505dcb7a7d14c80ed86b7815f8d81c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\x8b\r=\x1d\xf8UO"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5f7bc90e8e522be8bdf6097db2d1261c775c4962\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffv\xdd#1\xbf\x16T("[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -710,11 +710,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^ɦh\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(39331c584505dcb7a7d14c80ed86b7815f8d81c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY\xf8W\x98R92\xa6"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5f7bc90e8e522be8bdf6097db2d1261c775c4962\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffZ\x88\xdcc\xf3g\xe9\xae"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -734,11 +734,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 39331c584505dcb7a7d14c80ed86b7815f8d81c4 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 5f7bc90e8e522be8bdf6097db2d1261c775c4962 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2^ɦh\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(39331c584505dcb7a7d14c80ed86b7815f8d81c4\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xabr\x0f\x9f\xe9\xdd\xd5:"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5f7bc90e8e522be8bdf6097db2d1261c775c4962\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xba\bω\xd39\x80Y"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -823,11 +823,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 168d94af167a8df8363cdfdbbef5df5781a3d424 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 168d94af167a8df8363cdfdbbef5df5781a3d424 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 168d94af167a8df8363cdfdbbef5df5781a3d424 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 489c4f3118c58157ae7985ee04d4df3ebba2848c 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 489c4f3118c58157ae7985ee04d4df3ebba2848c 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 489c4f3118c58157ae7985ee04d4df3ebba2848c 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_ɦh\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(168d94af167a8df8363cdfdbbef5df5781a3d424\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff֟\xc2\xe8\x95A^\xdb"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(489c4f3118c58157ae7985ee04d4df3ebba2848c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb1G\xed\r\xd0K\xcem"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -882,11 +882,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 073d3d02fb013d79106a1360de9e90886663428a 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 073d3d02fb013d79106a1360de9e90886663428a 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 073d3d02fb013d79106a1360de9e90886663428a 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 10fda5e732354fdfd3286eff4d5862a6c6a50662 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 10fda5e732354fdfd3286eff4d5862a6c6a50662 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 10fda5e732354fdfd3286eff4d5862a6c6a50662 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2_ɦh\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(073d3d02fb013d79106a1360de9e90886663428a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffA\x04Зs\rp)"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2(n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10fda5e732354fdfd3286eff4d5862a6c6a50662\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfdҤ<\xa6\x85`\x8e"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -911,9 +911,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 65490fda62fcb762ad3a6fd6b857b364d9530644 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 65490fda62fcb762ad3a6fd6b857b364d9530644 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 65490fda62fcb762ad3a6fd6b857b364d9530644 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 9fae7506dae3b83bc39eb251f213e11f428bca1a 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 9fae7506dae3b83bc39eb251f213e11f428bca1a 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 9fae7506dae3b83bc39eb251f213e11f428bca1a 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1060,9 +1060,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:398567259ea172339f71e9609490697e2b2e07a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:398567259ea172339f71e9609490697e2b2e07a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:398567259ea172339f71e9609490697e2b2e07a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7c262134f07413a75cd43134742b6eb86c2bc019\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7c262134f07413a75cd43134742b6eb86c2bc019\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7c262134f07413a75cd43134742b6eb86c2bc019\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1086,9 +1086,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c15be0b00128e6686b063eec21e50e1ffda58bbc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c15be0b00128e6686b063eec21e50e1ffda58bbc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c15be0b00128e6686b063eec21e50e1ffda58bbc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dfb0dd2d19726f1cca5287220cbdc12b0c5dcafc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dfb0dd2d19726f1cca5287220cbdc12b0c5dcafc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dfb0dd2d19726f1cca5287220cbdc12b0c5dcafc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1118,7 +1118,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0080 | c7 01 00 00 00 09 62 6c 75 65 62 65 72 72 79 05 | ......blueberry.[0m
 [33m[tester::#SM4] [0m[36m0090 | 61 70 70 6c 65 ff 92 f1 de f7 06 f6 06 ae       | apple.........[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3943 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3943 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET pineapple[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$9\r\npineapple\r\n"[0m
@@ -1156,7 +1156,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
 [33m[tester::#DQ3] [0m[36m0060 | ff d2 b9 68 6d 79 81 2e 5d                      | ...hmy..][0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-662 --dbfilename pear.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-662 --dbfilename pear.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET pineapple[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
@@ -1190,7 +1190,7 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 69 6e 65 61 70 70 6c 65 0a 73 74 72 61 77 62 65 | ineapple.strawbe[0m
 [33m[tester::#JW4] [0m[36m0070 | 72 72 79 ff 1e 60 ef 0f 40 01 3a b1             | rry..`..@.:.[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-5147 --dbfilename banana.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-5147 --dbfilename banana.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$6\r\norange\r\n$9\r\nblueberry\r\n$9\r\npineapple\r\n$5\r\ngrape\r\n"[0m
@@ -1221,7 +1221,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 70 70 6c 65 06 62 61 6e 61 6e 61 ff 3f d7 e8 25 | pple.banana.?..%[0m
 [33m[tester::#GC6] [0m[36m0040 | b6 f2 cc 03                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1473 --dbfilename raspberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1473 --dbfilename raspberry.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET apple[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
@@ -1242,7 +1242,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 70 70 6c 65 06 6f 72 61 6e 67 65 ff 02 51 6c 32 | pple.orange..Ql2[0m
 [33m[tester::#JZ6] [0m[36m0040 | 97 93 08 f8                                     | ....[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-181 --dbfilename apple.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-181 --dbfilename apple.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$5\r\napple\r\n"[0m
@@ -1253,32 +1253,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2445 --dbfilename blueberry.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2445 --dbfilename blueberry.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-2445\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-2445"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-2445"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-2445\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-2445"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-2445"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple blueberry PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$9\r\nblueberry\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 07:23:14.680[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 07:23:14.680 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:21:00.070[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:21:00.070 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nblueberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "blueberry"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "blueberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 07:23:14.788 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:21:00.173 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/streams/pass
+++ b/internal/test_helpers/fixtures/streams/pass
@@ -366,9 +366,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758637360782-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758637360782-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758637360782-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407778686-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407778686-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407778686-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -490,11 +490,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acfd841117be9b2d0f0109f088d446efc5fdc17a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf7\xab\xd6 \x1c\xe2m\xfe"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(182b623e07151195d9879c4de26e76a9d3e850ae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffVL\xe1m\xb7\x1d\t\x14"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -514,11 +514,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acfd841117be9b2d0f0109f088d446efc5fdc17a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffx\xb0\aA\x17\xc5WX"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(182b623e07151195d9879c4de26e76a9d3e850ae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1c\xb2.c3\x86\t/"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -538,11 +538,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acfd841117be9b2d0f0109f088d446efc5fdc17a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc6mxm\xbd\x1a\x84\x1e"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(182b623e07151195d9879c4de26e76a9d3e850ae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf7ѻ\xc2\xe0\x12t\xf6"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -562,11 +562,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC acfd841117be9b2d0f0109f088d446efc5fdc17a 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 182b623e07151195d9879c4de26e76a9d3e850ae 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc21\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(acfd841117be9b2d0f0109f088d446efc5fdc17a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff6\x89#y\x92\x97΅"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime£n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(182b623e07151195d9879c4de26e76a9d3e850ae\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb\x12\xc5\xe6\xf4\xf4\xc1\x82"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -683,7 +683,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2094 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2096 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -713,11 +713,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc24\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c0f979268479f6ec1067d10c09a9b7bc2ee5a98e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd2\x19V\x1e\x96kX\xcc"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¦n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff_\x9f\xb9;\b$\xe8\x15"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -737,11 +737,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc24\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c0f979268479f6ec1067d10c09a9b7bc2ee5a98e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff]\x02\x87\x7f\x9dLbj"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¦n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x15av5\x8c\xbf\xe8."[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c0f979268479f6ec1067d10c09a9b7bc2ee5a98e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc24\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c0f979268479f6ec1067d10c09a9b7bc2ee5a98e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe3\xdf\xf8S7\x93\xb1,"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¦n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(fb0b4cb6c8febf97ad2250a54194cf87f4ab0d2e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfe\x02\xe3\x94_+\x95\xf7"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1045,11 +1045,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f47d219d2012993b669d390ebaa601ce2e6d511c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff1/\x9c6$\x1c\x9d\xae"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¨n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0b0bf4c219f92d44abb1e112602c5a114c66fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff&\x14\x9a\v\xff\xec\x8fu"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1069,11 +1069,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\xad\xd2h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f47d219d2012993b669d390ebaa601ce2e6d511c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0\\Ɠk\xdd\xfaG"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¨n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0b0bf4c219f92d44abb1e112602c5a114c66fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\nAeY\xb3\x9d2\xf3"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1093,11 +1093,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC f47d219d2012993b669d390ebaa601ce2e6d511c 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 7b0b0bf4c219f92d44abb1e112602c5a114c66fa 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\xad\xd2h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f47d219d2012993b669d390ebaa601ce2e6d511c\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff2֞\x94\xd09\x1d\xdb"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¨n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(7b0b0bf4c219f92d44abb1e112602c5a114c66fa\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xea\xc1v\xb3\x93\xc3[\x04"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1182,11 +1182,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 52a2d0951afa1235aac07dd3ae60dafb7420573a 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 52a2d0951afa1235aac07dd3ae60dafb7420573a 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 52a2d0951afa1235aac07dd3ae60dafb7420573a 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 9c7617b2dd620308552d7f24f119143bafb8357a 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 9c7617b2dd620308552d7f24f119143bafb8357a 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 9c7617b2dd620308552d7f24f119143bafb8357a 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(52a2d0951afa1235aac07dd3ae60dafb7420573a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\"\x92\x1a\x8e:\x8b\xf2\x13"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime¨n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9c7617b2dd620308552d7f24f119143bafb8357a\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbd\xaa-\xc7e\x8bd\x80"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1241,11 +1241,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 5f89adfdcabb34bcd2213f421a42327867bab943 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 5f89adfdcabb34bcd2213f421a42327867bab943 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 5f89adfdcabb34bcd2213f421a42327867bab943 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 353a04b11f0d1532b321f5a52b5fb921a8e0756b 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 353a04b11f0d1532b321f5a52b5fb921a8e0756b 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 353a04b11f0d1532b321f5a52b5fb921a8e0756b 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc26\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5f89adfdcabb34bcd2213f421a42327867bab943\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff$\xea&\x04\x8d\x85*\xeb"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime©n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(353a04b11f0d1532b321f5a52b5fb921a8e0756b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x13\xb3\x19\xde\xd5\xc4Zg"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1270,9 +1270,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC a94aa3dfeb1febb32e728ce0330cffdd1cd7208f 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC a94aa3dfeb1febb32e728ce0330cffdd1cd7208f 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC a94aa3dfeb1febb32e728ce0330cffdd1cd7208f 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 8b491eacc5ed43bef149627add04f55efa71e8dc 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 8b491eacc5ed43bef149627add04f55efa71e8dc 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 8b491eacc5ed43bef149627add04f55efa71e8dc 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1419,9 +1419,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c0901be9fdf5e44b922115b769de77efa09bbc43\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c0901be9fdf5e44b922115b769de77efa09bbc43\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:c0901be9fdf5e44b922115b769de77efa09bbc43\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6b4b85a8b52e6cc998b2e201be488415ceacb7ae\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6b4b85a8b52e6cc998b2e201be488415ceacb7ae\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:6b4b85a8b52e6cc998b2e201be488415ceacb7ae\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1445,9 +1445,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb9508ebdf5d149a4b5c59106988729c8bfaba66\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb9508ebdf5d149a4b5c59106988729c8bfaba66\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:cb9508ebdf5d149a4b5c59106988729c8bfaba66\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:33c0350f1b113987e7b07f083c070f43557eb54e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:33c0350f1b113987e7b07f083c070f43557eb54e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:33c0350f1b113987e7b07f083c070f43557eb54e\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1476,7 +1476,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0070 | 6e 67 6f 06 6f 72 61 6e 67 65 ff 58 9d c8 3c e9 | ngo.orange.X..<.[0m
 [33m[tester::#SM4] [0m[36m0080 | bc 46 59                                        | .FY[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1600 --dbfilename apple.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1600 --dbfilename apple.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET raspberry[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nraspberry\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$6\r\nbanana\r\n"[0m
@@ -1509,7 +1509,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0050 | 75 65 62 65 72 72 79 09 62 6c 75 65 62 65 72 72 | ueberry.blueberr[0m
 [33m[tester::#DQ3] [0m[36m0060 | 79 ff 8d bc a5 75 40 e0 5f 22                   | y....u@._"[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9407 --dbfilename strawberry.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9407 --dbfilename strawberry.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\napple\r\n"[0m
@@ -1545,22 +1545,22 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0080 | 72 79 09 70 69 6e 65 61 70 70 6c 65 ff 6f da 7a | ry.pineapple.o.z[0m
 [33m[tester::#JW4] [0m[36m0090 | 6e 99 43 a8 45                                  | n.C.E[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-2389 --dbfilename pineapple.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-2389 --dbfilename pineapple.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$9\r\npineapple\r\n$9\r\nraspberry\r\n$9\r\nblueberry\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$9\r\npineapple\r\n$10\r\nstrawberry\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
-[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "blueberry"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
-[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
 [33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "pineapple",[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "blueberry"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
@@ -1578,7 +1578,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 72 | ineapple.raspber[0m
 [33m[tester::#GC6] [0m[36m0040 | 72 79 ff f1 2b db 4b ca 51 08 d5                | ry..+.K.Q..[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9534 --dbfilename orange.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET pineapple[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
@@ -1599,7 +1599,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 65 61 72 0a 73 74 72 61 77 62 65 72 72 79 ff ac | ear.strawberry..[0m
 [33m[tester::#JZ6] [0m[36m0040 | 16 e9 97 c8 3c d1 28                            | ....<.([0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3687 --dbfilename banana.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3687 --dbfilename banana.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$4\r\npear\r\n"[0m
@@ -1610,32 +1610,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1438 --dbfilename pineapple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-1438\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-1438"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-1438"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-1438\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-1438"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-1438"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET banana raspberry px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET banana raspberry PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$9\r\nraspberry\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:22:49.730[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:22:49.730 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:23:08.517[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 21:23:08.517 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$9\r\nraspberry\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "raspberry"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "raspberry"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "banana" at 14:22:49.838 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "banana" at 21:23:08.620 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET banana[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/transactions/pass
+++ b/internal/test_helpers/fixtures/transactions/pass
@@ -2,9 +2,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 34018 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 34020 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 34026 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 49792 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 49793 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 49794 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET blueberry 80[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\nblueberry\r\n$2\r\n80\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -107,8 +107,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 34036 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 34042 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 49797 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 49798 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET pineapple pear[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$9\r\npineapple\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -211,8 +211,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 34070 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 34072 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 49804 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 49805 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -258,8 +258,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 34092 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 34104 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 49808 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 49809 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -759,9 +759,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD banana * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$6\r\nbanana\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758637420668-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758637420668-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758637420668-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407734961-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407734961-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407734961-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -883,11 +883,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a08fd396764fb3fd56db419f96cffd98a93af5b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffʯ\"\x8f\x9dܲI"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xcb{\xe2á$\x04\xa0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -907,11 +907,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a08fd396764fb3fd56db419f96cffd98a93af5b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffE\xb4\xf3\xee\x96\xfb\x88\xef"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wn\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x81\x85-\xcd%\xbf\x04\x9b"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -931,11 +931,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a08fd396764fb3fd56db419f96cffd98a93af5b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfbi\x8c\xc2<$[\xa9"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wn\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffj\xe6\xb8l\xf6+yB"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -955,11 +955,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 9a08fd396764fb3fd56db419f96cffd98a93af5b 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9a08fd396764fb3fd56db419f96cffd98a93af5b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\v\x8d\xd7\xd6\x13\xa9\x112"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2wn\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b6f09b78e2d8faa2e47a2651a56f3100ce9c2ffe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffV%\xc6H\xe2\xcd\xcc6"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1076,7 +1076,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6383] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":3\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 3[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2089 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2095 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -1108,11 +1108,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2o\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(befec5a88062c3b96f47c3dc7906032ada01d316\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff(Pդ*\xed\x9eV"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(272bccf8157fcdf40bec98f66508443341a0391b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff7\x05@\x1d\xbc\xaf\xe1\xd1"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1132,11 +1132,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2o\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(befec5a88062c3b96f47c3dc7906032ada01d316\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa7K\x04\xc5!ʤ\xf0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zn\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(272bccf8157fcdf40bec98f66508443341a0391b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff}\xfb\x8f\x1384\xe1\xea"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1156,11 +1156,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2p\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(befec5a88062c3b96f47c3dc7906032ada01d316\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffr4\x05w\x9c\xa2\xc1\xe0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zn\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(272bccf8157fcdf40bec98f66508443341a0391b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x96\x98\x1a\xb2렜3"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -1180,11 +1180,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2p\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(befec5a88062c3b96f47c3dc7906032ada01d316\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\xd0^c\xb3/\x8b{"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zn\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(272bccf8157fcdf40bec98f66508443341a0391b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xaa[d\x96\xffF)G"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -1204,11 +1204,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC befec5a88062c3b96f47c3dc7906032ada01d316 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 272bccf8157fcdf40bec98f66508443341a0391b 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2p\xad\xd2h\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(befec5a88062c3b96f47c3dc7906032ada01d316\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffMj\xe9o\x96\x17\xc7}"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2zn\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(272bccf8157fcdf40bec98f66508443341a0391b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xeb\xcc\x04`_X\x99z"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -1498,11 +1498,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2r\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c2cbf1f46049b86b8e92ed413991c79b0431925\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa4\xdf,rT\xfa,\x8d"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2|n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10d9844057dac1c25fa764bc463ccaf63eb5adbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8eOrK\x82TB\xbb"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1522,11 +1522,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2r\xad\xd2h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c2cbf1f46049b86b8e92ed413991c79b0431925\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffU\xacv\xd7\x1b;Kd"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2|n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10d9844057dac1c25fa764bc463ccaf63eb5adbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa2\x1a\x8d\x19\xce%\xff="[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1546,11 +1546,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 1c2cbf1f46049b86b8e92ed413991c79b0431925 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 10d9844057dac1c25fa764bc463ccaf63eb5adbe 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2r\xad\xd2h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(1c2cbf1f46049b86b8e92ed413991c79b0431925\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa7&.Р߬\xf8"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10d9844057dac1c25fa764bc463ccaf63eb5adbe\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb7oƗ\x15\xca\xc0\x14"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1635,11 +1635,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC b36c2d072e78e60e00da1044b496c8774b9864e2 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC b36c2d072e78e60e00da1044b496c8774b9864e2 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC b36c2d072e78e60e00da1044b496c8774b9864e2 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC a5d2bd34e24770e852f32d9763df63c02d7f50b0 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC a5d2bd34e24770e852f32d9763df63c02d7f50b0 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC a5d2bd34e24770e852f32d9763df63c02d7f50b0 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2r\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(b36c2d072e78e60e00da1044b496c8774b9864e2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffRb<\xebZ{\x12\xef"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a5d2bd34e24770e852f32d9763df63c02d7f50b0\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfc+ITaP\x17\x01"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1694,11 +1694,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 452cb15551fdb7e74a3e7f1ee75ce82a4aacb950 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 452cb15551fdb7e74a3e7f1ee75ce82a4aacb950 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 452cb15551fdb7e74a3e7f1ee75ce82a4aacb950 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC d453997c85fe5c9520b255936bc3864803dc4596 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC d453997c85fe5c9520b255936bc3864803dc4596 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC d453997c85fe5c9520b255936bc3864803dc4596 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2r\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(452cb15551fdb7e74a3e7f1ee75ce82a4aacb950\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\t\x0f\x81\xd9J!\x8c"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2}n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(d453997c85fe5c9520b255936bc3864803dc4596\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffT\x96\xb7\xda\xcf;\x11\xe5"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -1723,9 +1723,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC f0cf3e66fe647c53df0ea70c950e3e58923a9bba 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC f0cf3e66fe647c53df0ea70c950e3e58923a9bba 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC f0cf3e66fe647c53df0ea70c950e3e58923a9bba 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 6c92096c1400b83f2d2d348a487b78b5b5decda7 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 6c92096c1400b83f2d2d348a487b78b5b5decda7 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 6c92096c1400b83f2d2d348a487b78b5b5decda7 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -1872,9 +1872,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7bc255c59916b0a06e8dfb90ecbac161898f05bd\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7bc255c59916b0a06e8dfb90ecbac161898f05bd\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:7bc255c59916b0a06e8dfb90ecbac161898f05bd\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe099a02298906b0d761ee25ade781a59958075\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe099a02298906b0d761ee25ade781a59958075\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2fe099a02298906b0d761ee25ade781a59958075\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -1898,9 +1898,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ce893143c8146aca41091efb3622ceaf84b8dd88\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ce893143c8146aca41091efb3622ceaf84b8dd88\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:ce893143c8146aca41091efb3622ceaf84b8dd88\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dad4ab475556a5b143dd0b0779e9704b415cafe0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dad4ab475556a5b143dd0b0779e9704b415cafe0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:dad4ab475556a5b143dd0b0779e9704b415cafe0\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -1931,7 +1931,7 @@ Debug = true
 [33m[tester::#SM4] [0m[36m0090 | 28 8a c7 01 00 00 00 05 61 70 70 6c 65 09 72 61 | (.......apple.ra[0m
 [33m[tester::#SM4] [0m[36m00a0 | 73 70 62 65 72 72 79 ff 10 f6 99 42 96 77 a1 8d | spberry....B.w..[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9534 --dbfilename orange.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9534 --dbfilename orange.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
@@ -1975,7 +1975,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0060 | 61 70 70 6c 65 0a 73 74 72 61 77 62 65 72 72 79 | apple.strawberry[0m
 [33m[tester::#DQ3] [0m[36m0070 | ff 97 22 dd 30 46 ee 83 03                      | ..".0F...[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1438 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1438 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET strawberry[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -2014,21 +2014,21 @@ Debug = true
 [33m[tester::#JW4] [0m[36m0060 | 79 00 05 6d 61 6e 67 6f 05 67 72 61 70 65 ff ba | y..mango.grape..[0m
 [33m[tester::#JW4] [0m[36m0070 | fb 6e db 72 08 1e 1b                            | .n.r...[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3062 --dbfilename orange.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3062 --dbfilename orange.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$6\r\norange\r\n$5\r\nmango\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*4\r\n$5\r\nmango\r\n$10\r\nstrawberry\r\n$6\r\nbanana\r\n$6\r\norange\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
+[33m[tester::#JW4] [client] [0m[36m  "mango",[0m
 [33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "banana",[0m
-[33m[tester::#JW4] [client] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[36m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[36m  "orange"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
+[33m[tester::#JW4] [client] [0m[92m  "mango",[0m
 [33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "banana",[0m
-[33m[tester::#JW4] [client] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[92m  "mango"[0m
+[33m[tester::#JW4] [client] [0m[92m  "orange"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -2045,7 +2045,7 @@ Debug = true
 [33m[tester::#GC6] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 ff df 76 69 ad | rape.orange..vi.[0m
 [33m[tester::#GC6] [0m[36m0040 | c7 19 1a 7f                                     | ....[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-3337 --dbfilename banana.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-3337 --dbfilename banana.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET grape[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$6\r\norange\r\n"[0m
@@ -2066,7 +2066,7 @@ Debug = true
 [33m[tester::#JZ6] [0m[36m0030 | 65 61 72 09 70 69 6e 65 61 70 70 6c 65 ff a1 e2 | ear.pineapple...[0m
 [33m[tester::#JZ6] [0m[36m0040 | 16 a7 2d 81 76 2a                               | ..-.v*[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1646 --dbfilename grape.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1646 --dbfilename grape.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$4\r\npear\r\n"[0m
@@ -2077,32 +2077,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-6307 --dbfilename apple.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-6307 --dbfilename apple.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-6307\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-6307"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-6307"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-6307\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-6307"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-6307"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple grape px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET apple grape PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\napple\r\n$5\r\ngrape\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:23:49.766[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:23:49.766 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:22:24.999[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:22:24.999 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$5\r\ngrape\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "grape"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "grape"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "apple" at 14:23:49.873 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "apple" at 21:22:25.104 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET apple[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\napple\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m

--- a/internal/test_helpers/fixtures/zset/pass
+++ b/internal/test_helpers/fixtures/zset/pass
@@ -340,9 +340,9 @@ Debug = true
 
 [33m[tester::#ZE9] [0m[94mRunning tests for Stage #ZE9 (ze9)[0m
 [33m[tester::#ZE9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 37342 -> port 6379)[0m
-[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 37352 -> port 6379)[0m
-[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 37362 -> port 6379)[0m
+[33m[tester::#ZE9] [client-1] [0m[36mConnected (port 50027 -> port 6379)[0m
+[33m[tester::#ZE9] [client-2] [0m[36mConnected (port 50028 -> port 6379)[0m
+[33m[tester::#ZE9] [client-3] [0m[36mConnected (port 50029 -> port 6379)[0m
 [33m[tester::#ZE9] [client-1] [0m[94m$ redis-cli SUBSCRIBE pineapple[0m
 [33m[tester::#ZE9] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#ZE9] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\npineapple\r\n:1\r\n"[0m
@@ -422,10 +422,10 @@ Debug = true
 
 [33m[tester::#DN4] [0m[94mRunning tests for Stage #DN4 (dn4)[0m
 [33m[tester::#DN4] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#DN4] [client-1] [0m[36mConnected (port 37370 -> port 6379)[0m
-[33m[tester::#DN4] [client-2] [0m[36mConnected (port 37376 -> port 6379)[0m
-[33m[tester::#DN4] [client-3] [0m[36mConnected (port 37380 -> port 6379)[0m
-[33m[tester::#DN4] [client-4] [0m[36mConnected (port 37386 -> port 6379)[0m
+[33m[tester::#DN4] [client-1] [0m[36mConnected (port 50032 -> port 6379)[0m
+[33m[tester::#DN4] [client-2] [0m[36mConnected (port 50033 -> port 6379)[0m
+[33m[tester::#DN4] [client-3] [0m[36mConnected (port 50034 -> port 6379)[0m
+[33m[tester::#DN4] [client-4] [0m[36mConnected (port 50035 -> port 6379)[0m
 [33m[tester::#DN4] [client-1] [0m[94m$ redis-cli SUBSCRIBE apple[0m
 [33m[tester::#DN4] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\napple\r\n"[0m
 [33m[tester::#DN4] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\napple\r\n:1\r\n"[0m
@@ -483,10 +483,10 @@ Debug = true
 
 [33m[tester::#HF2] [0m[94mRunning tests for Stage #HF2 (hf2)[0m
 [33m[tester::#HF2] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#HF2] [client-1] [0m[36mConnected (port 37410 -> port 6379)[0m
-[33m[tester::#HF2] [client-2] [0m[36mConnected (port 37424 -> port 6379)[0m
-[33m[tester::#HF2] [client-3] [0m[36mConnected (port 37436 -> port 6379)[0m
-[33m[tester::#HF2] [client-4] [0m[36mConnected (port 37442 -> port 6379)[0m
+[33m[tester::#HF2] [client-1] [0m[36mConnected (port 50038 -> port 6379)[0m
+[33m[tester::#HF2] [client-2] [0m[36mConnected (port 50039 -> port 6379)[0m
+[33m[tester::#HF2] [client-3] [0m[36mConnected (port 50040 -> port 6379)[0m
+[33m[tester::#HF2] [client-4] [0m[36mConnected (port 50041 -> port 6379)[0m
 [33m[tester::#HF2] [client-1] [0m[94m$ redis-cli SUBSCRIBE mango[0m
 [33m[tester::#HF2] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#HF2] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$5\r\nmango\r\n:1\r\n"[0m
@@ -518,8 +518,8 @@ Debug = true
 
 [33m[tester::#LF1] [0m[94mRunning tests for Stage #LF1 (lf1)[0m
 [33m[tester::#LF1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#LF1] [client-1] [0m[36mConnected (port 37464 -> port 6379)[0m
-[33m[tester::#LF1] [client-2] [0m[36mConnected (port 37472 -> port 6379)[0m
+[33m[tester::#LF1] [client-1] [0m[36mConnected (port 50044 -> port 6379)[0m
+[33m[tester::#LF1] [client-2] [0m[36mConnected (port 50045 -> port 6379)[0m
 [33m[tester::#LF1] [client-1] [0m[94m$ redis-cli SUBSCRIBE pineapple[0m
 [33m[tester::#LF1] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#LF1] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\npineapple\r\n:1\r\n"[0m
@@ -572,8 +572,8 @@ Debug = true
 
 [33m[tester::#ZC8] [0m[94mRunning tests for Stage #ZC8 (zc8)[0m
 [33m[tester::#ZC8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 37506 -> port 6379)[0m
-[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 37514 -> port 6379)[0m
+[33m[tester::#ZC8] [client-1] [0m[36mConnected (port 50051 -> port 6379)[0m
+[33m[tester::#ZC8] [client-2] [0m[36mConnected (port 50052 -> port 6379)[0m
 [33m[tester::#ZC8] [client-1] [0m[94m$ redis-cli SUBSCRIBE pineapple[0m
 [33m[tester::#ZC8] [client-1] [0m[36mSent bytes: "*2\r\n$9\r\nSUBSCRIBE\r\n$9\r\npineapple\r\n"[0m
 [33m[tester::#ZC8] [client-1] [0m[36mReceived bytes: "*3\r\n$9\r\nsubscribe\r\n$9\r\npineapple\r\n:1\r\n"[0m
@@ -636,8 +636,8 @@ Debug = true
 [33m[tester::#XJ7] [client] [0m[36mReceived bytes: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[36mReceived RESP null array: "*-1\r\n"[0m
 [33m[tester::#XJ7] [client] [0m[92m✔︎ Received "*-1\r\n"[0m
-[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 37566 -> port 6379)[0m
-[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 37574 -> port 6379)[0m
+[33m[tester::#XJ7] [client-1] [0m[36mConnected (port 50059 -> port 6379)[0m
+[33m[tester::#XJ7] [client-2] [0m[36mConnected (port 50060 -> port 6379)[0m
 [33m[tester::#XJ7] [client-1] [0m[94m$ redis-cli BLPOP pineapple 0.1[0m
 [33m[tester::#XJ7] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\npineapple\r\n$3\r\n0.1\r\n"[0m
 [33m[tester::#XJ7] [client-2] [0m[94m$ redis-cli RPUSH pineapple mango[0m
@@ -655,9 +655,9 @@ Debug = true
 
 [33m[tester::#EC3] [0m[94mRunning tests for Stage #EC3 (ec3)[0m
 [33m[tester::#EC3] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#EC3] [client-1] [0m[36mConnected (port 37604 -> port 6379)[0m
-[33m[tester::#EC3] [client-2] [0m[36mConnected (port 37614 -> port 6379)[0m
-[33m[tester::#EC3] [client-3] [0m[36mConnected (port 37620 -> port 6379)[0m
+[33m[tester::#EC3] [client-1] [0m[36mConnected (port 50063 -> port 6379)[0m
+[33m[tester::#EC3] [client-2] [0m[36mConnected (port 50064 -> port 6379)[0m
+[33m[tester::#EC3] [client-3] [0m[36mConnected (port 50065 -> port 6379)[0m
 [33m[tester::#EC3] [client-1] [0m[94m$ redis-cli BLPOP pineapple 0[0m
 [33m[tester::#EC3] [client-1] [0m[36mSent bytes: "*3\r\n$5\r\nBLPOP\r\n$9\r\npineapple\r\n$1\r\n0\r\n"[0m
 [33m[tester::#EC3] [client-2] [0m[94m$ redis-cli BLPOP pineapple 0[0m
@@ -982,9 +982,9 @@ Debug = true
 
 [33m[tester::#JF8] [0m[94mRunning tests for Stage #JF8 (jf8)[0m
 [33m[tester::#JF8] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#JF8] [client-1] [0m[36mConnected (port 37804 -> port 6379)[0m
-[33m[tester::#JF8] [client-2] [0m[36mConnected (port 37810 -> port 6379)[0m
-[33m[tester::#JF8] [client-3] [0m[36mConnected (port 37814 -> port 6379)[0m
+[33m[tester::#JF8] [client-1] [0m[36mConnected (port 50095 -> port 6379)[0m
+[33m[tester::#JF8] [client-2] [0m[36mConnected (port 50096 -> port 6379)[0m
+[33m[tester::#JF8] [client-3] [0m[36mConnected (port 50097 -> port 6379)[0m
 [33m[tester::#JF8] [client-1] [0m[94m$ redis-cli SET banana 65[0m
 [33m[tester::#JF8] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$2\r\n65\r\n"[0m
 [33m[tester::#JF8] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1087,8 +1087,8 @@ Debug = true
 
 [33m[tester::#SG9] [0m[94mRunning tests for Stage #SG9 (sg9)[0m
 [33m[tester::#SG9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#SG9] [client-1] [0m[36mConnected (port 37828 -> port 6379)[0m
-[33m[tester::#SG9] [client-2] [0m[36mConnected (port 37830 -> port 6379)[0m
+[33m[tester::#SG9] [client-1] [0m[36mConnected (port 50100 -> port 6379)[0m
+[33m[tester::#SG9] [client-2] [0m[36mConnected (port 50101 -> port 6379)[0m
 [33m[tester::#SG9] [client-1] [0m[94m$ redis-cli SET banana grape[0m
 [33m[tester::#SG9] [client-1] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$6\r\nbanana\r\n$5\r\ngrape\r\n"[0m
 [33m[tester::#SG9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1191,8 +1191,8 @@ Debug = true
 
 [33m[tester::#FY6] [0m[94mRunning tests for Stage #FY6 (fy6)[0m
 [33m[tester::#FY6] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#FY6] [client-1] [0m[36mConnected (port 37866 -> port 6379)[0m
-[33m[tester::#FY6] [client-2] [0m[36mConnected (port 37876 -> port 6379)[0m
+[33m[tester::#FY6] [client-1] [0m[36mConnected (port 50107 -> port 6379)[0m
+[33m[tester::#FY6] [client-2] [0m[36mConnected (port 50108 -> port 6379)[0m
 [33m[tester::#FY6] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#FY6] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#FY6] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1238,8 +1238,8 @@ Debug = true
 
 [33m[tester::#RS9] [0m[94mRunning tests for Stage #RS9 (rs9)[0m
 [33m[tester::#RS9] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#RS9] [client-1] [0m[36mConnected (port 37888 -> port 6379)[0m
-[33m[tester::#RS9] [client-2] [0m[36mConnected (port 37892 -> port 6379)[0m
+[33m[tester::#RS9] [client-1] [0m[36mConnected (port 50111 -> port 6379)[0m
+[33m[tester::#RS9] [client-2] [0m[36mConnected (port 50112 -> port 6379)[0m
 [33m[tester::#RS9] [client-1] [0m[94m$ redis-cli MULTI[0m
 [33m[tester::#RS9] [client-1] [0m[36mSent bytes: "*1\r\n$5\r\nMULTI\r\n"[0m
 [33m[tester::#RS9] [client-1] [0m[36mReceived bytes: "+OK\r\n"[0m
@@ -1727,9 +1727,9 @@ Debug = true
 [33m[tester::#XU6] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XU6] [client] [0m[94m$ redis-cli XADD raspberry * foo bar[0m
 [33m[tester::#XU6] [client] [0m[36mSent bytes: "*5\r\n$4\r\nXADD\r\n$9\r\nraspberry\r\n$1\r\n*\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1758637442537-0\r\n"[0m
-[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1758637442537-0"[0m
-[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1758637442537-0"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived bytes: "$15\r\n1759407758944-0\r\n"[0m
+[33m[tester::#XU6] [client] [0m[36mReceived RESP bulk string: "1759407758944-0"[0m
+[33m[tester::#XU6] [client] [0m[92m✔︎ Received "1759407758944-0"[0m
 [33m[tester::#XU6] [0m[92mThe first part of the ID is a valid unix milliseconds timestamp[0m
 [33m[tester::#XU6] [0m[92mThe second part of the ID is a valid sequence number[0m
 [33m[tester::#XU6] [0m[92mTest passed.[0m
@@ -1850,11 +1850,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0083\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cf5c1f70d242c96f83b32e1032dc8e1b6c81871\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1a;\xdc\\\xf2\xd3{\x98"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u008fn\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(252ee99e32969db4c90b645b2539976a5c24039e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc0yO\xb9\xe5\xd7ע"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -1874,11 +1874,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0083\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cf5c1f70d242c96f83b32e1032dc8e1b6c81871\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x95 \r=\xf9\xf4A>"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u008fn\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(252ee99e32969db4c90b645b2539976a5c24039e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8a\x87\x80\xb7aLי"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -1898,11 +1898,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 5cf5c1f70d242c96f83b32e1032dc8e1b6c81871 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 252ee99e32969db4c90b645b2539976a5c24039e 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0083\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5cf5c1f70d242c96f83b32e1032dc8e1b6c81871\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff+\xfdr\x11S+\x92x"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u008fn\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(252ee99e32969db4c90b645b2539976a5c24039e\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffa\xe4\x15\x16\xb2ت@"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -1995,7 +1995,7 @@ Debug = true
 [33m[tester::#NA2] [test] [replica@6382] [0m[36mNot sending ACK to Master[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: ":2\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived RESP integer: 2[0m
-[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2087 ms[0m
+[33m[tester::#NA2] [test] [0m[94mWAIT command returned after 2089 ms[0m
 [33m[tester::#NA2] [0m[92mTest passed.[0m
 [33m[tester::#NA2] [0m[36mTerminating program[0m
 [33m[tester::#NA2] [0m[36mProgram terminated successfully[0m
@@ -2030,11 +2030,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0085\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\r\x027i\x12\xb1\xab"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82(\xc5\x0e\xffVz\xa6"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2054,11 +2054,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0085\xad\xd2h\xfa\bused-mem¸m\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffo\x16\xd3Vb5\x8b\r"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem°;\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc8\xd6\n\x00{\xcdz\x9d"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2078,11 +2078,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0085\xad\xd2h\xfa\bused-mem\xc2(w\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd1ˬz\xc8\xeaXK"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\xc2PE\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff#\xb5\x9f\xa1\xa8Y\aD"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -2102,11 +2102,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0085\xad\xd2h\xfa\bused-mem\u0098\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff!/\xf7n\xe7g\x12\xd0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\xc2\x00O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1fvᅼ\xbf\xb20"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -2126,11 +2126,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0086\xad\xd2h\xfa\bused-mem\xc2\x10\x8a\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x9a\x18>\x96\x9c\xab\xfc\x9f"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem°X\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff^\xe1\x81s\x1c\xa1\x02\r"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6385[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m$ redis-cli PING[0m
@@ -2150,11 +2150,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0086\xad\xd2h\xfa\bused-mem\u0080\x93\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x10$[=\xf0\x87v\xa3"[0m
+[33m[tester::#TU8] [handshake] [replica@6385] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\xc2Pb\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe0\x14^I6xT&"[0m
 [33m[tester::#TU8] [handshake] [replica@6385] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6386[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m$ redis-cli PING[0m
@@ -2174,11 +2174,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0086\xad\xd2h\xfa\bused-mem\xc2\xf8\x9c\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb2\x86\x1a\v\ue499\xed"[0m
+[33m[tester::#TU8] [handshake] [replica@6386] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\xc2\x00l\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xb5\xdatQ\xe5\xc6\v\x13"[0m
 [33m[tester::#TU8] [handshake] [replica@6386] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6387[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m$ redis-cli PING[0m
@@ -2198,11 +2198,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC 986353ad300c8d3d36374ae7f8bc8c9e50542df8 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "+FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived RESP simple string: "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[92m✔︎ Received "FULLRESYNC a1f5124cba53a57824d8366a6f1c7258dc93dda2 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0086\xad\xd2h\xfa\bused-mem\xc2`\xe2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(986353ad300c8d3d36374ae7f8bc8c9e50542df8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\xb1(_\xac\tl\xc2"[0m
+[33m[tester::#TU8] [handshake] [replica@6387] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0092n\xdeh\xfa\bused-mem\u00a0\xb1\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a1f5124cba53a57824d8366a6f1c7258dc93dda2\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x05V\xeee\xdf\xee\xaeI"[0m
 [33m[tester::#TU8] [handshake] [replica@6387] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
@@ -2487,11 +2487,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6e57acd16dc415abe75dedbc708cb6f2781b6248\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\fX\r\x10\x0f\xef\x8c\r"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0094n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c00a1db00e64a2791125f075f0539a3e684f15b8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff3\xc1c@%\x80\xf5?"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -2511,11 +2511,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xad\xd2h\xfa\bused-mem\xc2\xf8\xb2\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6e57acd16dc415abe75dedbc708cb6f2781b6248\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfd+W\xb5@.\xeb\xe4"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0094n\xdeh\xfa\bused-mem\xc2\x10\x81\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c00a1db00e64a2791125f075f0539a3e684f15b8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1f\x94\x9c\x12i\xf1H\xb9"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -2535,11 +2535,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 6e57acd16dc415abe75dedbc708cb6f2781b6248 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC c00a1db00e64a2791125f075f0539a3e684f15b8 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0087\xad\xd2h\xfa\bused-mem\xc2h\x80\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(6e57acd16dc415abe75dedbc708cb6f2781b6248\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x0f\xa1\x0f\xb2\xfb\xca\fx"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0094n\xdeh\xfa\bused-mem\xc2\xc0N\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c00a1db00e64a2791125f075f0539a3e684f15b8\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xff\x14\x8f\xf8I\xaf!N"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2624,11 +2624,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 195fb16ab810b640ea3567079b99e32991a302b1 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 195fb16ab810b640ea3567079b99e32991a302b1 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 195fb16ab810b640ea3567079b99e32991a302b1 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 0f331d19d50005d848a98fab6008f0f91918609b 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 0f331d19d50005d848a98fab6008f0f91918609b 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 0f331d19d50005d848a98fab6008f0f91918609b 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0088\xad\xd2h\xfa\bused-mem\xc2\x18\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(195fb16ab810b640ea3567079b99e32991a302b1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff$\xcd?t\xa9\xe7_W"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0094n\xdeh\xfa\bused-mem\xc2\x00\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(0f331d19d50005d848a98fab6008f0f91918609b\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x1e|\f\x90\xd5\xd3\xd6V"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -2683,11 +2683,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC c55d4e414c0455c45bc2a631602b8e4261bb29d5 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC c55d4e414c0455c45bc2a631602b8e4261bb29d5 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC c55d4e414c0455c45bc2a631602b8e4261bb29d5 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC c152ba5ceabab7222535db42c1ae6ed3545fc3ad 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC c152ba5ceabab7222535db42c1ae6ed3545fc3ad 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC c152ba5ceabab7222535db42c1ae6ed3545fc3ad 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0088\xad\xd2h\xfa\bused-mem\xc2\xc8\xc7\v\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c55d4e414c0455c45bc2a631602b8e4261bb29d5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff ]\x18\xc5;\xccsa"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.1\xfa\nredis-bits\xc0@\xfa\x05ctime\u0095n\xdeh\xfa\bused-mem\u0080\x95\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(c152ba5ceabab7222535db42c1ae6ed3545fc3ad\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd0\xc50n\xa2\xf3\x9b\x94"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -2712,9 +2712,9 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC a69050eefc0571bd16208d1dd38679fed8d3f1f6 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC a69050eefc0571bd16208d1dd38679fed8d3f1f6 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC a69050eefc0571bd16208d1dd38679fed8d3f1f6 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC a7bb5b8e3bc5aae80578907cccde18f8e9cc49e0 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC a7bb5b8e3bc5aae80578907cccde18f8e9cc49e0 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC a7bb5b8e3bc5aae80578907cccde18f8e9cc49e0 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
@@ -2861,9 +2861,9 @@ Debug = true
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96541bc29db223528f0d2a0b8bfa9f356a6b7a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96541bc29db223528f0d2a0b8bfa9f356a6b7a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f96541bc29db223528f0d2a0b8bfa9f356a6b7a5\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f183630422a9a7fadb51fec4423fb237f054beb2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f183630422a9a7fadb51fec4423fb237f054beb2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f183630422a9a7fadb51fec4423fb237f054beb2\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -2887,9 +2887,9 @@ Debug = true
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7e66f2b8b3f6c76ecbf79f550bf340e96f36221\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7e66f2b8b3f6c76ecbf79f550bf340e96f36221\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7e66f2b8b3f6c76ecbf79f550bf340e96f36221\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2898a40d8f81fd0c4eeb6dead2184b6e2b8aa087\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2898a40d8f81fd0c4eeb6dead2184b6e2b8aa087\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:2898a40d8f81fd0c4eeb6dead2184b6e2b8aa087\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -2908,18 +2908,18 @@ Debug = true
 [33m[tester::#SM4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#SM4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#SM4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#SM4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#SM4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 04 04 fc 00 0c | er.7.2.0........[0m
+[33m[tester::#SM4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#SM4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#SM4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 04 04 fc 00 0c | s-bits.@........[0m
 [33m[tester::#SM4] [0m[36m0030 | 28 8a c7 01 00 00 00 06 62 61 6e 61 6e 61 0a 73 | (.......banana.s[0m
 [33m[tester::#SM4] [0m[36m0040 | 74 72 61 77 62 65 72 72 79 fc 00 9c ef 12 7e 01 | trawberry.....~.[0m
 [33m[tester::#SM4] [0m[36m0050 | 00 00 00 06 6f 72 61 6e 67 65 05 6d 61 6e 67 6f | ....orange.mango[0m
 [33m[tester::#SM4] [0m[36m0060 | fc 00 0c 28 8a c7 01 00 00 00 04 70 65 61 72 06 | ...(.......pear.[0m
 [33m[tester::#SM4] [0m[36m0070 | 62 61 6e 61 6e 61 fc 00 0c 28 8a c7 01 00 00 00 | banana...(......[0m
 [33m[tester::#SM4] [0m[36m0080 | 09 62 6c 75 65 62 65 72 72 79 04 70 65 61 72 ff | .blueberry.pear.[0m
-[33m[tester::#SM4] [0m[36m0090 | 3d b9 dc b4 dc 65 53 1c                         | =....eS.[0m
+[33m[tester::#SM4] [0m[36m0090 | 7f 1a 8c 4c ee d4 e1 2f                         | ...L.../[0m
 [33m[tester::#SM4] [0m[36m[0m
-[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-9919 --dbfilename strawberry.rdb[0m
+[33m[tester::#SM4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-9919 --dbfilename strawberry.rdb[0m
 [33m[tester::#SM4] [client] [0m[94m$ redis-cli GET banana[0m
 [33m[tester::#SM4] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$6\r\nbanana\r\n"[0m
 [33m[tester::#SM4] [client] [0m[36mReceived bytes: "$10\r\nstrawberry\r\n"[0m
@@ -2959,7 +2959,7 @@ Debug = true
 [33m[tester::#DQ3] [0m[36m0070 | 62 65 72 72 79 09 72 61 73 70 62 65 72 72 79 ff | berry.raspberry.[0m
 [33m[tester::#DQ3] [0m[36m0080 | ad 3e b0 db b8 27 c3 a4                         | .>...'..[0m
 [33m[tester::#DQ3] [0m[36m[0m
-[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1176 --dbfilename pineapple.rdb[0m
+[33m[tester::#DQ3] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1176 --dbfilename pineapple.rdb[0m
 [33m[tester::#DQ3] [client] [0m[94m$ redis-cli GET pear[0m
 [33m[tester::#DQ3] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$4\r\npear\r\n"[0m
 [33m[tester::#DQ3] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -2994,33 +2994,33 @@ Debug = true
 [33m[tester::#JW4] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JW4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JW4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JW4] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#JW4] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 05 00 00 05 67 | s-bits.@.......g[0m
+[33m[tester::#JW4] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JW4] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#JW4] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 05 00 00 05 67 | er.7.2.0.......g[0m
 [33m[tester::#JW4] [0m[36m0030 | 72 61 70 65 06 6f 72 61 6e 67 65 00 06 6f 72 61 | rape.orange..ora[0m
 [33m[tester::#JW4] [0m[36m0040 | 6e 67 65 09 62 6c 75 65 62 65 72 72 79 00 09 72 | nge.blueberry..r[0m
 [33m[tester::#JW4] [0m[36m0050 | 61 73 70 62 65 72 72 79 05 67 72 61 70 65 00 0a | aspberry.grape..[0m
 [33m[tester::#JW4] [0m[36m0060 | 73 74 72 61 77 62 65 72 72 79 05 6d 61 6e 67 6f | strawberry.mango[0m
 [33m[tester::#JW4] [0m[36m0070 | 00 09 62 6c 75 65 62 65 72 72 79 09 72 61 73 70 | ..blueberry.rasp[0m
-[33m[tester::#JW4] [0m[36m0080 | 62 65 72 72 79 ff 35 51 d2 af 95 09 69 64       | berry.5Q....id[0m
+[33m[tester::#JW4] [0m[36m0080 | 62 65 72 72 79 ff da 81 b0 83 bf 90 0b 00       | berry.........[0m
 [33m[tester::#JW4] [0m[36m[0m
-[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-4109 --dbfilename mango.rdb[0m
+[33m[tester::#JW4] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-4109 --dbfilename mango.rdb[0m
 [33m[tester::#JW4] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JW4] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
-[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\nraspberry\r\n$10\r\nstrawberry\r\n$9\r\nblueberry\r\n$6\r\norange\r\n$5\r\ngrape\r\n"[0m
+[33m[tester::#JW4] [client] [0m[36mReceived bytes: "*5\r\n$9\r\nblueberry\r\n$5\r\ngrape\r\n$6\r\norange\r\n$9\r\nraspberry\r\n$10\r\nstrawberry\r\n"[0m
 [33m[tester::#JW4] [client] [0m[36mReceived RESP array: [[0m
-[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[36m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[36m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "grape",[0m
 [33m[tester::#JW4] [client] [0m[36m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[36m  "grape"[0m
+[33m[tester::#JW4] [client] [0m[36m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[36m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[36m][0m
 [33m[tester::#JW4] [client] [0m[92m✔︎ Received [[0m
-[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
-[33m[tester::#JW4] [client] [0m[92m  "strawberry",[0m
 [33m[tester::#JW4] [client] [0m[92m  "blueberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "grape",[0m
 [33m[tester::#JW4] [client] [0m[92m  "orange",[0m
-[33m[tester::#JW4] [client] [0m[92m  "grape"[0m
+[33m[tester::#JW4] [client] [0m[92m  "raspberry",[0m
+[33m[tester::#JW4] [client] [0m[92m  "strawberry"[0m
 [33m[tester::#JW4] [client] [0m[92m][0m
 [33m[tester::#JW4] [0m[92mTest passed.[0m
 [33m[tester::#JW4] [0m[36mTerminating program[0m
@@ -3031,13 +3031,13 @@ Debug = true
 [33m[tester::#GC6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#GC6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#GC6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#GC6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
-[33m[tester::#GC6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 62 | s-bits.@.......b[0m
-[33m[tester::#GC6] [0m[36m0030 | 6c 75 65 62 65 72 72 79 05 6d 61 6e 67 6f ff e8 | lueberry.mango..[0m
-[33m[tester::#GC6] [0m[36m0040 | 69 1f 57 6b 37 ff 0b                            | i.Wk7..[0m
+[33m[tester::#GC6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#GC6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
+[33m[tester::#GC6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 62 | er.7.2.0.......b[0m
+[33m[tester::#GC6] [0m[36m0030 | 6c 75 65 62 65 72 72 79 05 6d 61 6e 67 6f ff 92 | lueberry.mango..[0m
+[33m[tester::#GC6] [0m[36m0040 | 20 14 d4 8f 50 49 e5                            |  ...PI.[0m
 [33m[tester::#GC6] [0m[36m[0m
-[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-1376 --dbfilename strawberry.rdb[0m
+[33m[tester::#GC6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-1376 --dbfilename strawberry.rdb[0m
 [33m[tester::#GC6] [client] [0m[94m$ redis-cli GET blueberry[0m
 [33m[tester::#GC6] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$9\r\nblueberry\r\n"[0m
 [33m[tester::#GC6] [client] [0m[36mReceived bytes: "$5\r\nmango\r\n"[0m
@@ -3052,13 +3052,13 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mHexdump of RDB file contents: [0m
 [33m[tester::#JZ6] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#JZ6] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 0a 72 65 64 69 73 | REDIS0011..redis[0m
-[33m[tester::#JZ6] [0m[36m0010 | 2d 62 69 74 73 c0 40 fa 09 72 65 64 69 73 2d 76 | -bits.@..redis-v[0m
-[33m[tester::#JZ6] [0m[36m0020 | 65 72 05 37 2e 32 2e 30 fe 00 fb 01 00 00 09 70 | er.7.2.0.......p[0m
+[33m[tester::#JZ6] [0m[36m0000 | 52 45 44 49 53 30 30 31 31 fa 09 72 65 64 69 73 | REDIS0011..redis[0m
+[33m[tester::#JZ6] [0m[36m0010 | 2d 76 65 72 05 37 2e 32 2e 30 fa 0a 72 65 64 69 | -ver.7.2.0..redi[0m
+[33m[tester::#JZ6] [0m[36m0020 | 73 2d 62 69 74 73 c0 40 fe 00 fb 01 00 00 09 70 | s-bits.@.......p[0m
 [33m[tester::#JZ6] [0m[36m0030 | 69 6e 65 61 70 70 6c 65 09 72 61 73 70 62 65 72 | ineapple.raspber[0m
-[33m[tester::#JZ6] [0m[36m0040 | 72 79 ff 0a 19 c4 51 32 9f 06 5e                | ry....Q2..^[0m
+[33m[tester::#JZ6] [0m[36m0040 | 72 79 ff f1 2b db 4b ca 51 08 d5                | ry..+.K.Q..[0m
 [33m[tester::#JZ6] [0m[36m[0m
-[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-8623 --dbfilename raspberry.rdb[0m
+[33m[tester::#JZ6] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-8623 --dbfilename raspberry.rdb[0m
 [33m[tester::#JZ6] [client] [0m[94m$ redis-cli KEYS *[0m
 [33m[tester::#JZ6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nKEYS\r\n$1\r\n*\r\n"[0m
 [33m[tester::#JZ6] [client] [0m[36mReceived bytes: "*1\r\n$9\r\npineapple\r\n"[0m
@@ -3069,32 +3069,32 @@ Debug = true
 [33m[tester::#JZ6] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#ZG5] [0m[94mRunning tests for Stage #ZG5 (zg5)[0m
-[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /tmp/rdb-4409 --dbfilename pear.rdb[0m
+[33m[tester::#ZG5] [0m[94m$ ./spawn_redis_server.sh --dir /private/tmp/rdb-4409 --dbfilename pear.rdb[0m
 [33m[tester::#ZG5] [client] [0m[94m$ redis-cli CONFIG GET dir[0m
 [33m[tester::#ZG5] [client] [0m[36mSent bytes: "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$3\r\ndir\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$13\r\n/tmp/rdb-4409\r\n"[0m
-[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/tmp/rdb-4409"][0m
-[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/tmp/rdb-4409"][0m
+[33m[tester::#ZG5] [client] [0m[36mReceived bytes: "*2\r\n$3\r\ndir\r\n$21\r\n/private/tmp/rdb-4409\r\n"[0m
+[33m[tester::#ZG5] [client] [0m[36mReceived RESP array: ["dir", "/private/tmp/rdb-4409"][0m
+[33m[tester::#ZG5] [client] [0m[92m✔︎ Received ["dir", "/private/tmp/rdb-4409"][0m
 [33m[tester::#ZG5] [0m[92mTest passed.[0m
 [33m[tester::#ZG5] [0m[36mTerminating program[0m
 [33m[tester::#ZG5] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#YZ1] [0m[94mRunning tests for Stage #YZ1 (yz1)[0m
 [33m[tester::#YZ1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET mango pear px 100[0m
-[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$4\r\npear\r\n$2\r\npx\r\n$3\r\n100\r\n"[0m
+[33m[tester::#YZ1] [client] [0m[94m$ redis-cli SET mango pear PX 100[0m
+[33m[tester::#YZ1] [client] [0m[36mSent bytes: "*5\r\n$3\r\nSET\r\n$5\r\nmango\r\n$4\r\npear\r\n$2\r\nPX\r\n$3\r\n100\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "+OK\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP simple string: "OK"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "OK"[0m
-[33m[tester::#YZ1] [0m[92mReceived OK at 14:24:11.406[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:24:11.406 (should not be expired)[0m
+[33m[tester::#YZ1] [0m[92mReceived OK at 21:22:48.643[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 21:22:48.643 (should not be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$4\r\npear\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived RESP bulk string: "pear"[0m
 [33m[tester::#YZ1] [client] [0m[92m✔︎ Received "pear"[0m
 [33m[tester::#YZ1] [0m[36mSleeping for 101ms[0m
-[33m[tester::#YZ1] [0m[94mFetching key "mango" at 14:24:11.511 (should be expired)[0m
+[33m[tester::#YZ1] [0m[94mFetching key "mango" at 21:22:48.747 (should be expired)[0m
 [33m[tester::#YZ1] [client] [0m[94m> GET mango[0m
 [33m[tester::#YZ1] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$5\r\nmango\r\n"[0m
 [33m[tester::#YZ1] [client] [0m[36mReceived bytes: "$-1\r\n"[0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches SET expiration flag to PX in fixtures and refreshes golden outputs (paths, ports, IDs, hexdumps, ordering).
> 
> - **Expiry/commands**:
>   - Use uppercase `PX` for `SET` expiration in fixtures (was `px`).
> - **Fixtures/logs**:
>   - Update paths from `/tmp/...` to `/private/tmp/...` in RDB-related fixtures.
>   - Refresh recorded outputs: connection ports, replication IDs, RDB hexdumps, stream IDs/timestamps, and some key ordering.
>   - No functional code changes; only test fixture/golden output updates to match current behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37ce7012e067272c7f45cb201f2989606b33356. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->