### PR TITLE
Add AnnotatedAssertion for enhanced error reporting in RESP assertions

### DIFF
--- a/internal/resp_assertions/annotated_assertion.go
+++ b/internal/resp_assertions/annotated_assertion.go
@@ -1,0 +1,27 @@
+package resp_assertions
+
+import (
+	"fmt"
+
+	resp_value "github.com/codecrafters-io/redis-tester/internal/resp/value"
+)
+
+type AnnotatedAssertion struct {
+	Annotation string
+	Assertion  RESPAssertion
+}
+
+func NewAnnotatedAssertion(annotation string, assertion RESPAssertion) RESPAssertion {
+	return AnnotatedAssertion{
+		Annotation: annotation,
+		Assertion:  assertion,
+	}
+}
+
+func (a AnnotatedAssertion) Run(value resp_value.Value) error {
+	if err := a.Assertion.Run(value); err != nil {
+		return fmt.Errorf("%s: %w", a.Annotation, err)
+	}
+
+	return nil
+}

--- a/internal/test_list_blpop_no_timeout.go
+++ b/internal/test_list_blpop_no_timeout.go
@@ -44,9 +44,12 @@ func testListBlpopNoTimeout(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 
 	rpushTestCase := test_cases.SendCommandTestCase{
-		Command:   "RPUSH",
-		Args:      []string{listKey, pushValue},
-		Assertion: resp_assertions.NewIntegerAssertion(1),
+		Command: "RPUSH",
+		Args:    []string{listKey, pushValue},
+		Assertion: resp_assertions.NewAnnotatedAssertion(
+			"RPUSH response",
+			resp_assertions.NewIntegerAssertion(1),
+		),
 	}
 
 	sendingClient := clients[2]


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/improve-error-message-for-test-ec3/16185

> A message like expecting RPUSH to return integer 1 instead of 0 would be more helpful.

Before change:

<img width="1184" height="672" alt="image" src="https://github.com/user-attachments/assets/2df3f148-a854-46ee-9694-12d2e1a3050c" />


After change:

<img width="1180" height="648" alt="image" src="https://github.com/user-attachments/assets/ede961e6-671f-4176-a4b7-7a212bbc713f" />


---

- Introduced a new AnnotatedAssertion type to provide contextual annotations for RESP assertions.
- Updated testListBlpopNoTimeout to utilize AnnotatedAssertion for clearer error messages during assertion failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion helper and a single test update; no runtime or learner Redis behavior changes.
> 
> **Overview**
> Adds a **decorator** `AnnotatedAssertion` that implements `RESPAssertion` and wraps an inner assertion. On failure it rewrites the error as `{annotation}: {wrapped error}` via `fmt.Errorf` and `%w`, so learners see which response was wrong (e.g. **"RPUSH response"** ahead of the integer mismatch).
> 
> `testListBlpopNoTimeout` now wraps the RPUSH `NewIntegerAssertion(1)` with `NewAnnotatedAssertion("RPUSH response", ...)` instead of using the bare integer assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c42ff3f1d84437d0fe2eb207fc3f0347cb7df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->