### PR TITLE
Add explicit port handling in RESP connection callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ setup:
 	sudo chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
 	@echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(shell lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 
+	echo 'Package: redis*' | sudo tee /etc/apt/preferences.d/redis-8.4.pref
+	echo 'Pin: version 6:8.4*' | sudo tee -a /etc/apt/preferences.d/redis-8.4.pref
+	echo 'Pin-Priority: 1000' | sudo tee -a /etc/apt/preferences.d/redis-8.4.pref
+
 	sudo apt-get update && sudo apt-get install redis -y
 
 	sudo service redis-server stop

--- a/internal/instrumented_resp_connection/instrumented_resp_connection.go
+++ b/internal/instrumented_resp_connection/instrumented_resp_connection.go
@@ -1,12 +1,15 @@
 package instrumented_resp_connection
 
 import (
+	"fmt"
 	"net"
 
 	resp_connection "github.com/codecrafters-io/redis-tester/internal/resp/connection"
 	resp_value "github.com/codecrafters-io/redis-tester/internal/resp/value"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
+
+const REDIS_DEFAULT_PORT = 6379
 
 type InstrumentedRespConnection struct {
 	*resp_connection.RespConnection
@@ -15,14 +18,19 @@ type InstrumentedRespConnection struct {
 	logger *logger.Logger
 }
 
-func defaultCallbacks(logger *logger.Logger) resp_connection.RespConnectionCallbacks {
+func defaultCallbacks(logger *logger.Logger, remoteAddr net.Addr) resp_connection.RespConnectionCallbacks {
 	return resp_connection.RespConnectionCallbacks{
 		BeforeSendCommand: func(reusedConnection bool, command string, args ...string) {
 			var commandPrefix string
 			if reusedConnection {
 				commandPrefix = ">"
 			} else {
-				commandPrefix = "$ redis-cli"
+				remotePort := remoteAddr.(*net.TCPAddr).Port
+				if remotePort == REDIS_DEFAULT_PORT {
+					commandPrefix = "$ redis-cli"
+				} else {
+					commandPrefix = fmt.Sprintf("$ redis-cli -p %d", remotePort)
+				}
 			}
 
 			commandWithArgs := append([]string{command}, args...)
@@ -46,7 +54,13 @@ func defaultCallbacks(logger *logger.Logger) resp_connection.RespConnectionCallb
 func NewFromAddr(baseLogger *logger.Logger, addr string, connIdentifier string) (*InstrumentedRespConnection, error) {
 	logger := baseLogger.Clone()
 	logger.PushSecondaryPrefix(connIdentifier)
-	c, err := resp_connection.NewRespConnectionFromAddr(addr, defaultCallbacks(logger))
+
+	remoteAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := resp_connection.NewRespConnectionFromAddr(addr, defaultCallbacks(logger, remoteAddr))
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +73,8 @@ func NewFromAddr(baseLogger *logger.Logger, addr string, connIdentifier string) 
 func NewFromConn(baseLogger *logger.Logger, conn net.Conn, connIdentifier string) (*InstrumentedRespConnection, error) {
 	logger := baseLogger.Clone()
 	logger.PushSecondaryPrefix(connIdentifier)
-	c, err := resp_connection.NewRespConnectionFromConn(conn, defaultCallbacks(logger))
+
+	c, err := resp_connection.NewRespConnectionFromConn(conn, defaultCallbacks(logger, conn.RemoteAddr()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +98,8 @@ func (c *InstrumentedRespConnection) UpdateBaseLogger(l *logger.Logger) {
 	newLogger := l.Clone()
 	newLogger.PushSecondaryPrefix(c.GetIdentifier())
 	c.logger = newLogger
-	c.UpdateCallBacks(defaultCallbacks(c.logger))
+
+	c.UpdateCallBacks(defaultCallbacks(c.logger, c.Conn.RemoteAddr()))
 }
 
 func (c *InstrumentedRespConnection) SetReadValueInterceptor(transformer func(value resp_value.Value) resp_value.Value) {

--- a/internal/test_helpers/fixtures/repl-wait/pass
+++ b/internal/test_helpers/fixtures/repl-wait/pass
@@ -10,12 +10,12 @@ Debug = true
 
 [33m[tester::#YE5] [0m[94mRunning tests for Stage #YE5 (ye5)[0m
 [33m[tester::#YE5] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#YE5] [client] [0m[36mConnected (port 35290 -> port 6379)[0m
+[33m[tester::#YE5] [client] [0m[36mConnected (port 59988 -> port 6379)[0m
 [33m[tester::#YE5] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#YE5] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5a89fca39c34976e7fdfc46a9727e74e115ddd83\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5a89fca39c34976e7fdfc46a9727e74e115ddd83\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:5a89fca39c34976e7fdfc46a9727e74e115ddd83\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7749379f594f41c01461dcdf1aae0882d2cc16c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#YE5] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7749379f594f41c01461dcdf1aae0882d2cc16c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#YE5] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:f7749379f594f41c01461dcdf1aae0882d2cc16c\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#YE5] [0m[92mFound role:master in response.[0m
 [33m[tester::#YE5] [0m[92mTest passed.[0m
 [33m[tester::#YE5] [0m[36mTerminating program[0m
@@ -24,8 +24,8 @@ Debug = true
 [33m[tester::#HC6] [0m[94mRunning tests for Stage #HC6 (hc6)[0m
 [33m[tester::#HC6] [0m[94mMaster is running on port 6379[0m
 [33m[tester::#HC6] [0m[94m$ ./spawn_redis_server.sh --port 6380 --replicaof "localhost 6379"[0m
-[33m[tester::#HC6] [client] [0m[36mConnected (port 46260 -> port 6380)[0m
-[33m[tester::#HC6] [client] [0m[94m$ redis-cli INFO replication[0m
+[33m[tester::#HC6] [client] [0m[36mConnected (port 59993 -> port 6380)[0m
+[33m[tester::#HC6] [client] [0m[94m$ redis-cli -p 6380 INFO replication[0m
 [33m[tester::#HC6] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
 [33m[tester::#HC6] [client] [0m[36mReceived bytes: "$770\r\n# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_current_sync_attempts:1\r\nmaster_total_sync_attempts:2\r\nmaster_link_down_since_seconds:0\r\ntotal_disconnect_time_sec:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
 [33m[tester::#HC6] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:slave\r\nmaster_host:localhost\r\nmaster_port:6379\r\nmaster_link_status:down\r\nmaster_last_io_seconds_ago:-1\r\nmaster_sync_in_progress:0\r\nslave_read_repl_offset:0\r\nslave_repl_offset:0\r\nreplica_full_sync_buffer_size:0\r\nreplica_full_sync_buffer_peak:0\r\nmaster_current_sync_attempts:1\r\nmaster_total_sync_attempts:2\r\nmaster_link_down_since_seconds:0\r\ntotal_disconnect_time_sec:0\r\nslave_priority:100\r\nslave_read_only:1\r\nreplica_announced:1\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:75cd7bc10c49047e0d163660f3b90625b1af31dc\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"[0m
@@ -37,12 +37,12 @@ Debug = true
 
 [33m[tester::#XC1] [0m[94mRunning tests for Stage #XC1 (xc1)[0m
 [33m[tester::#XC1] [0m[94m$ ./spawn_redis_server.sh[0m
-[33m[tester::#XC1] [client] [0m[36mConnected (port 35330 -> port 6379)[0m
+[33m[tester::#XC1] [client] [0m[36mConnected (port 59996 -> port 6379)[0m
 [33m[tester::#XC1] [client] [0m[94m$ redis-cli INFO replication[0m
 [33m[tester::#XC1] [client] [0m[36mSent bytes: "*2\r\n$4\r\nINFO\r\n$11\r\nreplication\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de3f715225e8cac8fa48aacda73d48bb8c8f05b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
-[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de3f715225e8cac8fa48aacda73d48bb8c8f05b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
-[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:de3f715225e8cac8fa48aacda73d48bb8c8f05b7\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived bytes: "$349\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f5e3de23bbeb4208591ffa6141f5fb063723512\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n\r\n"[0m
+[33m[tester::#XC1] [client] [0m[36mReceived RESP bulk string: "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f5e3de23bbeb4208591ffa6141f5fb063723512\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
+[33m[tester::#XC1] [client] [0m[92m✔︎ Received "# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:1f5e3de23bbeb4208591ffa6141f5fb063723512\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:0\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:0\r\nrepl_backlog_histlen:0\r\n"[0m
 [33m[tester::#XC1] [0m[92mFound master_replid:xxx in response.[0m
 [33m[tester::#XC1] [0m[92mFound master_reploffset:0 in response.[0m
 [33m[tester::#XC1] [0m[92mTest passed.[0m
@@ -168,7 +168,7 @@ Debug = true
 
 [33m[tester::#FJ0] [0m[94mRunning tests for Stage #FJ0 (fj0)[0m
 [33m[tester::#FJ0] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#FJ0] [client] [0m[36mConnected (port 35384 -> port 6379)[0m
+[33m[tester::#FJ0] [client] [0m[36mConnected (port 60003 -> port 6379)[0m
 [33m[tester::#FJ0] [client] [0m[94m$ redis-cli PING[0m
 [33m[tester::#FJ0] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[tester::#FJ0] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
@@ -190,7 +190,7 @@ Debug = true
 
 [33m[tester::#VM3] [0m[94mRunning tests for Stage #VM3 (vm3)[0m
 [33m[tester::#VM3] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#VM3] [client] [0m[36mConnected (port 35390 -> port 6379)[0m
+[33m[tester::#VM3] [client] [0m[36mConnected (port 60006 -> port 6379)[0m
 [33m[tester::#VM3] [client] [0m[94m$ redis-cli PING[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[tester::#VM3] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
@@ -208,16 +208,16 @@ Debug = true
 [33m[tester::#VM3] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#VM3] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#VM3] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC a13f10992f57c216690c362d32db8084b6660778 0\r\n"[0m
-[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC a13f10992f57c216690c362d32db8084b6660778 0"[0m
-[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC a13f10992f57c216690c362d32db8084b6660778 0"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived bytes: "+FULLRESYNC 381ee5a6229a5b61273b4c9f3390af98f269f2a8 0\r\n"[0m
+[33m[tester::#VM3] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 381ee5a6229a5b61273b4c9f3390af98f269f2a8 0"[0m
+[33m[tester::#VM3] [client] [0m[92m✔︎ Received "FULLRESYNC 381ee5a6229a5b61273b4c9f3390af98f269f2a8 0"[0m
 [33m[tester::#VM3] [0m[92mTest passed.[0m
 [33m[tester::#VM3] [0m[36mTerminating program[0m
 [33m[tester::#VM3] [0m[36mProgram terminated successfully[0m
 
 [33m[tester::#CF8] [0m[94mRunning tests for Stage #CF8 (cf8)[0m
 [33m[tester::#CF8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#CF8] [client] [0m[36mConnected (port 35410 -> port 6379)[0m
+[33m[tester::#CF8] [client] [0m[36mConnected (port 60009 -> port 6379)[0m
 [33m[tester::#CF8] [client] [0m[94m$ redis-cli PING[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[tester::#CF8] [client] [0m[36mReceived bytes: "+PONG\r\n"[0m
@@ -235,11 +235,11 @@ Debug = true
 [33m[tester::#CF8] [client] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#CF8] [client] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#CF8] [client] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC 408b24f6cecdd3a519f3bd456843be4156130d48 0\r\n"[0m
-[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC 408b24f6cecdd3a519f3bd456843be4156130d48 0"[0m
-[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC 408b24f6cecdd3a519f3bd456843be4156130d48 0"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "+FULLRESYNC f48bfe3272022e9750a3f9ddbf739624b8479deb 0\r\n"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived RESP simple string: "FULLRESYNC f48bfe3272022e9750a3f9ddbf739624b8479deb 0"[0m
+[33m[tester::#CF8] [client] [0m[92m✔︎ Received "FULLRESYNC f48bfe3272022e9750a3f9ddbf739624b8479deb 0"[0m
 [33m[tester::#CF8] [client] [0m[36mReading RDB file...[0m
-[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ڎ\xb3i\xfa\bused-mem\u0098\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(408b24f6cecdd3a519f3bd456843be4156130d48\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff5\xc5\x1f\xad\x88\x11\xec\xfc"[0m
+[33m[tester::#CF8] [client] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xebm\xd2i\xfa\bused-mem\xc2@\x96\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f48bfe3272022e9750a3f9ddbf739624b8479deb\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffʧ|\x96Z2U\xb2"[0m
 [33m[tester::#CF8] [client] [0m[92mReceived RDB file[0m
 [33m[tester::#CF8] [0m[92mTest passed.[0m
 [33m[tester::#CF8] [0m[36mTerminating program[0m
@@ -247,8 +247,8 @@ Debug = true
 
 [33m[tester::#ZN8] [0m[94mRunning tests for Stage #ZN8 (zn8)[0m
 [33m[tester::#ZN8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#ZN8] [handshake] [client] [0m[36mConnected (port 35418 -> port 6379)[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mConnected (port 35422 -> port 6379)[0m
+[33m[tester::#ZN8] [handshake] [client] [0m[36mConnected (port 60012 -> port 6379)[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mConnected (port 60013 -> port 6379)[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m$ redis-cli PING[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*1\r\n$4\r\nPING\r\n"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+PONG\r\n"[0m
@@ -266,11 +266,11 @@ Debug = true
 [33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC 527b1d5abe8d8567b879e3e5bdf9ca9c42f4f7ca 0\r\n"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC 527b1d5abe8d8567b879e3e5bdf9ca9c42f4f7ca 0"[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC 527b1d5abe8d8567b879e3e5bdf9ca9c42f4f7ca 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "+FULLRESYNC bd582ee907f75890f46eec7b01894ece8e3daa9d 0\r\n"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived RESP simple string: "FULLRESYNC bd582ee907f75890f46eec7b01894ece8e3daa9d 0"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[92m✔︎ Received "FULLRESYNC bd582ee907f75890f46eec7b01894ece8e3daa9d 0"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[36mReading RDB file...[0m
-[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ڎ\xb3i\xfa\bused-mem\xc2hS\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(527b1d5abe8d8567b879e3e5bdf9ca9c42f4f7ca\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xee\xac\v\xfa\xd8\u07b9\x02"[0m
+[33m[tester::#ZN8] [handshake] [replica] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xebm\xd2i\xfa\bused-mem\xc2\xc0\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(bd582ee907f75890f46eec7b01894ece8e3daa9d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x82\ndF\x13}F\xad"[0m
 [33m[tester::#ZN8] [handshake] [replica] [0m[92mReceived RDB file[0m
 [33m[tester::#ZN8] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#ZN8] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -308,7 +308,7 @@ Debug = true
 
 [33m[tester::#HD5] [0m[94mRunning tests for Stage #HD5 (hd5)[0m
 [33m[tester::#HD5] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#HD5] [handshake] [client] [0m[36mConnected (port 35444 -> port 6379)[0m
+[33m[tester::#HD5] [handshake] [client] [0m[36mConnected (port 60016 -> port 6379)[0m
 [33m[tester::#HD5] [setup] [0m[94mCreating 3 replicas:[0m
 [33m[tester::#HD5] [setup] [0m[94m1. replica@6380 (Listening port = 6380)[0m
 [33m[tester::#HD5] [setup] [0m[94m2. replica@6381 (Listening port = 6381)[0m
@@ -331,11 +331,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\u070e\xb3i\xfa\bused-mem\xc2hS\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f76a066e02375b6e3cf726f32765c538f70a3b0d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffHP\x84\xdc\x03\xddp\xf1"[0m
+[33m[tester::#HD5] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeem\xd2i\xfa\bused-mem\xc2\xc0\xdb\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10490c28b153efeb837463f01275025e89f409ea\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf5j\x19\xd6䝿R"[0m
 [33m[tester::#HD5] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6381[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -355,11 +355,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\u070e\xb3i\xfa\bused-mem°\xf9\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f76a066e02375b6e3cf726f32765c538f70a3b0d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xe5\x14\xa1\xfbG\x8b?\xa0"[0m
+[33m[tester::#HD5] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeem\xd2i\xfa\bused-mem\xc2Ё\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10490c28b153efeb837463f01275025e89f409ea\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd9?愨\xec\x02\xd4"[0m
 [33m[tester::#HD5] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [0m[36mCreating replica@6382[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -379,11 +379,11 @@ Debug = true
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0\r\n"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC f76a066e02375b6e3cf726f32765c538f70a3b0d 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0\r\n"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 10490c28b153efeb837463f01275025e89f409ea 0"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\u070e\xb3i\xfa\bused-mem\u0088\xc7\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(f76a066e02375b6e3cf726f32765c538f70a3b0d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xc1\x95\xe3՛\xd4z\xb8"[0m
+[33m[tester::#HD5] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xeem\xd2i\xfa\bused-mem\u0080O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(10490c28b153efeb837463f01275025e89f409ea\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa3\xcfx-kKG\x1e"[0m
 [33m[tester::#HD5] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#HD5] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#HD5] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
@@ -503,7 +503,7 @@ Debug = true
 [33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
 [33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [client] [0m[36mConnected (port 46274 -> port 6380)[0m
+[33m[tester::#YG4] [propagation] [client] [0m[36mConnected (port 60021 -> port 6380)[0m
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
 [33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
@@ -511,7 +511,7 @@ Debug = true
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
 [33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli -p 6380 GET foo[0m
 [33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
 [33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$3\r\n123\r\n"[0m
 [33m[tester::#YG4] [test] [client] [0m[36mReceived RESP bulk string: "123"[0m
@@ -676,7 +676,7 @@ Debug = true
 
 [33m[tester::#MY8] [0m[94mRunning tests for Stage #MY8 (my8)[0m
 [33m[tester::#MY8] [0m[94m$ ./spawn_redis_server.sh --port 6379[0m
-[33m[tester::#MY8] [client] [0m[36mConnected (port 35492 -> port 6379)[0m
+[33m[tester::#MY8] [client] [0m[36mConnected (port 60029 -> port 6379)[0m
 [33m[tester::#MY8] [client] [0m[94m$ redis-cli WAIT 0 60000[0m
 [33m[tester::#MY8] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n0\r\n$5\r\n60000\r\n"[0m
 [33m[tester::#MY8] [client] [0m[36mReceived bytes: ":0\r\n"[0m
@@ -713,11 +713,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ݎ\xb3i\xfa\bused-mem\u0098\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(30ca7599917e5644227619c7f173d40cd7b8bbf5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x05\xf0\x94\x1bKR1\x0e"[0m
+[33m[tester::#TU8] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xefm\xd2i\xfa\bused-mem\xc2@\x96\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ba6fc890258a2d66d7592a94ee313451b4de26d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xf2<\x81hA~tE"[0m
 [33m[tester::#TU8] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6381[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -737,11 +737,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ݎ\xb3i\xfa\bused-mem\xc2\xf0\xb3\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(30ca7599917e5644227619c7f173d40cd7b8bbf5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xdd\xc2\xcbMi\xe9\x97\x18"[0m
+[33m[tester::#TU8] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xefm\xd2i\xfa\bused-mem\xc2p<\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ba6fc890258a2d66d7592a94ee313451b4de26d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xd1\xcf\x1aZ\x02\xbd\x9e?"[0m
 [33m[tester::#TU8] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6382[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -761,11 +761,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ݎ\xb3i\xfa\bused-mem\xc2Ƚ\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(30ca7599917e5644227619c7f173d40cd7b8bbf5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xa8\xa8\xc1\x99ey\xc2u"[0m
+[33m[tester::#TU8] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xefm\xd2i\xfa\bused-mem\xc2\x10F\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ba6fc890258a2d66d7592a94ee313451b4de26d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfc\xff-1y\xc4%U"[0m
 [33m[tester::#TU8] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6383[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -785,11 +785,11 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ݎ\xb3i\xfa\bused-mem\u00a0\xc7\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(30ca7599917e5644227619c7f173d40cd7b8bbf5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff6\xa9~B\x90\x83\x94\xdd"[0m
+[33m[tester::#TU8] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xefm\xd2i\xfa\bused-mem\xc2\xc0O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ba6fc890258a2d66d7592a94ee313451b4de26d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff[\x83\xbfd\xc4d\xe5\xa9"[0m
 [33m[tester::#TU8] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
 [33m[tester::#TU8] [0m[36mCreating replica@6384[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m$ redis-cli PING[0m
@@ -809,13 +809,13 @@ Debug = true
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0\r\n"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 30ca7599917e5644227619c7f173d40cd7b8bbf5 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "+FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0\r\n"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived RESP simple string: "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[92m✔︎ Received "FULLRESYNC 9ba6fc890258a2d66d7592a94ee313451b4de26d 0"[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReading RDB file...[0m
-[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ގ\xb3i\xfa\bused-mem\u0080\xd1\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(30ca7599917e5644227619c7f173d40cd7b8bbf5\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x943j:ñ(:"[0m
+[33m[tester::#TU8] [handshake] [replica@6384] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xefm\xd2i\xfa\bused-mem\xc2pY\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(9ba6fc890258a2d66d7592a94ee313451b4de26d\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff/:\xa4'\xe86U["[0m
 [33m[tester::#TU8] [handshake] [replica@6384] [0m[92mReceived RDB file[0m
-[33m[tester::#TU8] [client] [0m[36mConnected (port 35550 -> port 6379)[0m
+[33m[tester::#TU8] [client] [0m[36mConnected (port 60037 -> port 6379)[0m
 [33m[tester::#TU8] [test] [client] [0m[94m$ redis-cli WAIT 3 500[0m
 [33m[tester::#TU8] [test] [client] [0m[36mSent bytes: "*3\r\n$4\r\nWAIT\r\n$1\r\n3\r\n$3\r\n500\r\n"[0m
 [33m[tester::#TU8] [test] [client] [0m[36mReceived bytes: ":5\r\n"[0m
@@ -871,11 +871,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "+FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived RESP simple string: "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[92m✔︎ Received "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ߎ\xb3i\xfa\bused-mem\u0098\r\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a610f5ed9d3283a69f2781c07d9c931daffece00\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\x8d\xc4*n\x03ҝ\x01"[0m
+[33m[tester::#NA2] [handshake] [replica@6380] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf1m\xd2i\xfa\bused-mem\xc2@\x96\r\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5519367077abcc5829e9a5d9817c5ddd2c3b6ac1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffW\xef\xf2\n\x19d\xe4\xe7"[0m
 [33m[tester::#NA2] [handshake] [replica@6380] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6381[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m$ redis-cli PING[0m
@@ -895,11 +895,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "+FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived RESP simple string: "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[92m✔︎ Received "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ߎ\xb3i\xfa\bused-mem\xc2\xf0\xb3\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a610f5ed9d3283a69f2781c07d9c931daffece00\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffU\xf6u8!i;\x17"[0m
+[33m[tester::#NA2] [handshake] [replica@6381] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf1m\xd2i\xfa\bused-mem\xc2p<\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5519367077abcc5829e9a5d9817c5ddd2c3b6ac1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xfft\x1ci8Z\xa7\x0e\x9d"[0m
 [33m[tester::#NA2] [handshake] [replica@6381] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6382[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m$ redis-cli PING[0m
@@ -919,11 +919,11 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "+FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived RESP simple string: "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[92m✔︎ Received "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ߎ\xb3i\xfa\bused-mem\xc2Ƚ\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a610f5ed9d3283a69f2781c07d9c931daffece00\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff \x9c\x7f\xec-\xf9nz"[0m
+[33m[tester::#NA2] [handshake] [replica@6382] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf1m\xd2i\xfa\bused-mem\xc2\x10F\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5519367077abcc5829e9a5d9817c5ddd2c3b6ac1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xffY,^S!\u07b5\xf7"[0m
 [33m[tester::#NA2] [handshake] [replica@6382] [0m[92mReceived RDB file[0m
 [33m[tester::#NA2] [0m[36mCreating replica@6383[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m$ redis-cli PING[0m
@@ -943,13 +943,13 @@ Debug = true
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "OK"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[94m> PSYNC ? -1[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mSent bytes: "*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0\r\n"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC a610f5ed9d3283a69f2781c07d9c931daffece00 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "+FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0\r\n"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived RESP simple string: "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[92m✔︎ Received "FULLRESYNC 5519367077abcc5829e9a5d9817c5ddd2c3b6ac1 0"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReading RDB file...[0m
-[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.4.2\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2ߎ\xb3i\xfa\bused-mem\u00a0\xc7\f\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(a610f5ed9d3283a69f2781c07d9c931daffece00\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xbe\x9d\xc07\xd8\x038\xd2"[0m
+[33m[tester::#NA2] [handshake] [replica@6383] [0m[36mReceived bytes: "$171\r\nREDIS0012\xfa\tredis-ver\x058.2.5\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2\xf1m\xd2i\xfa\bused-mem\xc2\xc0O\x0e\x00\xfa\x0erepl-stream-db\xc0\x00\xfa\arepl-id(5519367077abcc5829e9a5d9817c5ddd2c3b6ac1\xfa\vrepl-offset\xc0\x00\xfa\baof-base\xc0\x00\xff\xfeP\xcc\x06\x9c~u\v"[0m
 [33m[tester::#NA2] [handshake] [replica@6383] [0m[92mReceived RDB file[0m
-[33m[tester::#NA2] [client] [0m[36mConnected (port 38248 -> port 6379)[0m
+[33m[tester::#NA2] [client] [0m[36mConnected (port 60044 -> port 6379)[0m
 [33m[tester::#NA2] [test] [client] [0m[94m$ redis-cli SET foo 123[0m
 [33m[tester::#NA2] [test] [client] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[tester::#NA2] [test] [client] [0m[36mReceived bytes: "+OK\r\n"[0m

--- a/internal/test_helpers/fixtures/repl-wait/repl_propagation_retry
+++ b/internal/test_helpers/fixtures/repl-wait/repl_propagation_retry
@@ -40,7 +40,7 @@ Debug = true
 [33m[tester::#YG4] [handshake] [master] [0m[36mSending RDB file...[0m
 [33m[tester::#YG4] [handshake] [master] [0m[36mSent bytes: "$88\r\nREDIS0011\xfa\tredis-ver\x057.2.0\xfa\nredis-bits\xc0@\xfa\x05ctime\xc2m\b\xbce\xfa\bused-mem°\xc4\x10\x00\xfa\baof-base\xc0\x00\xff\xf0n;\xfe\xc0\xffZ\xa2"[0m
 [33m[tester::#YG4] [handshake] [master] [0m[92mSent RDB file.[0m
-[33m[tester::#YG4] [propagation] [client] [0m[36mConnected (port 40944 -> port 6380)[0m
+[33m[tester::#YG4] [propagation] [client] [0m[36mConnected (port 59969 -> port 6380)[0m
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET foo 123[0m
 [33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n123\r\n"[0m
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET bar 456[0m
@@ -48,7 +48,7 @@ Debug = true
 [33m[tester::#YG4] [propagation] [master] [0m[94m> SET baz 789[0m
 [33m[tester::#YG4] [propagation] [master] [0m[36mSent bytes: "*3\r\n$3\r\nSET\r\n$3\r\nbaz\r\n$3\r\n789\r\n"[0m
 [33m[tester::#YG4] [test] [0m[94mGetting key foo[0m
-[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli GET foo[0m
+[33m[tester::#YG4] [test] [client] [0m[94m$ redis-cli -p 6380 GET foo[0m
 [33m[tester::#YG4] [test] [client] [0m[36mSent bytes: "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n"[0m
 [33m[tester::#YG4] [test] [client] [0m[36mReceived bytes: "$-1\r\n"[0m
 [33m[tester::#YG4] [test] [client] [0m[36mReceived RESP null bulk string: "$-1\r\n"[0m


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3280458366/12317?viewId=8414074

Discrepancy:

<img width="2438" height="440" alt="image" src="https://github.com/user-attachments/assets/98b60678-a84d-48f8-883c-7556cbba06b8" />

New fixture:

<img width="1712" height="570" alt="image" src="https://github.com/user-attachments/assets/debcb89a-c753-428b-9d15-6979480391d6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes shared connection callback wiring and adds a `net.TCPAddr` type assertion that could panic if a non-TCP address is ever used. Functional impact is otherwise limited to developer-facing logging and local setup behavior.
> 
> **Overview**
> **Improves command logging for non-default Redis ports.** `InstrumentedRespConnection` callbacks now derive the remote TCP port and log initial commands as `$ redis-cli -p <port> ...` when connecting to anything other than `6379`, keeping reused-connection commands as `>`.
> 
> The constructor/update paths (`NewFromAddr`, `NewFromConn`, `UpdateBaseLogger`) were updated to pass the resolved/remote address into the callbacks, and replication fixtures were refreshed to reflect the new log output. Separately, the `Makefile` `setup` target now pins Redis installs to the `8.4` package series via apt preferences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45b3257acaf40801ff9d45a1acb35c8d0441076e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->